### PR TITLE
feat: add 'step' props to input number

### DIFF
--- a/docs/pages/components/inputs-number/index.vue
+++ b/docs/pages/components/inputs-number/index.vue
@@ -102,6 +102,13 @@ export default defineComponent({
         description: 'Add the trailing text to the input.'
       },
       {
+        name: 'step',
+        type: 'number',
+        required: false,
+        default: '1',
+        description: 'A stepping interval to use when using up and down arrows to adjust the value.'
+      },
+      {
         name: 'help-format',
         type: 'boolean',
         required: false,

--- a/lib/components/SInputNumber.vue
+++ b/lib/components/SInputNumber.vue
@@ -11,6 +11,7 @@
     :placeholder="placeholder"
     :text="text"
     :text-after="textAfter"
+    :step="step"
     :validation="validation"
     :value="value"
     @input="emitInput"
@@ -46,6 +47,7 @@ export default defineComponent({
     placeholder: { type: String, default: null },
     text: { type: String, default: null },
     textAfter: { type: String, default: null },
+    step: { type: Number, default: 1 },
     helpFormat: { type: Boolean, default: false },
     value: { type: Number, default: null },
     validation: { type: Object as PropType<Validation>, default: null }

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -32,6 +32,7 @@
           :class="{ 'has-icon': icon, 'is-clearable': clearable }"
           :style="inputStyles"
           :type="type"
+          :step="step"
           :placeholder="placeholder"
           :value="value"
           @input="emitInput"
@@ -111,6 +112,7 @@ export default defineComponent({
     icon: { type: Object, default: null },
     text: { type: String, default: null },
     textAfter: { type: String, default: null },
+    step: { type: Number, default: 1 },
     clearable: { type: Boolean, default: false },
     value: { type: [String, Number], default: null },
     validation: { type: Object as PropType<Validation>, default: null }


### PR DESCRIPTION
## Proposal
Add `step` props to `SInputNumber` .
This is usable to input a decimal value.

If input decimal value without decimal step attribute,
waring message is shown.
![image](https://user-images.githubusercontent.com/62658104/112447594-d8fbf800-8d94-11eb-9582-4235fdfcfb2a.png)
