### PR TITLE
feat(validation): add `requiredIf` rule

### DIFF
--- a/lib/support/Util.ts
+++ b/lib/support/Util.ts
@@ -5,6 +5,10 @@ export function isNullish(value: any): value is undefined | null {
   return value === null || value === undefined
 }
 
+export function isString(value: any): value is string {
+  return typeof value === 'string'
+}
+
 export function isArray(value: any): value is any[] {
   return Array.isArray(value)
 }

--- a/lib/validation/rules/index.ts
+++ b/lib/validation/rules/index.ts
@@ -1,3 +1,4 @@
+import { isString } from '../../support/Util'
 import day from './day'
 import email from './email'
 import include from './include'
@@ -18,6 +19,13 @@ export interface Rule {
   message: string
   optional: boolean
   validate (value: any, data: Record<string, any>): boolean
+}
+
+export type Locator = string | LocatorFunction
+export type LocatorFunction = (data: Record<string, any>) => any
+
+export function locate(data: Record<string, any>, locator: Locator): any {
+  return isString(locator) ? data[locator] : locator(data)
 }
 
 export {

--- a/lib/validation/rules/index.ts
+++ b/lib/validation/rules/index.ts
@@ -7,6 +7,7 @@ import month from './month'
 import not from './not'
 import regex from './regex'
 import required from './required'
+import requiredIf from './requiredIf'
 import rule from './rule'
 import sameAs from './sameAs'
 import url from './url'
@@ -29,6 +30,7 @@ export {
   not,
   regex,
   required,
+  requiredIf,
   rule,
   sameAs,
   url,

--- a/lib/validation/rules/requiredIf.ts
+++ b/lib/validation/rules/requiredIf.ts
@@ -1,13 +1,13 @@
 import { required } from '../validators'
-import { Rule } from './'
+import { Rule, Locator, locate } from './'
 
-export default function requiredIf(locator: string, message?: string): Rule {
+export default function requiredIf(locator: Locator, message?: string): Rule {
   return {
     name: 'requiredIf',
     message: message ?? 'The field is required.',
     optional: false,
     validate(value, data) {
-      return data[locator] ? required(value) : true
+      return locate(data, locator) ? required(value) : true
     }
   }
 }

--- a/lib/validation/rules/requiredIf.ts
+++ b/lib/validation/rules/requiredIf.ts
@@ -1,0 +1,13 @@
+import { required } from '../validators'
+import { Rule } from './'
+
+export default function requiredIf(locator: string, message?: string): Rule {
+  return {
+    name: 'requiredIf',
+    message: message ?? 'The field is required.',
+    optional: false,
+    validate(value, data) {
+      return data[locator] ? required(value) : true
+    }
+  }
+}

--- a/test/validation/rules/requiredIf.spec.ts
+++ b/test/validation/rules/requiredIf.spec.ts
@@ -30,6 +30,14 @@ describe('validation/rules/requiredIf', () => {
     })
   })
 
+  test('it can take callback as a locator', () => {
+    const rule = requiredIf(data => data.other)
+
+    expect(rule.validate('', { other: false })).toBe(true)
+    expect(rule.validate('', { other: true })).toBe(false)
+    expect(rule.validate('Exist', { other: true })).toBe(true)
+  })
+
   test('it can set custom error message', () => {
     const rule = requiredIf('dummy', 'Custom message')
 

--- a/test/validation/rules/requiredIf.spec.ts
+++ b/test/validation/rules/requiredIf.spec.ts
@@ -1,0 +1,38 @@
+import { requiredIf } from 'sefirot/validation/rules'
+
+describe('validation/rules/requiredIf', () => {
+  test('it validates if the value is present only when specified locator is truthy', () => {
+    const checks: any[] = [
+      [undefined, '', true],
+      [undefined, 'Exist', true],
+      [null, '', true],
+      [null, 'Exist', true],
+      [true, '', false],
+      [true, 'Exist', true],
+      [false, '', true],
+      [false, 'Exist', true],
+      ['', '', true],
+      ['', 'Exist', true],
+      ['Hello', '', false],
+      ['Hello', 'Exist', true],
+      [0, '', true],
+      [0, 'Exist', true],
+      [1, '', false],
+      [1, 'Exist', true]
+    ]
+
+    checks.forEach((check) => {
+      const result = requiredIf('other').validate(check[1], {
+        other: check[0]
+      })
+
+      expect(result).toBe(check[2])
+    })
+  })
+
+  test('it can set custom error message', () => {
+    const rule = requiredIf('dummy', 'Custom message')
+
+    expect(rule.message).toBe('Custom message')
+  })
+})


### PR DESCRIPTION
This PR adds `requiredIf` validation rule.

```ts
const { data } = useData({
  requireEmail: true,
  email: null
})

const validation = useValidation(data, {
  email: [requiredIf('requireEmail')]
})
```

```ts
const { data } = useData({
  status: 'Open',
  description: null
})

const validation = useValidation(data, {
  description: [requiredIf(d => d.status === 'Open')]
})
```