### PR TITLE
feat: narrow form validation type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,9 +3,11 @@ module.exports = {
     '@nuxtjs/eslint-config-typescript'
   ],
   rules: {
+    '@typescript-eslint/no-redeclare': ['error'],
     'import/named': 'off',
     'no-use-before-define': 'off',
     'no-unreachable-loop': 'off',
+    'no-redeclare': 'off',
     'space-before-function-paren': [
       'error',
       {
@@ -14,8 +16,6 @@ module.exports = {
         asyncArrow: 'always'
       }
     ],
-    'no-redeclare': 'off',
-    '@typescript-eslint/no-redeclare': ['error'],
     'vue/component-tags-order': 'off',
     'vue/max-attributes-per-line': 'off',
     'vue/no-v-html': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,8 @@ module.exports = {
         asyncArrow: 'always'
       }
     ],
+    'no-redeclare': 'off',
+    '@typescript-eslint/no-redeclare': ['error'],
     'vue/component-tags-order': 'off',
     'vue/max-attributes-per-line': 'off',
     'vue/no-v-html': 'off',

--- a/lib/composables/Form.ts
+++ b/lib/composables/Form.ts
@@ -21,7 +21,7 @@ export type UpdateFunction<T extends Record<string, any> = Record<string, any>> 
   value: any
 ) => void
 
-export type FormValidation<T, U extends Form<T> = Form<T>> = WithRequired<U, 'validation'>
+export type FormWithValidation<T, U extends Form<T> = Form<T>> = WithRequired<U, 'validation'>
 
 export type UseFormOptionsWithRules<T, U extends UseFormOptions<T> = UseFormOptions<T>> = WithRequired<U, 'rules'>
 
@@ -29,7 +29,7 @@ type Data<T> = UnwrapRef<T>
 
 export function useForm<T extends Record<string, any>>(
   options: UseFormOptionsWithRules<T>
-): FormValidation<T>
+): FormWithValidation<T>
 
 export function useForm<T extends Record<string, any>>(
   options: UseFormOptions<T>
@@ -37,7 +37,7 @@ export function useForm<T extends Record<string, any>>(
 
 export function useForm<T extends Record<string, any>>(
   options: UseFormOptions<T> | UseFormOptionsWithRules<T>
-): Form<T> | FormValidation<T> {
+): Form<T> | FormWithValidation<T> {
   const initialData = getData(options.data)
   const rules = options.rules
 

--- a/lib/composables/Form.ts
+++ b/lib/composables/Form.ts
@@ -1,4 +1,5 @@
 import { UnwrapRef, reactive } from '@vue/composition-api'
+import { WithRequired } from '../types/Utils'
 import { Validation, Rules, useFormValidation } from './FormValidation'
 
 export * from './FormValidation'
@@ -10,18 +11,33 @@ export interface Form<T extends Record<string, any>> {
   update: UpdateFunction<T>
 }
 
-export type Data<T extends Record<string, any>> = UnwrapRef<T>
-
-export type UpdateFunction<
-  T extends Record<string, any>
-> = (model: keyof Data<T>, value: any) => void
-
-export interface UseFormOptions<T extends Record<string, any>> {
+export interface UseFormOptions<T> {
   data: T | (() => T)
   rules?: Rules
 }
 
-export function useForm<T extends Record<string, any>>(options: UseFormOptions<T>): Form<T> {
+export type UpdateFunction<T extends Record<string, any> = Record<string, any>> = (
+  model: keyof Data<T>,
+  value: any
+) => void
+
+export type FormValidation<T, U extends Form<T> = Form<T>> = WithRequired<U, 'validation'>
+
+export type UseFormOptionsWithRules<T, U extends UseFormOptions<T> = UseFormOptions<T>> = WithRequired<U, 'rules'>
+
+type Data<T> = UnwrapRef<T>
+
+export function useForm<T extends Record<string, any>>(
+  options: UseFormOptionsWithRules<T>
+): FormValidation<T>
+
+export function useForm<T extends Record<string, any>>(
+  options: UseFormOptions<T>
+): Form<T>
+
+export function useForm<T extends Record<string, any>>(
+  options: UseFormOptions<T> | UseFormOptionsWithRules<T>
+): Form<T> | FormValidation<T> {
   const initialData = getData(options.data)
   const rules = options.rules
 

--- a/lib/types/Utils.ts
+++ b/lib/types/Utils.ts
@@ -2,6 +2,9 @@ export type Values<T> = T[keyof T]
 
 export type OmitType<T> = Omit<T, 'type'>
 
+export type WithRequired<T, K extends keyof T> = Exclude<T, K> & Required<Pick<T, K>>
+export type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+
 export type SyntheticEvent<E extends Event, T extends Element> = E & { target: T }
 export type SyntheticInputEvent<T extends Element = HTMLInputElement> = SyntheticEvent<InputEvent, T>
 export type SyntheticMouseEvent<T extends Element = HTMLElement> = SyntheticEvent<MouseEvent, T>


### PR DESCRIPTION
Intersects the form validation property as a required key when using rules.

![useForm](https://user-images.githubusercontent.com/1493221/114118239-6173b000-98e0-11eb-8b27-606cefafad84.gif)
