### PR TITLE
feat(validation): implement includeSome

### DIFF
--- a/lib/validation/rules/includeSome.ts
+++ b/lib/validation/rules/includeSome.ts
@@ -1,0 +1,11 @@
+import { includeSome as baseIncludeSome } from '../validators'
+import { Rule } from './'
+
+export default function required(other: string, message?: string): Rule {
+  return {
+    name: 'includeSome',
+    message: message ?? `The value must include some of ${other}.`,
+    optional: true,
+    validate: (value, data) => baseIncludeSome(value, data[other])
+  }
+}

--- a/lib/validation/rules/index.ts
+++ b/lib/validation/rules/index.ts
@@ -2,6 +2,7 @@ import { isString } from '../../support/Util'
 import day from './day'
 import email from './email'
 import include from './include'
+import includeSome from './includeSome'
 import maxLength from './maxLength'
 import maxValue from './maxValue'
 import month from './month'
@@ -32,6 +33,7 @@ export {
   day,
   email,
   include,
+  includeSome,
   maxLength,
   maxValue,
   month,

--- a/lib/validation/validators/includeSome.ts
+++ b/lib/validation/validators/includeSome.ts
@@ -1,0 +1,5 @@
+import { isEqual } from '../../support/Util'
+
+export default function includeSome(value: any[], other: any[]): boolean {
+  return value.some(v => other.some(o => isEqual(v, o)))
+}

--- a/lib/validation/validators/index.ts
+++ b/lib/validation/validators/index.ts
@@ -1,6 +1,7 @@
 import day from './day'
 import email from './email'
 import include from './include'
+import includeSome from './includeSome'
 import maxLength from './maxLength'
 import maxValue from './maxValue'
 import month from './month'
@@ -14,6 +15,7 @@ export {
   day,
   email,
   include,
+  includeSome,
   maxLength,
   maxValue,
   month,

--- a/test/validation/validators/includeSome.spec.ts
+++ b/test/validation/validators/includeSome.spec.ts
@@ -1,0 +1,20 @@
+import { includeSome } from 'sefirot/validation/validators'
+
+type Check = [any[], any[], boolean]
+
+describe('validation/validators/includeSome', () => {
+  test('it validates if the value includes the some of given another value', () => {
+    const checks: Check[] = [
+      [['abc'], ['abc', 'bcd'], true],
+      [['0'], [0, 2], false],
+      [[1, 2, 3], [2, 3], true],
+      [[1, 2, 3], [4, 5, 6], false],
+      [[{ id: 1 }], [{ id: 1 }, { id: 2 }], true],
+      [[{ id: 1 }], [{ id: 2 }, { id: 4 }], false]
+    ]
+
+    checks.forEach((check) => {
+      expect(includeSome(check[0], check[1])).toBe(check[2])
+    })
+  })
+})


### PR DESCRIPTION
## Proposal
Implement `includeSome` validator which is like `include`.
The difference is this validator can receive array as `other` argument,
and return true if `value` includes one or more of given another value.