### PR TITLE
refactor: typescript remediation

### DIFF
--- a/lib/components/SAlert.vue
+++ b/lib/components/SAlert.vue
@@ -17,8 +17,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api'
+import { PropType, defineComponent } from '@vue/composition-api'
 import { useHeader, useFooter, useButtonAction } from '../composables/Card'
+import { ButtonAction, Mode } from '../composables/Header'
 import SIconInfo from './icons/SIconInfo.vue'
 import SIconCheckCircle from './icons/SIconCheckCircle.vue'
 import SIconWarning from './icons/SIconWarning.vue'
@@ -33,28 +34,23 @@ export default defineComponent({
   },
 
   props: {
-    type: { type: String, required: true },
+    type: { type: String as PropType<Mode>, required: true },
     name: { type: String, required: true },
     title: { type: String, default: null },
     text: { type: String, default: null },
-    actions: { type: Array, default: () => [] }
+    actions: { type: Array as PropType<ButtonAction[]>, default: () => [] }
   },
 
   setup(props) {
     const header = useHeader({
-      mode: props.type as any,
+      mode: props.type,
       icon: getIcon(),
       title: props.title
     })
 
     const footer = useFooter({
-      actions: props.actions.map((action: any) => {
-        return useButtonAction({
-          kind: action.type,
-          mode: action.mode,
-          label: action.label,
-          callback: action.callback
-        })
+      actions: props.actions.map(({ kind, mode, label, callback }) => {
+        return useButtonAction({ kind, mode, label, callback })
       })
     })
 

--- a/lib/components/SDialog.vue
+++ b/lib/components/SDialog.vue
@@ -29,11 +29,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api'
+import { defineComponent, computed, PropType } from '@vue/composition-api'
 import SIconPreloaderDark from './icons/SIconPreloaderDark.vue'
 import SButton from './SButton.vue'
 import SProgressBar from './SProgressBar.vue'
 import SModalBase from './SModalBase.vue'
+
+type Dialog = 'loading' | 'progress'
+type Action = 'text' | 'mute'
 
 export default defineComponent({
   components: {
@@ -44,7 +47,7 @@ export default defineComponent({
   },
 
   props: {
-    type: { type: String, required: true },
+    type: { type: String as PropType<Dialog>, required: true },
     name: { type: String, required: true },
     title: { type: String, default: null },
     text: { type: String, default: null },
@@ -57,7 +60,7 @@ export default defineComponent({
     const isTypeProgress = computed(() => props.type === 'progress')
     const isLoadOnly = computed(() => isTypeLoading.value && !props.title && !props.text)
 
-    function getActionType(value?: string): string {
+    function getActionType(value?: Action): Action {
       return value !== 'mute' ? 'text' : 'mute'
     }
 

--- a/lib/components/SGrid.vue
+++ b/lib/components/SGrid.vue
@@ -52,6 +52,7 @@
 <script lang="ts">
 import { defineComponent, computed } from '@vue/composition-api'
 import VueSimplebar from 'simplebar-vue'
+import { isArray } from '../support/Util'
 import SIconPreloaderDark from './icons/SIconPreloaderDark.vue'
 import SGridActionLink from './SGridActionLink.vue'
 import SGridActionSingle from './SGridActionSingle.vue'
@@ -71,13 +72,13 @@ export default defineComponent({
     loading: { type: Boolean, default: false }
   },
 
-  setup(props, context) {
+  setup(props, { emit }) {
     const actionComponent = computed(() => {
       if (typeof props.actions === 'string') {
         return SGridActionLink
       }
 
-      if (Array.isArray(props.actions)) {
+      if (isArray(props.actions)) {
         return SGridActionMulti
       }
 
@@ -85,7 +86,7 @@ export default defineComponent({
     })
 
     function handleClick(record: object): void {
-      props.clickable && context.emit('click', record)
+      props.clickable && emit('click', record)
     }
 
     return {

--- a/lib/components/SGridActionMulti.vue
+++ b/lib/components/SGridActionMulti.vue
@@ -37,7 +37,7 @@ export default defineComponent({
   },
 
   setup(props) {
-    function actionStyles(index: number): Record<string, string> {
+    function actionStyles(index: number): Partial<CSSStyleDeclaration> {
       const size = props.actions.length
       const sec = (size - (index + 1)) * 0.1
 

--- a/lib/components/SInputCheckbox.vue
+++ b/lib/components/SInputCheckbox.vue
@@ -20,11 +20,12 @@
   </SInputBase>
 </template>
 
-<script>
-import SIconCheck from './icons/SIconCheck'
-import SInputBase from './SInputBase'
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api'
+import SIconCheck from './icons/SIconCheck.vue'
+import SInputBase from './SInputBase.vue'
 
-export default {
+export default defineComponent({
   components: {
     SIconCheck,
     SInputBase
@@ -44,12 +45,16 @@ export default {
     value: { type: Boolean, required: true }
   },
 
-  methods: {
-    emitChange() {
-      this.$emit('change', !this.value)
+  setup(props, { emit }) {
+    function emitChange() {
+      emit('change', !props.value)
+    }
+
+    return {
+      emitChange
     }
   }
-}
+})
 </script>
 
 <style lang="postcss" scoped>

--- a/lib/components/SInputCheckboxes.vue
+++ b/lib/components/SInputCheckboxes.vue
@@ -20,11 +20,12 @@
   </SInputBase>
 </template>
 
-<script>
-import SInputBase from './SInputBase'
-import SInputCheckbox from './SInputCheckbox'
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api'
+import SInputBase from './SInputBase.vue'
+import SInputCheckbox from './SInputCheckbox.vue'
 
-export default {
+export default defineComponent({
   components: {
     SInputBase,
     SInputCheckbox
@@ -44,20 +45,25 @@ export default {
     value: { type: Array, required: true }
   },
 
-  methods: {
-    isChecked(value) {
-      return this.value.includes(value)
-    },
+  setup(props, { emit }) {
+    function isChecked(value: unknown): boolean {
+      return props.value.includes(value)
+    }
 
-    handleChange(value) {
-      const difference = this.value
+    function handleChange(value: unknown): void {
+      const distinct = props.value
         .filter(v => v !== value)
-        .concat(this.value.includes(value) ? [] : [value])
+        .concat(props.value.includes(value) ? [] : [value])
 
-      this.$emit('change', difference)
+      emit('change', distinct)
+    }
+
+    return {
+      isChecked,
+      handleChange
     }
   }
-}
+})
 </script>
 
 <style lang="postcss" scoped>

--- a/lib/components/SInputDate.vue
+++ b/lib/components/SInputDate.vue
@@ -38,6 +38,7 @@
 
 <script lang="ts">
 import { PropType, defineComponent, computed } from '@vue/composition-api'
+import { SyntheticInputEvent } from '../types/Utils'
 import { Validation } from '../validation/Validation'
 import SInputBase from './SInputBase.vue'
 
@@ -67,10 +68,10 @@ export default defineComponent({
       emit('input', date)
     }
 
-    function emitBlur(e: InputEvent) {
+    function emitBlur(e: SyntheticInputEvent) {
       setTimeout(() => {
         props.validation && props.validation.$touch()
-        emit('blur', (e.target as HTMLInputElement).value)
+        emit('blur', e.target.value)
       }, 100)
     }
 

--- a/lib/components/SInputDropdown.vue
+++ b/lib/components/SInputDropdown.vue
@@ -69,7 +69,7 @@ export default defineComponent({
     options: { type: Array as PropType<Item[]>, required: true },
     closeOnClick: { type: Boolean, default: false },
     validation: { type: Object, default: null },
-    value: { type: [String, Number, Boolean, Array, Object] as PropType<any>, default: null }
+    value: { type: [String, Number, Boolean, Array, Object] as PropType<string | number | boolean | unknown[]>, default: null }
   },
 
   setup(props, { emit }) {
@@ -87,13 +87,13 @@ export default defineComponent({
 
     const selected = computed(() => {
       return isArray(props.value)
-        ? props.options.filter(o => (props.value as any).includes(o.value))
+        ? props.options.filter(o => (props.value as unknown[]).includes(o.value))
         : props.options.find(o => isEqual(o.value, props.value))
     })
 
     const hasSelected = computed(() => {
       return isArray(selected.value)
-        ? (selected.value as any).length > 0
+        ? selected.value.length > 0
         : !isNullish(selected.value) && selected.value.value !== ''
     })
 
@@ -102,9 +102,9 @@ export default defineComponent({
 
       await nextTick()
 
-      const el = document.querySelector('.SInputDropdown .SDropdown .search .SInputText input')
+      const el = document.querySelector<HTMLInputElement>('.SInputDropdown .SDropdown .search .SInputText input')
 
-      el && (el as any).focus()
+      el && el.focus()
     }
 
     function handleCallback(item: Item): void {
@@ -113,7 +113,7 @@ export default defineComponent({
       isArray(props.value) ? handleArray(item.value) : handlePrimitive(item.value)
     }
 
-    function handlePrimitive(value: any): void {
+    function handlePrimitive(value: unknown): void {
       if (!isEqual(props.value, value)) {
         emit('change', value)
 
@@ -125,8 +125,8 @@ export default defineComponent({
       }
     }
 
-    function handleArray(value: any): void {
-      const difference = getDifference(value)
+    function handleArray(value: unknown[]): void {
+      const difference = getDifference(props.value as unknown[], value)
 
       if (!props.nullable && difference.length === 0) {
         return
@@ -135,10 +135,10 @@ export default defineComponent({
       emit('change', difference)
     }
 
-    function getDifference(value: any): any[] {
-      return (props.value as any)
-        .filter((v: any) => !isEqual(v, value))
-        .concat((props.value as any).includes(value) ? [] : [value])
+    function getDifference(source: unknown[], value: unknown[]): unknown[] {
+      return source
+        .filter(item => !isEqual(item, value))
+        .concat(source.includes(value) ? [] : [value])
     }
 
     return {

--- a/lib/components/SInputNumber.vue
+++ b/lib/components/SInputNumber.vue
@@ -26,11 +26,7 @@
 </template>
 
 <script lang="ts">
-import {
-  defineComponent,
-  computed,
-  PropType
-} from '@vue/composition-api'
+import { defineComponent, computed, PropType } from '@vue/composition-api'
 import { isNullish } from '../support/Util'
 import { Validation } from '../validation/Validation'
 import SInputText, { Size, Mode } from './SInputText.vue'

--- a/lib/components/SInputRadio.vue
+++ b/lib/components/SInputRadio.vue
@@ -18,10 +18,11 @@
   </SInputBase>
 </template>
 
-<script>
-import SInputBase from './SInputBase'
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api'
+import SInputBase from './SInputBase.vue'
 
-export default {
+export default defineComponent({
   components: {
     SInputBase
   },
@@ -40,12 +41,16 @@ export default {
     value: { type: Boolean, required: true }
   },
 
-  methods: {
-    emitChange() {
-      this.$emit('change', !this.value)
+  setup(props, { emit }) {
+    function emitChange(): void {
+      emit('change', !props.value)
+    }
+
+    return {
+      emitChange
     }
   }
-}
+})
 </script>
 
 <style lang="postcss" scoped>

--- a/lib/components/SInputRadios.vue
+++ b/lib/components/SInputRadios.vue
@@ -20,11 +20,12 @@
   </SInputBase>
 </template>
 
-<script>
-import SInputBase from './SInputBase'
-import SInputRadio from './SInputRadio'
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api'
+import SInputBase from './SInputBase.vue'
+import SInputRadio from './SInputRadio.vue'
 
-export default {
+export default defineComponent({
   components: {
     SInputBase,
     SInputRadio
@@ -45,24 +46,29 @@ export default {
     value: { type: [String, Number, Boolean], default: null }
   },
 
-  methods: {
-    isChecked(value) {
-      return value === this.value
-    },
+  setup(props, { emit }) {
+    function isChecked(value: unknown): boolean {
+      return value === props.value
+    }
 
-    handleChange(value) {
-      if (value !== this.value) {
-        this.$emit('change', value)
+    function handleChange(value: unknown): void {
+      if (value !== props.value) {
+        emit('change', value)
 
         return
       }
 
-      if (this.nullable) {
-        this.$emit('change', null)
+      if (props.nullable) {
+        emit('change', null)
       }
     }
+
+    return {
+      isChecked,
+      handleChange
+    }
   }
-}
+})
 </script>
 
 <style lang="postcss" scoped>

--- a/lib/components/SInputSelect.vue
+++ b/lib/components/SInputSelect.vue
@@ -44,6 +44,7 @@
 
 <script lang="ts">
 import { defineComponent, computed, PropType } from '@vue/composition-api'
+import { SyntheticInputEvent } from '../types/Utils'
 import SIconChevronUp from './icons/SIconChevronUp.vue'
 import SIconChevronDown from './icons/SIconChevronDown.vue'
 import SInputBase from './SInputBase.vue'
@@ -81,7 +82,7 @@ export default defineComponent({
     value: { type: [String, Number, Boolean], default: null }
   },
 
-  setup(props, context) {
+  setup(props, { emit }) {
     const classes = computed(() => ({
       medium: props.size === 'medium',
       mini: props.size === 'mini',
@@ -97,12 +98,12 @@ export default defineComponent({
       return option.value === props.value
     }
 
-    function emitChange(e: Event): void {
+    function emitChange(e: SyntheticInputEvent): void {
       props.validation && props.validation.$touch()
 
-      const option = JSON.parse((e.target as HTMLInputElement).value)
+      const option = JSON.parse(e.target.value)
 
-      context.emit('change', option.value)
+      emit('change', option.value)
     }
 
     return {

--- a/lib/components/SInputSwitches.vue
+++ b/lib/components/SInputSwitches.vue
@@ -33,7 +33,7 @@ type Mode = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
 
 interface Option {
   label: string
-  value: any
+  value: unknown
 }
 
 export default defineComponent({
@@ -55,7 +55,7 @@ export default defineComponent({
     note: { type: String, default: null },
     help: { type: String, default: null },
     options: { type: Array as PropType<Option[]>, required: true },
-    value: { type: Array as PropType<any[]>, required: true }
+    value: { type: Array as PropType<unknown[]>, required: true }
   },
 
   setup(props, { emit }) {
@@ -64,11 +64,11 @@ export default defineComponent({
       props.mode
     ])
 
-    function isChecked(value: any): boolean {
+    function isChecked(value: unknown): boolean {
       return props.value.includes(value)
     }
 
-    function handleChange(value: any): void {
+    function handleChange(value: unknown): void {
       const difference = props.value
         .filter(v => v !== value)
         .concat(props.value.includes(value) ? [] : [value])

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -74,6 +74,7 @@ import {
   PropType
 } from '@vue/composition-api'
 import { Validation } from '../validation/Validation'
+import { SyntheticInputEvent } from '../types/Utils'
 import SIconChevronUp from './icons/SIconChevronUp.vue'
 import SIconChevronDown from './icons/SIconChevronDown.vue'
 import SIconX from './icons/SIconX.vue'
@@ -115,7 +116,7 @@ export default defineComponent({
     validation: { type: Object as PropType<Validation>, default: null }
   },
 
-  setup(props, context) {
+  setup(props, { emit }) {
     const inputEl = ref<HTMLElement | null>(null)
     const textEl = ref<HTMLElement | null>(null)
     const textAfterEl = ref<HTMLElement | null>(null)
@@ -143,25 +144,25 @@ export default defineComponent({
     })
 
     function focus() {
-      (inputEl.value as HTMLElement).focus()
+      inputEl.value && inputEl.value.focus()
     }
 
     function blur() {
-      (inputEl.value as HTMLElement).blur()
+      inputEl.value && inputEl.value.blur()
     }
 
-    function emitInput(e: InputEvent) {
-      context.emit('input', getValue((e.target as HTMLInputElement).value))
+    function emitInput(e: SyntheticInputEvent) {
+      emit('input', getValue(e.target.value))
     }
 
-    function emitBlur(e: InputEvent) {
+    function emitBlur(e: SyntheticInputEvent) {
       props.validation && props.validation.$touch()
-      context.emit('blur', getValue((e.target as HTMLInputElement).value))
+      emit('blur', getValue(e.target.value))
     }
 
-    function emitEnter(e: InputEvent) {
+    function emitEnter(e: SyntheticInputEvent) {
       blur()
-      context.emit('enter', getValue((e.target as HTMLInputElement).value))
+      emit('enter', getValue(e.target.value))
     }
 
     function getValue(value: string): string | number | null {
@@ -173,7 +174,7 @@ export default defineComponent({
     }
 
     function emitClear() {
-      context.emit('clear')
+      emit('clear')
     }
 
     function setTextPadding(): void {

--- a/lib/components/SInputTextarea.vue
+++ b/lib/components/SInputTextarea.vue
@@ -24,6 +24,7 @@
 
 <script lang="ts">
 import { PropType, defineComponent, computed } from '@vue/composition-api'
+import { SyntheticInputEvent } from '../types/Utils'
 import { Validation } from '../validation/Validation'
 import SInputBase from './SInputBase.vue'
 
@@ -48,19 +49,23 @@ export default defineComponent({
     validation: { type: Object as PropType<Validation>, default: null }
   },
 
-  setup(props, context) {
+  setup(props, { emit }) {
     const classes = computed(() => [props.size, props.mode])
 
-    function emitInput(e: InputEvent): void {
-      context.emit('input', (e.target as HTMLInputElement).value)
+    function emitInput(e: SyntheticInputEvent): void {
+      emit('input', e.target.value)
     }
 
-    function emitBlur(e: InputEvent): void {
+    function emitBlur(e: SyntheticInputEvent): void {
       props.validation && props.validation.$touch()
-      context.emit('blur', (e.target as HTMLInputElement).value)
+      emit('blur', e.target.value)
     }
 
-    return { classes, emitInput, emitBlur }
+    return {
+      classes,
+      emitInput,
+      emitBlur
+    }
   }
 })
 </script>

--- a/lib/components/SInputTime.vue
+++ b/lib/components/SInputTime.vue
@@ -59,6 +59,7 @@
 <script lang="ts">
 import { defineComponent, ref, computed, onMounted, onUnmounted, PropType } from '@vue/composition-api'
 import useTime from '../compositions/useTime'
+import { SyntheticInputEvent } from '../types/Utils'
 import { Validation } from '../validation/Validation'
 import SInputBase from './SInputBase.vue'
 
@@ -81,7 +82,7 @@ export default defineComponent({
     validation: { type: Object as PropType<Validation>, default: null }
   },
 
-  setup(props, context) {
+  setup(props, { emit }) {
     const input = ref<HTMLInputElement | null>(null)
 
     const on = ref(false)
@@ -108,8 +109,8 @@ export default defineComponent({
       on.value = false
     }
 
-    function handleBlur(e: Event): void {
-      let value: string | null = (e.target as HTMLInputElement).value
+    function handleBlur(e: SyntheticInputEvent): void {
+      let value: string | null = e.target.value
 
       if (!value) {
         value = null
@@ -117,7 +118,7 @@ export default defineComponent({
         value = [hValue.value, mValue.value].join(':')
       }
 
-      context.emit('change', value)
+      emit('change', value)
       updateInput(value ?? '')
     }
 
@@ -126,11 +127,11 @@ export default defineComponent({
     }
 
     function setHour(hour: string): void {
-      context.emit('change', [hour, mValue.value].join(':'))
+      emit('change', [hour, mValue.value].join(':'))
     }
 
     function setMin(minute: string): void {
-      context.emit('change', [hValue.value, minute].join(':'))
+      emit('change', [hValue.value, minute].join(':'))
     }
 
     return {

--- a/lib/components/SModalBase.vue
+++ b/lib/components/SModalBase.vue
@@ -12,6 +12,7 @@
 
 <script lang="ts">
 import { defineComponent, computed } from '@vue/composition-api'
+import { SyntheticMouseEvent } from '../types/Utils'
 import { useStore } from '../composables/Store'
 
 export default defineComponent({
@@ -24,10 +25,10 @@ export default defineComponent({
     const store = useStore()
 
     const first = computed(() => store.state.modal.first)
-    const mount = computed(() => store.state.modal.history.some((h: any) => h.name === props.name))
+    const mount = computed(() => store.state.modal.history.some(h => h.name === props.name))
     const show = computed(() => props.name === store.state.modal.name)
 
-    function close(e: MouseEvent): void {
+    function close(e: SyntheticMouseEvent): void {
       if (props.closable) {
         if (!isDescendant(e.target)) {
           store.dispatch('modal/close')
@@ -35,7 +36,7 @@ export default defineComponent({
       }
     }
 
-    function isDescendant(el: any): boolean {
+    function isDescendant(el: Element): boolean {
       if (el.classList && el.classList.contains('SModalBase')) {
         return false
       }

--- a/lib/components/SPlaceholderBlank.vue
+++ b/lib/components/SPlaceholderBlank.vue
@@ -14,10 +14,11 @@
   </div>
 </template>
 
-<script>
-import SIconPreloaderDark from './icons/SIconPreloaderDark'
+<script lang="ts">
+import { computed, defineComponent } from '@vue/composition-api'
+import SIconPreloaderDark from './icons/SIconPreloaderDark.vue'
 
-export default {
+export default defineComponent({
   components: {
     SIconPreloaderDark
   },
@@ -27,17 +28,19 @@ export default {
     loaderPosition: { type: String, default: 'left' }
   },
 
-  computed: {
-    classes() {
-      return {
-        loaded: this.loaded,
-        left: this.loaderPosition === 'left',
-        center: this.loaderPosition === 'center',
-        right: this.loaderPosition === 'right'
-      }
+  setup(props) {
+    const classes = computed(() => ({
+      loaded: props.loaded,
+      left: props.loaderPosition === 'left',
+      center: props.loaderPosition === 'center',
+      right: props.loaderPosition === 'right'
+    }))
+
+    return {
+      classes
     }
   }
-}
+})
 </script>
 
 <style lang="postcss" scoped>

--- a/lib/components/SPlaceholderImage.vue
+++ b/lib/components/SPlaceholderImage.vue
@@ -1,17 +1,18 @@
 <template>
-  <SPlaceholderBlank class="SPlaceholderImage" :loaded="loaded">
+  <SPlaceholderBlank class="SPlaceholderImage" :loaded="isLoaded">
     <div class="placeholder" :style="styles" />
 
     <div class="img">
-      <img class="img-src" :src="img" :alt="alt" @load="load">
+      <img class="img-src" :src="img" :alt="alt" @load="handleLoad">
     </div>
   </SPlaceholderBlank>
 </template>
 
-<script>
-import SPlaceholderBlank from './SPlaceholderBlank'
+<script lang="ts">
+import { computed, ref, defineComponent } from '@vue/composition-api'
+import SPlaceholderBlank from './SPlaceholderBlank.vue'
 
-export default {
+export default defineComponent({
   components: {
     SPlaceholderBlank
   },
@@ -24,30 +25,28 @@ export default {
     delay: { type: Number, default: 0 }
   },
 
-  data() {
-    return {
-      loaded: false
-    }
-  },
+  setup(props, { emit }) {
+    const isLoaded = ref(false)
 
-  computed: {
-    styles() {
-      return {
-        paddingBottom: `calc((${this.height} / ${this.width}) * 100%)`
-      }
-    }
-  },
+    const styles = computed(() => ({
+      paddingBottom: `calc((${props.height} / ${props.width}) * 100%)`
+    }))
 
-  methods: {
-    load() {
+    function handleLoad(): void {
       setTimeout(() => {
-        this.loaded = true
+        isLoaded.value = true
 
-        this.$emit('load')
-      }, this.delay)
+        emit('load')
+      }, props.delay)
+    }
+
+    return {
+      isLoaded,
+      styles,
+      handleLoad
     }
   }
-}
+})
 </script>
 
 <style lang="postcss" scoped>

--- a/lib/components/SPortalModals.vue
+++ b/lib/components/SPortalModals.vue
@@ -22,6 +22,7 @@
 import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 import { defineComponent, ref, computed, watch } from '@vue/composition-api'
 import { useStore } from '../composables/Store'
+import { useRoute } from '../composables/Router'
 import SDialog from './SDialog.vue'
 import SAlert from './SAlert.vue'
 
@@ -33,8 +34,9 @@ export default defineComponent({
 
   setup() {
     const store = useStore()
+    const route = useRoute()
 
-    const el = ref<any>(null)
+    const el = ref<Element | null>(null)
 
     const show = ref(false)
 
@@ -42,22 +44,20 @@ export default defineComponent({
     const current = computed(() => store.state.modal.name)
 
     const dialogs = computed(() => {
-      return store.state.modal.history.filter((h: any) => {
-        return h.name.startsWith('dialog')
-      })
+      return store.state.modal.history.filter(h => h.name.startsWith('dialog'))
     })
 
     const alerts = computed(() => {
-      return store.state.modal.history.filter((h: any) => {
-        return h.name.startsWith('alert')
-      })
+      return store.state.modal.history.filter(h => h.name.startsWith('alert'))
     })
 
     watch(active, (value) => { value ? open() : close() })
 
     watch(current, () => {
-      setTimeout(() => { el.value.scrollTo(0, 0) }, 250)
+      setTimeout(() => { el.value && el.value.scrollTo(0, 0) }, 250)
     })
+
+    watch(() => route, () => { store.dispatch('modal/close') })
 
     function open(): void {
       show.value = true
@@ -74,8 +74,10 @@ export default defineComponent({
     }
 
     function release(): void {
-      el.value.scrollTo(0, 0)
-      el.value && clearAllBodyScrollLocks()
+      if (el.value) {
+        el.value.scrollTo(0, 0)
+        clearAllBodyScrollLocks()
+      }
     }
 
     return {
@@ -83,12 +85,6 @@ export default defineComponent({
       show,
       dialogs,
       alerts
-    }
-  },
-
-  watch: {
-    $route() {
-      this.$store.dispatch('modal/close')
     }
   }
 })

--- a/lib/components/SPortalModals.vue
+++ b/lib/components/SPortalModals.vue
@@ -57,7 +57,7 @@ export default defineComponent({
       setTimeout(() => { el.value && el.value.scrollTo(0, 0) }, 250)
     })
 
-    watch(() => route, () => { store.dispatch('modal/close') })
+    watch(route, () => { store.dispatch('modal/close') })
 
     function open(): void {
       show.value = true

--- a/lib/components/SPortalScreens.vue
+++ b/lib/components/SPortalScreens.vue
@@ -4,46 +4,59 @@
   </div>
 </template>
 
-<script>
-export default {
-  computed: {
-    screenName() {
-      return this.$store.state.screen.name
-    }
-  },
+<script lang="ts">
+import { computed, defineComponent, watch } from '@vue/composition-api'
+import { useRoute } from '../composables/Router'
+import { useStore } from '../composables/Store'
 
-  watch: {
-    screenName(value) {
-      value === null ? this.closeScreen() : this.openScreen()
-    },
+type Styles = Record<'paddingRight' | 'top' | 'position', string | null>
 
-    $route() {
-      this.$store.dispatch('screen/close')
-    }
-  },
+export default defineComponent({
+  setup() {
+    const store = useStore()
+    const route = useRoute()
 
-  methods: {
-    openScreen() {
-      document.body.style.paddingRight = `${this.scrollBarWidth()}px`
-      document.body.style.top = `-${window.scrollY}px`
-      document.body.style.position = 'fixed'
-    },
+    const name = computed(() => store.state.screen.name)
 
-    closeScreen() {
+    watch(() => name, (value) => {
+      value === null ? close() : open()
+    })
+
+    watch(() => route, () => {
+      store.dispatch('screen/close')
+    })
+
+    function close(): void {
       setTimeout(() => {
         const scrollY = document.body.style.top
 
-        document.body.style.paddingRight = null
-        document.body.style.position = null
-        document.body.style.top = null
+        setBodyStyles({
+          paddingRight: null,
+          top: null,
+          position: null
+        })
 
         window.scrollTo(0, parseInt(scrollY || '0') * -1)
       }, 300)
-    },
+    }
 
-    scrollBarWidth() {
+    function open(): void {
+      const scrollBarWidth = getScrollbarWidth()
+
+      setBodyStyles({
+        paddingRight: `${scrollBarWidth}px`,
+        top: `-${window.scrollY}px`,
+        position: 'fixed'
+      })
+    }
+
+    function setBodyStyles(styles: Styles): void {
+      Object.assign(document.body.style, styles)
+    }
+
+    function getScrollbarWidth(): number {
       return window.innerWidth - document.documentElement.clientWidth
     }
   }
-}
+})
 </script>

--- a/lib/components/SPortalScreens.vue
+++ b/lib/components/SPortalScreens.vue
@@ -16,15 +16,11 @@ export default defineComponent({
     const store = useStore()
     const route = useRoute()
 
-    const name = computed(() => store.state.screen.name)
+    const screenName = computed(() => store.state.screen.name)
 
-    watch(() => name, (value) => {
-      value === null ? close() : open()
-    })
+    watch(screenName, (value) => { value === null ? close() : open() })
 
-    watch(() => route, () => {
-      store.dispatch('screen/close')
-    })
+    watch(route, () => { store.dispatch('screen/close') })
 
     function close(): void {
       setTimeout(() => {
@@ -56,6 +52,10 @@ export default defineComponent({
 
     function getScrollbarWidth(): number {
       return window.innerWidth - document.documentElement.clientWidth
+    }
+
+    return {
+      screenName
     }
   }
 })

--- a/lib/components/SPortalSnackbars.vue
+++ b/lib/components/SPortalSnackbars.vue
@@ -16,6 +16,7 @@
 
 <script lang="ts">
 import { defineComponent, computed } from '@vue/composition-api'
+import { useStore } from '../composables/Store'
 import SSnackbar from './SSnackbar.vue'
 
 export default defineComponent({
@@ -23,8 +24,10 @@ export default defineComponent({
     SSnackbar
   },
 
-  setup(_props, context) {
-    const items = computed(() => context.root.$store.state.snackbars.items)
+  setup() {
+    const store = useStore()
+
+    const items = computed(() => store.state.snackbars.items)
     const hasItem = computed(() => items.value.length > 0)
 
     return {

--- a/lib/components/SProgressBar.vue
+++ b/lib/components/SProgressBar.vue
@@ -12,35 +12,35 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { computed, defineComponent } from '@vue/composition-api'
+
+export default defineComponent({
   props: {
     now: { type: Number, required: true },
     max: { type: Number, required: true }
   },
 
-  computed: {
-    styles() {
-      return {
-        transform: `scaleX(${this.progress})`
-      }
-    },
-
-    progress() {
-      const value = this.now / this.max
-
+  setup(props) {
+    const progress = computed(() => {
+      const value = props.now / props.max
       const pow = 10 ** 4
 
       return Math.round(value * pow) / pow
-    },
+    })
 
-    progressForNumber() {
-      const progress = this.progress * 100
+    const progressForNumber = computed(() => (progress.value * 100).toFixed(2))
 
-      return progress.toFixed(2)
+    const styles = computed<Partial<CSSStyleDeclaration>>(() => ({
+      transform: `scaleX(${progress.value})`
+    }))
+
+    return {
+      styles,
+      progressForNumber
     }
   }
-}
+})
 </script>
 
 <style lang="postcss" scoped>

--- a/lib/components/SScreen.vue
+++ b/lib/components/SScreen.vue
@@ -14,10 +14,12 @@
   </portal>
 </template>
 
-<script>
+<script lang="ts">
+import { computed, defineComponent } from '@vue/composition-api'
 import VueSimplebar from 'simplebar-vue'
+import { useStore } from '../composables/Store'
 
-export default {
+export default defineComponent({
   components: {
     VueSimplebar
   },
@@ -27,16 +29,18 @@ export default {
     title: { type: String, default: null }
   },
 
-  computed: {
-    screenName() {
-      return this.$store.state.screen.name
-    },
+  setup(props) {
+    const store = useStore()
 
-    show() {
-      return this.name === this.screenName
+    const screenName = computed(() => store.state.screen.name)
+    const show = computed(() => props.name === screenName.value)
+
+    return {
+      screenName,
+      show
     }
   }
-}
+})
 </script>
 
 <style lang="postcss" scoped>

--- a/lib/components/SSnackbar.vue
+++ b/lib/components/SSnackbar.vue
@@ -21,6 +21,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from '@vue/composition-api'
+import { useStore } from '../composables/Store'
 import { Action } from '../store/snackbars'
 import SIconX from './icons/SIconX.vue'
 import SButton from './SButton.vue'
@@ -37,9 +38,11 @@ export default defineComponent({
     actions: { type: Array as PropType<Action[]>, default: null }
   },
 
-  setup(props, context) {
+  setup(props) {
+    const store = useStore()
+
     function close(): void {
-      context.root.$store.dispatch('snackbars/pop', props.id)
+      store.dispatch('snackbars/pop', props.id)
     }
 
     return {

--- a/lib/components/SWindow.vue
+++ b/lib/components/SWindow.vue
@@ -29,12 +29,15 @@
   </SModalBase>
 </template>
 
-<script>
-import SIconX from './icons/SIconX'
-import SButton from './SButton'
-import SModalBase from './SModalBase'
+<script lang="ts">
+import { PropType, computed, defineComponent } from '@vue/composition-api'
+import { ButtonAction } from '../composables/Action'
+import { useStore } from '../composables/Store'
+import SIconX from './icons/SIconX.vue'
+import SButton from './SButton.vue'
+import SModalBase from './SModalBase.vue'
 
-export default {
+export default defineComponent({
   components: {
     SIconX,
     SButton,
@@ -45,22 +48,25 @@ export default {
     name: { type: String, required: true },
     title: { type: String, default: null },
     lead: { type: String, default: null },
-    actions: { type: Array, default: null },
+    actions: { type: Array as PropType<ButtonAction[]>, default: null },
     closable: { type: Boolean, default: false }
   },
 
-  computed: {
-    showHeader() {
-      return !!this.title
-    }
-  },
+  setup(props) {
+    const store = useStore()
 
-  methods: {
-    close() {
-      this.$store.dispatch('window/close')
+    const showHeader = computed(() => !!props.title)
+
+    function close(): void {
+      store.dispatch('window/close')
+    }
+
+    return {
+      showHeader,
+      close
     }
   }
-}
+})
 </script>
 
 <style lang="postcss" scoped>

--- a/lib/composables/Router.ts
+++ b/lib/composables/Router.ts
@@ -12,3 +12,9 @@ export function useRoute(): ComputedRef<Route> {
 
   return computed(() => proxy.$route)
 }
+
+export function useParams(): ComputedRef<Record<string, string>> {
+  const { proxy } = getCurrentInstance()!
+
+  return computed(() => proxy.$route.params)
+}

--- a/lib/composables/Router.ts
+++ b/lib/composables/Router.ts
@@ -1,14 +1,14 @@
 import { getCurrentInstance } from '@vue/composition-api'
 import VueRouter, { Route } from 'vue-router'
 
-export function useRouter() {
-  const vm = getCurrentInstance()?.proxy as any
+export function useRouter(): VueRouter {
+  const { proxy } = getCurrentInstance()!
 
-  return vm.$router as VueRouter
+  return proxy.$router
 }
 
-export function useRoute() {
-  const vm = getCurrentInstance()?.proxy as any
+export function useRoute(): Route {
+  const { proxy } = getCurrentInstance()!
 
-  return vm.$route as Route
+  return proxy.$route
 }

--- a/lib/composables/Router.ts
+++ b/lib/composables/Router.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance } from '@vue/composition-api'
+import { computed, ComputedRef, getCurrentInstance } from '@vue/composition-api'
 import VueRouter, { Route } from 'vue-router'
 
 export function useRouter(): VueRouter {
@@ -7,8 +7,8 @@ export function useRouter(): VueRouter {
   return proxy.$router
 }
 
-export function useRoute(): Route {
+export function useRoute(): ComputedRef<Route> {
   const { proxy } = getCurrentInstance()!
 
-  return proxy.$route
+  return computed(() => proxy.$route)
 }

--- a/lib/composables/Store.ts
+++ b/lib/composables/Store.ts
@@ -1,8 +1,9 @@
 import { getCurrentInstance } from '@vue/composition-api'
 import { Store } from 'vuex'
+import { State } from '../store/Sefirot'
 
-export function useStore() {
-  const vm = getCurrentInstance()?.proxy as any
+export function useStore(): Store<State> {
+  const { proxy } = getCurrentInstance()!
 
-  return vm.$store as Store<any>
+  return proxy.$store
 }

--- a/lib/compositions/useResizeObserver.ts
+++ b/lib/compositions/useResizeObserver.ts
@@ -6,7 +6,7 @@ export interface EL {
   h: number
 }
 
-export default function useResizeObserver(target: Ref<HTMLElement | null>) {
+export default function useResizeObserver(target: Ref<HTMLElement>) {
   const el = reactive({ w: 0, h: 0 })
 
   const ro = new ResizeObserver((entries) => {
@@ -15,7 +15,7 @@ export default function useResizeObserver(target: Ref<HTMLElement | null>) {
     el.h = entry.contentBoxSize[0].blockSize
   })
 
-  onMounted(() => { ro.observe(target.value as HTMLElement) })
+  onMounted(() => { ro.observe(target.value) })
   onUnmounted(() => { ro.disconnect() })
 
   return {

--- a/lib/support/Util.ts
+++ b/lib/support/Util.ts
@@ -3,14 +3,14 @@ export { default as cloneDeep } from 'lodash-es/cloneDeep'
 export { default as orderBy } from 'lodash-es/orderBy'
 export { default as groupBy } from 'lodash-es/groupBy'
 
-export function isNullish(value: any): value is undefined | null {
+export function isNullish(value: unknown): value is undefined | null {
   return value === null || value === undefined
 }
 
-export function isString(value: any): value is string {
+export function isString(value: unknown): value is string {
   return typeof value === 'string'
 }
 
-export function isArray(value: any): value is any[] {
+export function isArray(value: unknown): value is unknown[] {
   return Array.isArray(value)
 }

--- a/lib/types/Utils.ts
+++ b/lib/types/Utils.ts
@@ -1,3 +1,7 @@
 export type Values<T> = T[keyof T]
 
 export type OmitType<T> = Omit<T, 'type'>
+
+export type SyntheticEvent<E extends Event, T extends Element> = E & { target: T }
+export type SyntheticInputEvent<T extends Element = HTMLInputElement> = SyntheticEvent<InputEvent, T>
+export type SyntheticMouseEvent<T extends Element = HTMLElement> = SyntheticEvent<MouseEvent, T>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,10 +1,10 @@
-import { Configuration } from '@nuxt/types'
+import { NuxtConfig } from '@nuxt/types'
 import { highlight } from './docs/markdown/Highlight'
 import { preWrapper } from './docs/markdown/PreWrapper'
 
 require('dotenv').config()
 
-const config: Configuration = {
+const config: NuxtConfig = {
   target: 'static',
 
   ssr: false,


### PR DESCRIPTION
This PR remedies typings and brings remaining components into the composition environment.

### BREAKING CHANGES

* **useRoute**: now returns `ComputedRef<Route>` when previously it returned `Route`

### Features

* add `useParams` hook for route param lookups
* add `SyntheticInputEvent` & `SyntheticMouseEvent` type aliases for common event types

### Bug Fixes

* **alert**: correct action `kind` passed to composable

### Remedial

* overall type safety with appropriate type assertions and inference
* destructuring setup context methods (e.g. `{ emit }` replaces `context.emit`)
* `useStore` supersedes the now deprecated `root.$store` context reference
* use local `isArray` util where applicable
* assert `CSSStyleDeclaration` for better intellisense when generating style objects 
* components now using Composition API:
   - **input-checkbox**
   - **input-checkboxes**
   - **input-radio**
   - **input-radios**
   - **placeholder-blank**
   - **placeholder-image**
   - **portal-screens**
   - **progress-bar**
   - **screen**
   - **window**