### PR TITLE
test: refactor tests for better coverage

### DIFF
--- a/lib/components/SPortalModals.vue
+++ b/lib/components/SPortalModals.vue
@@ -74,10 +74,8 @@ export default defineComponent({
     }
 
     function release(): void {
-      if (el.value) {
-        el.value.scrollTo(0, 0)
-        clearAllBodyScrollLocks()
-      }
+      el.value && el.value.scrollTo(0, 0)
+      clearAllBodyScrollLocks()
     }
 
     return {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "jest-serializer-vue": "^2.0.2",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
-    "mutation-observer": "^1.0.3",
     "normalize.css": "^8.0.1",
     "nuxt": "^2.15.2",
     "portal-vue": "^2.1.7",

--- a/test/components/SButton.spec.ts
+++ b/test/components/SButton.spec.ts
@@ -1,41 +1,48 @@
-import { mount } from '@vue/test-utils'
+import { shallowMount } from '@vue/test-utils'
 import SIconPreloaderDark from 'sefirot/components/icons/SIconPreloaderDark.vue'
 import SIconPreloaderLight from 'sefirot/components/icons/SIconPreloaderLight.vue'
 import SButton from 'sefirot/components/SButton.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SButton>
+let createWrapper: CreateWrapperFn<Instance>
 
 describe('components/SButton', () => {
-  it('emits `click` event when a user clicks the button', () => {
-    const wrapper = mount(SButton, {
+  beforeEach(() => {
+    createWrapper = options => shallowMount(SButton, options)
+  })
+
+  it('should emit on click', () => {
+    const wrapper = createWrapper({
       propsData: {
         label: 'BUTTON'
       }
     })
 
     wrapper.find('.SButton').trigger('click')
-
     expect(wrapper.emitted('click')).toBeTruthy()
   })
 
-  it('shows the correct preloader depending on the button mode', async () => {
-    const wrapper = mount(SButton, {
+  it('should display correct preloader depending on mode', async () => {
+    const wrapper = createWrapper({
       propsData: {
         label: 'BUTTON',
         loading: true
       }
     })
 
-    expect((wrapper as any).vm.preloaderComponent).toBe(SIconPreloaderLight)
+    expect(wrapper.vm.preloaderComponent).toBe(SIconPreloaderLight)
 
     await wrapper.setProps({ type: 'secondary' })
-    expect((wrapper as any).vm.preloaderComponent).toBe(SIconPreloaderDark)
+    expect(wrapper.vm.preloaderComponent).toBe(SIconPreloaderDark)
 
     await wrapper.setProps({ type: 'primary', inverse: true })
-    expect((wrapper as any).vm.preloaderComponent).toBe(SIconPreloaderDark)
+    expect(wrapper.vm.preloaderComponent).toBe(SIconPreloaderDark)
 
     await wrapper.setProps({ type: 'secondary', inverse: true })
-    expect((wrapper as any).vm.preloaderComponent).toBe(SIconPreloaderLight)
+    expect(wrapper.vm.preloaderComponent).toBe(SIconPreloaderLight)
 
     await wrapper.setProps({ mode: 'info' })
-    expect((wrapper as any).vm.preloaderComponent).toBe(SIconPreloaderLight)
+    expect(wrapper.vm.preloaderComponent).toBe(SIconPreloaderLight)
   })
 })

--- a/test/components/SDropdown.spec.ts
+++ b/test/components/SDropdown.spec.ts
@@ -1,0 +1,124 @@
+import { mount } from '@vue/test-utils'
+import SDropdown from 'sefirot/components/SDropdown.vue'
+import { UseDropdownOptions, useDropdown, useTextItem, useUserItem } from 'sefirot/composables/Dropdown'
+import { Wrapper } from '../utils'
+
+type Instance = InstanceType<typeof SDropdown>
+let createWrapper: (options: UseDropdownOptions) => Wrapper<Instance>
+
+describe('components/SDropdown', () => {
+  beforeEach(() => {
+    createWrapper = options => mount(SDropdown, {
+      propsData: {
+        options: useDropdown(options)
+      }
+    })
+  })
+
+  it('should render text item', () => {
+    const wrapper = createWrapper({
+      items: [
+        useTextItem({ text: 'Item 1', value: 1 })
+      ]
+    })
+
+    expect(wrapper.find('.SDropdown .SDropdownItem .SDropdownItemText').exists())
+  })
+
+  it('should render user item', () => {
+    const wrapper = createWrapper({
+      items: [
+        useUserItem({ name: 'John Doe', value: 1, avatar: '' })
+      ]
+    })
+
+    expect(wrapper.find('.SDropdown .SDropdownItem .SDropdownItemUser').exists())
+  })
+
+  it('should throw with invalid item', () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => jest.fn())
+
+    const wrapper = () => {
+      createWrapper({
+        items: [{ type: 'invalid' }] as any
+      })
+    }
+
+    expect(wrapper).toThrowError('Invalid item type.')
+    expect(error).toHaveBeenCalled()
+  })
+
+  it('should mark multiple items as selected', () => {
+    const wrapper = createWrapper({
+      items: [
+        useTextItem({ text: 'Item 1', value: 1 }),
+        useTextItem({ text: 'Item 2', value: 2 }),
+        useTextItem({ text: 'Item 3', value: 3 })
+      ],
+      selected: { value: [1, 2] } as any
+    })
+
+    const selected = wrapper.findAll('.SDropdown .SDropdownItem .status')
+    expect(selected.at(0).isEmpty()).toBe(false)
+    expect(selected.at(1).isEmpty()).toBe(false)
+    expect(selected.at(2).isEmpty()).toBe(true)
+  })
+
+  it('should invoke callback on click', () => {
+    const callback = jest.fn()
+
+    const wrapper = createWrapper({
+      callback,
+      items: [
+        useTextItem({ text: 'Item 1', value: 1 })
+      ]
+    })
+
+    wrapper.find('.SDropdown .SDropdownItem').trigger('click')
+    expect(callback).toHaveBeenCalled()
+  })
+
+  it('should invoke item callback with precedence on click', () => {
+    const callback = jest.fn()
+    const blanketCallback = jest.fn()
+
+    const wrapper = createWrapper({
+      callback: blanketCallback,
+      items: [
+        useTextItem({
+          text: 'Item 1',
+          value: 1,
+          callback
+        })
+      ]
+    })
+
+    wrapper.find('.SDropdown .SDropdownItem').trigger('click')
+    expect(callback).toHaveBeenCalled()
+    expect(blanketCallback).not.toHaveBeenCalled()
+  })
+
+  it('should emit with `closeOnClick` enabled', () => {
+    const wrapper = createWrapper({
+      closeOnClick: true,
+      items: [
+        useTextItem({ text: 'Item 1', value: 1 })
+      ]
+    })
+
+    wrapper.find('.SDropdown .SDropdownItem').trigger('click')
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('should emit on close button click', () => {
+    const wrapper = createWrapper({
+      title: 'Title',
+      items: [
+        useTextItem({ text: 'Item 1', value: 1 })
+      ]
+    })
+
+    wrapper.find('.SDropdown .header .close').trigger('click')
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+})

--- a/test/components/SGrid.spec.ts
+++ b/test/components/SGrid.spec.ts
@@ -1,66 +1,63 @@
 import { mount } from '@vue/test-utils'
 import SIconX from 'sefirot/components/icons/SIconX.vue'
 import SGrid from 'sefirot/components/SGrid.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SGrid>
+let createWrapper: CreateWrapperFn<Instance>
 
 describe('components/SGrid', () => {
-  test('if clickable, it emits `click` event when a user clicks the record', () => {
-    const wrapper = mount(SGrid, {
+  beforeEach(() => {
+    createWrapper = (options = {}) => mount(SGrid, {
+      ...options,
       propsData: {
         columns: [{ name: 'name', label: 'NAME' }],
         records: [{ id: 1, name: 'John Doe' }],
-        clickable: true
+        ...options.propsData
       }
+    })
+  })
+
+  it('should emit on click when `clickable` is true', () => {
+    const wrapper = createWrapper({
+      propsData: { clickable: true }
     })
 
     wrapper.find('.SGrid .row').trigger('click')
-
-    expect(wrapper.emitted('click')?.[0][0]).toEqual({ id: 1, name: 'John Doe' })
+    expect(wrapper.emitted('click')).toHaveEmittedWith({ id: 1, name: 'John Doe' })
   })
 
-  test('if not clickable, it will not emits `click` event when a user clicks the record', () => {
-    const wrapper = mount(SGrid, {
-      propsData: {
-        columns: [{ name: 'name', label: 'NAME' }],
-        records: [{ id: 1, name: 'John Doe' }],
-        clickable: false
-      }
+  it('should not emit on click when `clickable` is false', () => {
+    const wrapper = createWrapper({
+      propsData: { clickable: false }
     })
 
     wrapper.find('.SGrid .row').trigger('click')
-
-    expect(wrapper.emitted('click')).toBe(undefined)
+    expect(wrapper.emitted('click')).toBeUndefined()
   })
 
-  test('it can shows link action', () => {
-    const wrapper = mount(SGrid, {
-      propsData: {
-        columns: [{ name: 'name', label: 'NAME' }],
-        records: [{ id: 1, name: 'John Doe' }],
-        actions: 'link'
-      }
+  it('should display link actions', () => {
+    const wrapper = createWrapper({
+      propsData: { actions: 'link' }
     })
 
     expect(wrapper.find('.SGrid .SGridActionLink').exists()).toBe(true)
   })
 
-  test('it can shows single action', () => {
-    const wrapper = mount(SGrid, {
+  it('should display single actions', () => {
+    const wrapper = createWrapper({
       propsData: {
-        columns: [{ name: 'name', label: 'NAME' }],
-        records: [{ id: 1, name: 'John Doe' }],
-        actions: { icon: SIconX, callback: () => {} }
+        actions: { icon: SIconX, callback: jest.fn() }
       }
     })
 
     expect(wrapper.find('.SGrid .SGridActionSingle').exists()).toBe(true)
   })
 
-  test('it can shows multi actions', () => {
-    const wrapper = mount(SGrid, {
+  it('should display multi actions', () => {
+    const wrapper = createWrapper({
       propsData: {
-        columns: [{ name: 'name', label: 'NAME' }],
-        records: [{ id: 1, name: 'John Doe' }],
-        actions: [{ name: 'Edit', icon: SIconX, callback: () => {} }]
+        actions: [{ name: 'Edit', icon: SIconX, callback: jest.fn() }]
       }
     })
 

--- a/test/components/SInputCheckbox.spec.ts
+++ b/test/components/SInputCheckbox.spec.ts
@@ -1,17 +1,24 @@
 import { mount } from '@vue/test-utils'
 import SInputCheckbox from 'sefirot/components/SInputCheckbox.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SInputCheckbox>
+let createWrapper: CreateWrapperFn<Instance>
 
 describe('components/SInputCheckbox', () => {
-  test('it emits `input` event when a user inputs the value', () => {
-    const wrapper = mount(SInputCheckbox, {
+  beforeEach(() => {
+    createWrapper = options => mount(SInputCheckbox, options)
+  })
+
+  it('should emit value on click', () => {
+    const wrapper = createWrapper({
       propsData: {
-        text: 'Checkbox text',
+        text: 'Checkbox',
         value: false
       }
     })
 
     wrapper.find('.SInputCheckbox .input').trigger('click')
-
-    expect(wrapper.emitted('change')?.[0][0]).toBe(true)
+    expect(wrapper.emitted('change')).toHaveEmittedWith(true)
   })
 })

--- a/test/components/SInputCheckboxes.spec.ts
+++ b/test/components/SInputCheckboxes.spec.ts
@@ -1,36 +1,55 @@
 import { mount } from '@vue/test-utils'
 import SInputCheckboxes from 'sefirot/components/SInputCheckboxes.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SInputCheckboxes>
+let createWrapper: CreateWrapperFn<Instance>
 
 describe('components/SInputCheckboxes', () => {
-  test('it emits correct value when an user clicks a checkbox', () => {
-    const options = [
-      { label: 'Check box 1', value: 1 },
-      { label: 'Check box 2', value: 2 },
-      { label: 'Check box 3', value: 3 }
-    ]
+  beforeEach(() => {
+    createWrapper = (options = {}) => mount(SInputCheckboxes, {
+      ...options,
+      propsData: {
+        options: [
+          { label: 'Checkbox 1', value: 1 },
+          { label: 'Checkbox 2', value: 2 },
+          { label: 'Checkbox 3', value: 3 }
+        ],
+        ...options.propsData
+      }
+    })
+  })
 
-    const wrapper1 = mount(SInputCheckboxes, {
-      propsData: { value: [], options }
+  it('should emit value on click', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        value: []
+      }
     })
 
-    wrapper1.find('.SInputCheckboxes .col:nth-child(1) .input').trigger('click')
+    wrapper.find('.SInputCheckboxes .col:nth-child(1) .input').trigger('click')
+    expect(wrapper.emitted('change')).toHaveEmittedWith([1])
+  })
 
-    expect(wrapper1.emitted('change')?.[0][0]).toEqual([1])
-
-    const wrapper2 = mount(SInputCheckboxes, {
-      propsData: { value: [1], options }
+  it('should append value on click', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        value: [1]
+      }
     })
 
-    wrapper2.find('.SInputCheckboxes .col:nth-child(2) .input').trigger('click')
+    wrapper.find('.SInputCheckboxes .col:nth-child(2) .input').trigger('click')
+    expect(wrapper.emitted('change')).toHaveEmittedWith([1, 2])
+  })
 
-    expect(wrapper2.emitted('change')?.[0][0]).toEqual([1, 2])
-
-    const wrapper3 = mount(SInputCheckboxes, {
-      propsData: { value: [1, 2], options }
+  it('should remove value on click', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        value: [1, 2]
+      }
     })
 
-    wrapper3.find('.SInputCheckboxes .col:nth-child(1) .input').trigger('click')
-
-    expect(wrapper3.emitted('change')?.[0][0]).toEqual([2])
+    wrapper.find('.SInputCheckboxes .col:nth-child(2) .input').trigger('click')
+    expect(wrapper.emitted('change')).toHaveEmittedWith([1])
   })
 })

--- a/test/components/SInputNumber.spec.ts
+++ b/test/components/SInputNumber.spec.ts
@@ -1,56 +1,70 @@
 import { mount } from '@vue/test-utils'
 import SInputNumber from 'sefirot/components/SInputNumber.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SInputNumber>
+let createWrapper: CreateWrapperFn<Instance>
 
 describe('components/SInputNumber', () => {
-  it('compute the number with thousand separator if `helpFormat` prop is true', async () => {
-    const wrapper = mount(SInputNumber, {
+  beforeEach(() => {
+    createWrapper = options => mount(SInputNumber, options)
+  })
+
+  it('should format help text with thousand separator', async () => {
+    const wrapper = createWrapper({
       propsData: {
         helpFormat: true
       }
     })
 
-    await wrapper.setProps({
-      value: 1000000
+    await wrapper.setProps({ value: 1000000000 })
+    expect(wrapper.vm.valueWithSeparator).toBe('1,000,000,000')
+  })
+
+  it('should not format help text with excessive value', async () => {
+    const wrapper = createWrapper({
+      propsData: {
+        helpFormat: true
+      }
     })
 
-    expect((wrapper.vm as any).valueWithSeparator).toBe('1,000,000')
+    await wrapper.setProps({ value: 200000000000000000000 })
+    expect(wrapper.vm.valueWithSeparator).toBe('The number is too big')
   })
 
-  it('emits `input` event when a user inputs the value', () => {
-    const wrapper = mount(SInputNumber)
+  it('should emit value on input', () => {
+    const wrapper = createWrapper()
 
     wrapper.find('.SInputNumber .input').setValue(1)
-
-    expect((wrapper.emitted('input') as any)[0][0]).toBe(1)
+    expect(wrapper.emitted('input')).toHaveEmittedWith(1)
   })
 
-  it('emits `input` event when a user inputs nothing', () => {
-    const wrapper = mount(SInputNumber)
+  it('should emit null when value is empty', () => {
+    const wrapper = createWrapper()
 
     wrapper.find('.SInputNumber .input').setValue(null)
-
-    expect((wrapper.emitted('input') as any)[0][0]).toBe(null)
+    expect(wrapper.emitted('input')).toHaveEmittedWith(null)
   })
 
-  it('emits `blur` event when a user blur form the input', () => {
-    const wrapper = mount(SInputNumber)
+  it('should emit value when losing focus', () => {
+    const wrapper = createWrapper()
 
     const input = wrapper.find('.SInputNumber .input')
 
     input.setValue(1)
     input.trigger('blur')
 
-    expect((wrapper.emitted('blur') as any)[0][0]).toBe(1)
+    expect(wrapper.emitted('blur')).toHaveEmittedWith(1)
   })
 
-  it('emits `enter` event when a user key down enter', () => {
-    const wrapper = mount(SInputNumber)
+  it('should emit value on `enter` keypress', () => {
+    const wrapper = createWrapper()
 
     const input = wrapper.find('.SInputNumber .input')
 
     input.setValue(1)
     input.trigger('keypress.enter')
 
-    expect((wrapper.emitted('enter') as any)[0][0]).toBe(1)
+    expect(wrapper.emitted('enter')).toHaveEmittedWith(1)
   })
 })

--- a/test/components/SInputRadios.spec.ts
+++ b/test/components/SInputRadios.spec.ts
@@ -1,52 +1,58 @@
 import { mount } from '@vue/test-utils'
 import SInputRadios from 'sefirot/components/SInputRadios.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SInputRadios>
+let createWrapper: CreateWrapperFn<Instance>
 
 describe('components/SInputRadios', () => {
-  test('it emits correct value when an user clicks a radio button', () => {
-    const options = [
-      { label: 'Radio button 1', value: 1 },
-      { label: 'Radio button 2', value: 2 },
-      { label: 'Radio button 3', value: 3 }
-    ]
-
-    const wrapper1 = mount(SInputRadios, {
-      propsData: { value: 1, nullable: false, options }
+  beforeEach(() => {
+    createWrapper = (options = {}) => mount(SInputRadios, {
+      ...options,
+      propsData: {
+        options: [
+          { label: 'Radio 1', value: 1 },
+          { label: 'Radio 2', value: 2 },
+          { label: 'Radio 3', value: 3 }
+        ],
+        ...options.propsData
+      }
     })
-
-    wrapper1.find('.SInputRadios .col:nth-child(1) .input').trigger('click')
-
-    expect(wrapper1.emitted('change')).toBe(undefined)
-
-    const wrapper2 = mount(SInputRadios, {
-      propsData: { value: 1, nullable: false, options }
-    })
-
-    wrapper2.find('.SInputRadios .col:nth-child(2) .input').trigger('click')
-
-    expect(wrapper2.emitted('change')?.[0][0]).toEqual(2)
   })
 
-  test('it can accept no radio to be checked when the `nullable` option are set', () => {
-    const options = [
-      { label: 'Radio button 1', value: 1 },
-      { label: 'Radio button 2', value: 2 },
-      { label: 'Radio button 3', value: 3 }
-    ]
-
-    const wrapper1 = mount(SInputRadios, {
-      propsData: { value: 1, nullable: true, options }
+  it('should emit changed value', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        value: 1,
+        nullable: false
+      }
     })
 
-    wrapper1.find('.SInputRadios .col:nth-child(1) .input').trigger('click')
+    wrapper.find('.SInputRadios .col:nth-child(2) .input').trigger('click')
+    expect(wrapper.emitted('change')).toHaveEmittedWith(2)
+  })
 
-    expect(wrapper1.emitted('change')?.[0][0]).toBe(null)
-
-    const wrapper2 = mount(SInputRadios, {
-      propsData: { value: 1, nullable: true, options }
+  it('should not emit checked value', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        value: 1,
+        nullable: false
+      }
     })
 
-    wrapper2.find('.SInputRadios .col:nth-child(2) .input').trigger('click')
+    wrapper.find('.SInputRadios .col:nth-child(1) .input').trigger('click')
+    expect(wrapper.emitted('change')).toBeUndefined()
+  })
 
-    expect(wrapper2.emitted('change')?.[0][0]).toEqual(2)
+  it('should emit nullable value', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        value: 1,
+        nullable: true
+      }
+    })
+
+    wrapper.find('.SInputRadios .col:nth-child(1) .input').trigger('click')
+    expect(wrapper.emitted('change')).toHaveEmittedWith(null)
   })
 })

--- a/test/components/SInputSelect.spec.ts
+++ b/test/components/SInputSelect.spec.ts
@@ -1,48 +1,53 @@
 import { mount } from '@vue/test-utils'
 import useForm from 'sefirot/compositions/useForm'
 import SInputSelect from 'sefirot/components/SInputSelect.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SInputSelect>
+let createWrapper: CreateWrapperFn<Instance>
 
 describe('components/SInputSelect', () => {
-  it('emits correct value when an user select an option', () => {
-    const options = [
-      { label: 'Option 1', value: 1 },
-      { label: 'Option 2', value: 2 },
-      { label: 'Option 3', value: 3 }
-    ]
-
-    const wrapper = mount(SInputSelect, {
-      propsData: { value: 1, options }
+  beforeEach(() => {
+    createWrapper = (options = {}) => mount(SInputSelect, {
+      ...options,
+      propsData: {
+        options: [
+          { label: 'Option 1', value: 1 },
+          { label: 'Option 2', value: 2 },
+          { label: 'Option 3', value: 3 }
+        ],
+        ...options.propsData
+      }
     })
-
-    wrapper.find('.SInputSelect .select').setValue(JSON.stringify({ label: 'Option 2', value: 2 }))
-
-    expect((wrapper as any).emitted('change')[0][0]).toEqual(2)
   })
 
-  it('"touches" the validation on change event', async () => {
-    const options = [
-      { label: 'Option 1', value: 1 },
-      { label: 'Option 2', value: 2 },
-      { label: 'Option 3', value: 3 }
-    ]
+  it('should emit value on input change', () => {
+    const wrapper = createWrapper({
+      propsData: { value: 1 }
+    })
 
+    wrapper.find('.SInputSelect .select').setValue(
+      JSON.stringify({ label: 'Option 2', value: 2 })
+    )
+    expect(wrapper.emitted('change')).toHaveEmittedWith(2)
+  })
+
+  it('should invoke validation on input change', async () => {
     const { data, validation } = useForm({
       data: { item: null },
       rules: { item: [] }
     })
 
-    const wrapper = mount(SInputSelect, {
+    const wrapper = createWrapper({
       propsData: {
         value: data.item,
-        options,
         validation: validation.item
       }
     })
 
-    const items = wrapper.find('.SInputSelect .select').findAll('option')
+    const option = wrapper.find('.SInputSelect .select').findAll('option').at(1)
 
-    await items.at(1).setSelected()
-
+    await option.setSelected()
     expect(validation.item.$isDirty.value).toBe(true)
   })
 })

--- a/test/components/SInputSwitch.spec.ts
+++ b/test/components/SInputSwitch.spec.ts
@@ -1,0 +1,21 @@
+import { mount } from '@vue/test-utils'
+import SInputSwitch from 'sefirot/components/SInputSwitch.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SInputSwitch>
+let createWrapper: CreateWrapperFn<Instance>
+
+describe('components/SInputSwitch', () => {
+  beforeEach(() => {
+    createWrapper = options => mount(SInputSwitch, options)
+  })
+
+  it('should emit value on click', () => {
+    const wrapper = createWrapper({
+      propsData: { value: false }
+    })
+
+    wrapper.find('.SInputSwitch .SInputSwitch-input').trigger('click')
+    expect(wrapper.emitted('change')).toHaveEmittedWith(true)
+  })
+})

--- a/test/components/SInputSwitches.spec.ts
+++ b/test/components/SInputSwitches.spec.ts
@@ -1,0 +1,28 @@
+import { mount } from '@vue/test-utils'
+import SInputSwitches from 'sefirot/components/SInputSwitches.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SInputSwitches>
+let createWrapper: CreateWrapperFn<Instance>
+
+describe('components/SInputSwitches', () => {
+  beforeEach(() => {
+    createWrapper = options => mount(SInputSwitches, options)
+  })
+
+  it('should emit value on click', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        options: [
+          { label: 'Option 1', value: 1 },
+          { label: 'Option 2', value: 2 },
+          { label: 'Option 3', value: 3 }
+        ],
+        value: [1]
+      }
+    })
+
+    wrapper.findAll('.SInputSwitches .SInputSwitch-input').at(1).trigger('click')
+    expect(wrapper.emitted('change')).toHaveEmittedWith([1, 2])
+  })
+})

--- a/test/components/SInputText.spec.ts
+++ b/test/components/SInputText.spec.ts
@@ -1,36 +1,46 @@
 import { mount } from '@vue/test-utils'
-import useForm from 'sefirot/compositions/useForm'
 import SIconSearch from 'sefirot/components/icons/SIconSearch.vue'
 import SInputText from 'sefirot/components/SInputText.vue'
+import useForm from 'sefirot/compositions/useForm'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SInputText>
+let createWrapper: CreateWrapperFn<Instance>
 
 describe('components/SInputText', () => {
-  it('emits `input` event when a user inputs the value', () => {
-    const wrapper = mount(SInputText)
-
-    wrapper.find('.SInputText .input').setValue('ok')
-
-    expect((wrapper.emitted('input') as any)[0][0]).toBe('ok')
+  beforeEach(() => {
+    createWrapper = options => mount(SInputText, options)
   })
 
-  it('emits `blur` event when a user blur from the input', () => {
-    const wrapper = mount(SInputText)
+  it('should emit value on input', () => {
+    const wrapper = createWrapper()
+
+    wrapper.find('.SInputText .input').setValue('ok')
+    expect(wrapper.emitted('input')).toHaveEmittedWith('ok')
+  })
+
+  it('should emit value when losing focus', () => {
+    const wrapper = createWrapper()
 
     const input = wrapper.find('.SInputText .input')
 
     input.setValue('ok')
     input.trigger('blur')
 
-    expect((wrapper.emitted('blur') as any)[0][0]).toBe('ok')
+    expect(wrapper.emitted('blur')).toHaveEmittedWith('ok')
   })
 
-  it('"touches" the validation on blur event', () => {
+  it('should invoke validation when losing focus', () => {
     const { data, validation } = useForm({
       data: { name: '' },
       rules: { name: [] }
     })
 
-    const wrapper = mount(SInputText, {
-      propsData: { value: data.name, validation }
+    const wrapper = createWrapper({
+      propsData: {
+        value: data.name,
+        validation
+      }
     })
 
     const input = wrapper.find('.SInputText .input')
@@ -41,19 +51,19 @@ describe('components/SInputText', () => {
     expect(validation.name.$isDirty.value).toBe(true)
   })
 
-  it('emits `enter` event when a user key down enter', () => {
-    const wrapper = mount(SInputText)
+  it('should emit value on `enter` keypress', () => {
+    const wrapper = createWrapper()
 
     const input = wrapper.find('.SInputText .input')
 
     input.setValue('ok')
     input.trigger('keypress.enter')
 
-    expect((wrapper.emitted('enter') as any)[0][0]).toBe('ok')
+    expect(wrapper.emitted('enter')).toHaveEmittedWith('ok')
   })
 
-  it('focus the input when the user clicks the icon', async () => {
-    const wrapper = mount(SInputText, {
+  it('should focus on icon click', async () => {
+    const wrapper = createWrapper({
       propsData: {
         icon: SIconSearch
       }
@@ -63,31 +73,29 @@ describe('components/SInputText', () => {
     const icon = wrapper.find('.SInputText .icon')
 
     await icon.trigger('click')
-
     expect(input.element === document.activeElement)
   })
 
-  it('sets correct padding styles when there is `text`', () => {
-    const wrapper = mount(SInputText, {
+  it('should apply correct padding on non-empty value', () => {
+    const wrapper = createWrapper({
       propsData: {
         text: 'a',
         textAfter: 'b'
       }
     })
 
-    expect((wrapper.vm as any).inputStyles.paddingRight).toBe('0px')
-    expect((wrapper.vm as any).inputStyles.paddingLeft).toBe('0px')
+    expect(wrapper.vm.inputStyles).toHaveProperty('paddingLeft', '0px')
+    expect(wrapper.vm.inputStyles).toHaveProperty('paddingRight', '0px')
   })
 
-  it('emits `clear` event when a user clicks the clear button', async () => {
-    const wrapper = mount(SInputText, {
+  it('should toggle `clear` button', async () => {
+    const wrapper = createWrapper({
       propsData: {
         clearable: true
       }
     })
 
     const clearButton = wrapper.find('.SInputText .clear')
-
     expect(clearButton.classes('show')).toBe(false)
 
     await wrapper.setProps({ value: null })
@@ -98,9 +106,17 @@ describe('components/SInputText', () => {
 
     await wrapper.setProps({ value: 'Hello' })
     expect(clearButton.classes('show')).toBe(true)
+  })
+
+  it('should emit when input is cleared', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        value: 'John Doe',
+        clearable: true
+      }
+    })
 
     wrapper.find('.SInputText .clear').trigger('click')
-
-    expect((wrapper.emitted('clear') as any)[0][0]).toBe(undefined)
+    expect(wrapper.emitted('clear')).toBeTruthy()
   })
 })

--- a/test/components/SInputTextarea.spec.ts
+++ b/test/components/SInputTextarea.spec.ts
@@ -1,23 +1,52 @@
 import { mount } from '@vue/test-utils'
 import SInputTextarea from 'sefirot/components/SInputTextarea.vue'
+import useForm from 'sefirot/compositions/useForm'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SInputTextarea>
+let createWrapper: CreateWrapperFn<Instance>
 
 describe('components/SInputTextarea', () => {
-  test('it emits `input` event when a user inputs the value', () => {
-    const wrapper = mount(SInputTextarea)
-
-    wrapper.find('.SInputTextarea .input').setValue('ok')
-
-    expect((wrapper.emitted('input') as any)[0][0]).toBe('ok')
+  beforeEach(() => {
+    createWrapper = options => mount(SInputTextarea, options)
   })
 
-  test('it emits `blur` event when a user blur from the input', () => {
-    const wrapper = mount(SInputTextarea)
+  it('should emit value on input', () => {
+    const wrapper = createWrapper()
 
-    const input = wrapper.find('.SInputTextarea .input') as any
+    wrapper.find('.SInputTextarea .input').setValue('ok')
+    expect(wrapper.emitted('input')).toHaveEmittedWith('ok')
+  })
 
-    input.element.value = 'ok'
+  it('should emit value when losing focus', () => {
+    const wrapper = createWrapper()
+
+    const input = wrapper.find('.SInputTextarea .input')
+
+    input.setValue('ok')
     input.trigger('blur')
 
-    expect((wrapper.emitted('blur') as any)[0][0]).toBe('ok')
+    expect(wrapper.emitted('blur')).toHaveEmittedWith('ok')
+  })
+
+  it('should invoke validation when losing focus', () => {
+    const { data, validation } = useForm({
+      data: { name: '' },
+      rules: { name: [] }
+    })
+
+    const wrapper = createWrapper({
+      propsData: {
+        value: data.name,
+        validation
+      }
+    })
+
+    const input = wrapper.find('.SInputTextarea .input')
+
+    input.setValue('ok')
+    input.trigger('blur')
+
+    expect(validation.name.$isDirty.value).toBe(true)
   })
 })

--- a/test/components/SPlaceholderImage.spec.ts
+++ b/test/components/SPlaceholderImage.spec.ts
@@ -1,11 +1,19 @@
 import { mount } from '@vue/test-utils'
 import SPlaceholderImage from 'sefirot/components/SPlaceholderImage.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SPlaceholderImage>
+let createWrapper: CreateWrapperFn<Instance>
 
 jest.useFakeTimers()
 
 describe('components/SPlaceholderImage', () => {
-  test('it emits `load` event when image is loaded', () => {
-    const wrapper = mount(SPlaceholderImage, {
+  beforeEach(() => {
+    createWrapper = options => mount(SPlaceholderImage, options)
+  })
+
+  it('should emit when image has loaded', () => {
+    const wrapper = createWrapper({
       propsData: {
         img: 'example.jpg',
         width: 100,
@@ -14,9 +22,8 @@ describe('components/SPlaceholderImage', () => {
     })
 
     wrapper.find('.SPlaceholderImage .img-src').trigger('load')
-
     jest.runAllTimers()
 
-    expect(wrapper.emitted('load')?.length).toBe(1)
+    expect(wrapper.emitted('load')).toBeTruthy()
   })
 })

--- a/test/components/SPortalModals.spec.ts
+++ b/test/components/SPortalModals.spec.ts
@@ -1,0 +1,59 @@
+import { shallowMount } from '@vue/test-utils'
+import VueRouter from 'vue-router'
+import Vuex from 'vuex'
+import PortalVue from 'portal-vue'
+import Sefirot from 'sefirot/store/Sefirot'
+import SPortalModals from 'sefirot/components/SPortalModals.vue'
+import { createVue, CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SPortalModals>
+let createWrapper: CreateWrapperFn<Instance>
+
+const { localVue } = createVue()
+  .use(Vuex)
+  .use(VueRouter)
+  .use(PortalVue)
+
+jest.useFakeTimers()
+
+Element.prototype.scrollTo = jest.fn()
+
+describe('components/SPortalModals', () => {
+  beforeEach(() => {
+    const router = new VueRouter()
+    const store = new Vuex.Store({ plugins: [Sefirot] })
+
+    createWrapper = options => shallowMount(SPortalModals, {
+      localVue,
+      router,
+      store,
+      ...options
+    })
+  })
+
+  it('should open and close modal', async () => {
+    const wrapper = createWrapper()
+
+    await wrapper.vm.$store.dispatch('modal/open', { name: 'modal' })
+    expect(wrapper.vm.show).toBe(true)
+
+    await wrapper.vm.$store.dispatch('modal/close')
+    jest.runAllTimers()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.show).toBe(false)
+  })
+
+  it('should close modal on route change', async () => {
+    const wrapper = createWrapper()
+
+    wrapper.vm.$store.dispatch('modal/open', { name: 'modal' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.show).toBe(true)
+
+    wrapper.vm.$router.push('/another-route')
+    await wrapper.vm.$nextTick()
+    jest.runAllTimers()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.show).toBe(false)
+  })
+})

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -1,0 +1,35 @@
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveEmittedWith(value: any): R
+    }
+  }
+}
+
+export function toHaveEmittedWith<T>(this: jest.MatcherUtils, actual: [any[]] | undefined, expected: T) {
+  let pass = false
+  let received = actual
+
+  if (Array.isArray(actual)) {
+    pass = this.equals(actual[0][0], expected)
+    received = actual[0][0]
+  }
+
+  if (pass) {
+    return {
+      pass: true,
+      message: () => `${this.utils.matcherHint('.not.toHaveEmittedWith')}
+
+Expected: not ${this.utils.printExpected(expected)}
+Received: ${this.utils.printReceived(received)}`
+    }
+  }
+
+  return {
+    pass: false,
+    message: () => `${this.utils.matcherHint('.toHaveEmittedWith')}
+
+Expected: ${this.utils.printExpected(expected)}
+Received: ${this.utils.printReceived(received)}`
+  }
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -2,7 +2,12 @@ import { config } from '@vue/test-utils'
 import Vue from 'vue'
 import VueCompositionApi from '@vue/composition-api'
 import ClientOnly from './_stubs/ClientOnly.vue'
+import * as matchers from './matchers'
 
 Vue.use(VueCompositionApi)
 
 config.stubs.ClientOnly = ClientOnly
+
+expect.extend({
+  ...matchers
+})

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,23 @@
+import Vue, { VueConstructor, PluginFunction, PluginObject } from 'vue'
+import { createLocalVue, Wrapper as VTUWrapper, MountOptions } from '@vue/test-utils'
+
+interface CreateVueContext {
+  localVue: VueConstructor<Vue>
+  use<T>(plugin: PluginObject<T> | PluginFunction<T>, options?: T): CreateVueContext
+}
+
+export type Wrapper<V extends Vue = Vue> = VTUWrapper<V & Record<string, any>>
+
+export type CreateWrapperFn<V extends Vue = Vue> = (options?: MountOptions<V>) => Wrapper<V>
+
+export function createVue(): CreateVueContext {
+  const localVue = createLocalVue()
+
+  return {
+    localVue,
+    use(plugin, options) {
+      localVue.use(plugin, options)
+      return this
+    }
+  }
+}

--- a/types/mutation-observer.d.ts
+++ b/types/mutation-observer.d.ts
@@ -1,4 +1,0 @@
-declare module 'mutation-observer' {
-  const MutationObserver: any
-  export default MutationObserver
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7892,11 +7892,6 @@ mustache@^2.3.0:
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
   integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
 
-mutation-observer@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/mutation-observer/-/mutation-observer-1.0.3.tgz#42e9222b101bca82e5ba9d5a7acf4a14c0f263d0"
-  integrity sha512-M/O/4rF2h776hV7qGMZUH3utZLO/jK7p8rnNgGkjKUw8zCGjRQPxB8z6+5l8+VjRUQ3dNYu4vjqXYLr+U8ZVNA==
-
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"


### PR DESCRIPTION
This PR addresses the following:
* improves typescript support
* improves coverage for existing specs
* revises test descriptions & scopes to spec
* adds `toHaveEmittedWith` matcher for component emit readings
* adds the following specs:
  * `dropdown`
  * `input-switch`
  * `input-switches`
  * `portal-modals`
* removes `mutation-observer` dependency

### createVue vs createLocalVue
`createVue` reduces test noise, is chainable, is scalable, and improves DX.

### createWrapper vs mount/shallowMount
`createWrapper` gives specs the ability to manufacture and execute repetitive mounting tasks with pre-emptive configuration and option handling. It also infers the component in question to suppress the copious amount of type assertions required to read Vue instances (although the vue-shim ruins that in VCA for Vue 2, still, `<any>` is a last resort).