### PR TITLE
feat: markdown component

### DIFF
--- a/lib/components/SMarkdown.vue
+++ b/lib/components/SMarkdown.vue
@@ -1,0 +1,38 @@
+<template>
+  <component :is="tag" v-if="$scopedSlots.default" class="SMarkdown-container">
+    <slot v-bind="{ rendered, selector }" />
+  </component>
+  <component :is="tag" v-else :class="['SMarkdown-container', selector]" v-html="rendered" />
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, nextTick, PropType, watch } from '@vue/composition-api'
+import { useMarkdown, useLink, LinkEvent } from '../composables/Markdown'
+
+export default defineComponent({
+  props: {
+    content: { type: String, required: true },
+    callbacks: { type: Array as PropType<LinkEvent[]>, default: () => [] },
+    inline: { type: Boolean, default: false },
+    tag: { type: String, default: 'div' }
+  },
+
+  setup(props) {
+    const markdown = useMarkdown()
+    const { selector, addListeners } = useLink({ callbacks: props.callbacks })
+
+    const rendered = computed(() => markdown(props.content, props.inline))
+
+    watch(
+      rendered,
+      () => nextTick(() => addListeners()),
+      { immediate: true }
+    )
+
+    return {
+      selector,
+      rendered
+    }
+  }
+})
+</script>

--- a/lib/components/SMarkdown.vue
+++ b/lib/components/SMarkdown.vue
@@ -17,9 +17,9 @@ export default defineComponent({
     tag: { type: String, default: 'div' }
   },
 
-  setup(props) {
+  setup(props, { emit }) {
     const markdown = useMarkdown()
-    const { selector, addListeners } = useLink({ callbacks: props.callbacks })
+    const { selector, addListeners, subscribe } = useLink({ callbacks: props.callbacks })
 
     const rendered = computed(() => markdown(props.content, props.inline))
 
@@ -28,6 +28,8 @@ export default defineComponent({
       () => nextTick(() => addListeners()),
       { immediate: true }
     )
+
+    subscribe(payload => emit('clicked', payload))
 
     return {
       selector,

--- a/lib/components/SMarkdown.vue
+++ b/lib/components/SMarkdown.vue
@@ -7,12 +7,12 @@
 
 <script lang="ts">
 import { computed, defineComponent, nextTick, PropType, watch } from '@vue/composition-api'
-import { useMarkdown, useLink, LinkEvent } from '../composables/Markdown'
+import { useMarkdown, useLink, LinkCallback } from '../composables/Markdown'
 
 export default defineComponent({
   props: {
     content: { type: String, required: true },
-    callbacks: { type: Array as PropType<LinkEvent[]>, default: () => [] },
+    callbacks: { type: Array as PropType<LinkCallback[]>, default: () => [] },
     inline: { type: Boolean, default: false },
     tag: { type: String, default: 'div' }
   },

--- a/lib/composables/Markdown.ts
+++ b/lib/composables/Markdown.ts
@@ -39,7 +39,7 @@ export interface UseLink {
 }
 
 export interface UseLinkOptions {
-  callbacks?: LinkEvent[]
+  callbacks?: LinkCallback[]
 }
 
 export interface LinkSubscriberPayload {
@@ -51,7 +51,7 @@ export interface LinkSubscriberPayload {
 
 export type LinkSubscriber = (payload: LinkSubscriberPayload) => void
 
-export type LinkEvent = () => void
+export type LinkCallback = () => void
 
 export function useLink(options: UseLinkOptions): UseLink {
   const router = useRouter()

--- a/lib/composables/Markdown.ts
+++ b/lib/composables/Markdown.ts
@@ -1,5 +1,5 @@
-import { onUnmounted } from '@vue/composition-api'
 import MarkdownIt from 'markdown-it'
+import { onUnmounted } from '@vue/composition-api'
 import { isCallbackUrl, isExternalUrl, LinkAttrs, linkPlugin } from './markdown/LinkPlugin'
 import { useRouter } from './Router'
 
@@ -109,7 +109,7 @@ export function useLink(options: UseLinkOptions): UseLink {
     const elements = document.querySelectorAll(querySelector)
 
     elements.forEach((element) => {
-      element.addEventListener('click', handler, false)
+      element.addEventListener('click', handler)
     })
   }
 
@@ -117,7 +117,7 @@ export function useLink(options: UseLinkOptions): UseLink {
     const elements = document.querySelectorAll(querySelector)
 
     elements.forEach((element) => {
-      element.removeEventListener('click', handler, false)
+      element.removeEventListener('click', handler)
     })
   }
 

--- a/lib/composables/Markdown.ts
+++ b/lib/composables/Markdown.ts
@@ -1,0 +1,147 @@
+import { onUnmounted } from '@vue/composition-api'
+import MarkdownIt from 'markdown-it'
+import { isCallbackUrl, isExternalUrl, LinkAttrs, linkPlugin } from './markdown/LinkPlugin'
+import { useRouter } from './Router'
+
+export type UseMarkdown = (source: string, inline: boolean) => string
+
+export interface UseMarkdownOptions extends MarkdownIt.Options {
+  linkAttrs?: LinkAttrs
+  config?: (md: MarkdownIt) => void
+}
+
+export function useMarkdown(options: UseMarkdownOptions = {}): UseMarkdown {
+  const md = new MarkdownIt({
+    linkify: true,
+    ...options
+  })
+
+  md.use(linkPlugin, {
+    target: '_blank',
+    rel: 'noopener noreferrer',
+    ...options.linkAttrs
+  })
+
+  if (options.config) {
+    options.config(md)
+  }
+
+  return (source, inline) => {
+    return inline ? md.renderInline(source) : md.render(source)
+  }
+}
+
+export interface UseLink {
+  selector: string
+  addListeners(): void
+  removeListeners(): void
+  subscribe(cb: LinkSubscriber): () => void
+}
+
+export interface UseLinkOptions {
+  callbacks?: LinkEvent[]
+}
+
+export interface LinkSubscriberPayload {
+  event: Event
+  target: HTMLAnchorElement
+  isExternal: boolean
+  isCallback: boolean
+}
+
+export type LinkSubscriber = (payload: LinkSubscriberPayload) => void
+
+export type LinkEvent = () => void
+
+export function useLink(options: UseLinkOptions): UseLink {
+  const router = useRouter()
+
+  const subscribers: LinkSubscriber[] = []
+  const selector = buildSelector()
+  const querySelector = `.${selector} a.SMarkdown-link`
+
+  onUnmounted(() => removeListeners())
+
+  function handler(event: Event): void {
+    const target = event.target as HTMLAnchorElement
+    const href = target.getAttribute('href')!
+
+    if (!href) {
+      return
+    }
+
+    const isExternal = isExternalUrl(href)
+    const isCallback = isCallbackUrl(href)
+
+    subscribers.forEach(sub => sub({
+      event,
+      target,
+      isExternal,
+      isCallback
+    }))
+
+    if (isExternal) {
+      return
+    }
+
+    if (!event.defaultPrevented) {
+      event.preventDefault()
+    }
+
+    if (isCallback) {
+      const idx = parseInt(target.dataset.callbackId || '')
+      const callbacks = options.callbacks || (options.callbacks = [])
+      const callback = callbacks[idx]
+
+      if (!callback) {
+        throw new Error(`Callback not found at index: ${idx}`)
+      }
+
+      return callback()
+    }
+
+    router.push(href)
+  }
+
+  function addListeners(): void {
+    removeListeners()
+
+    const elements = document.querySelectorAll(querySelector)
+
+    elements.forEach((element) => {
+      element.addEventListener('click', handler, false)
+    })
+  }
+
+  function removeListeners(): void {
+    const elements = document.querySelectorAll(querySelector)
+
+    elements.forEach((element) => {
+      element.removeEventListener('click', handler, false)
+    })
+  }
+
+  function subscribe(fn: LinkSubscriber): () => void {
+    subscribers.push(fn)
+
+    return () => {
+      const idx = subscribers.indexOf(fn)
+      idx > -1 && subscribers.splice(idx, 1)
+    }
+  }
+
+  return {
+    selector,
+    addListeners,
+    removeListeners,
+    subscribe
+  }
+}
+
+function buildSelector(): string {
+  const uuid = [...Array(8)].map(() => {
+    return (Math.random() * 36 | 0).toString(36)
+  }).join('')
+
+  return `SMarkdown-${uuid}`
+}

--- a/lib/composables/markdown/LinkPlugin.ts
+++ b/lib/composables/markdown/LinkPlugin.ts
@@ -1,0 +1,45 @@
+import MarkdownIt from 'markdown-it'
+
+export type LinkAttrs = Record<string, string>
+
+const EXTERNAL_REGEX = /^https?:/
+const CALLBACK_REGEX = /\{([\d}]+)\}/
+const CALLBACK_HREF = '#callback'
+
+export function linkPlugin(md: MarkdownIt, linkAttrs: LinkAttrs = {}): void {
+  md.renderer.rules.link_open = (tokens, idx, options, _env, self) => {
+    const token = tokens[idx]
+    const hrefIndex = token.attrIndex('href')
+
+    if (hrefIndex >= 0) {
+      const hrefAttr = token.attrs![hrefIndex]
+      const url = decodeURIComponent(hrefAttr[1])
+
+      if (isExternalUrl(url)) {
+        Object.entries(linkAttrs).forEach(([key, val]) => {
+          token.attrSet(key, val)
+        })
+      }
+
+      if (isCallbackUrl(url)) {
+        const matched = url.match(CALLBACK_REGEX)![1]
+
+        token.attrSet('data-callback-id', matched)
+
+        hrefAttr[1] = CALLBACK_HREF
+      }
+
+      token.attrSet('class', 'SMarkdown-link')
+    }
+
+    return self.renderToken(tokens, idx, options)
+  }
+}
+
+export function isExternalUrl(url: string): boolean {
+  return EXTERNAL_REGEX.test(url)
+}
+
+export function isCallbackUrl(url: string): boolean {
+  return url === CALLBACK_HREF || CALLBACK_REGEX.test(decodeURIComponent(url))
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "jest-serializer-vue": "^2.0.2",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
+    "markdown-it": "^12.0.4",
     "normalize.css": "^8.0.1",
     "nuxt": "^2.15.4",
     "portal-vue": "^2.1.7",

--- a/test/components/SMarkdown.spec.ts
+++ b/test/components/SMarkdown.spec.ts
@@ -1,0 +1,74 @@
+import { shallowMount } from '@vue/test-utils'
+import SMarkdown from 'sefirot/components/SMarkdown.vue'
+import { CreateWrapperFn } from '../utils'
+
+type Instance = InstanceType<typeof SMarkdown>
+let createWrapper: CreateWrapperFn<Instance>
+
+describe('components/SMarkdown', () => {
+  beforeEach(() => {
+    createWrapper = options => shallowMount(SMarkdown, options)
+  })
+
+  it('should render content', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        content: '**text**'
+      }
+    })
+
+    const content = wrapper.find('.SMarkdown-container > p > strong')
+    expect(content.text()).toBe('text')
+  })
+
+  it('should render inline content', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        content: '**text**',
+        inline: true
+      }
+    })
+
+    const content = wrapper.find('.SMarkdown-container > strong')
+    expect(content.text()).toBe('text')
+  })
+
+  it('should render component tag', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        tag: 'span',
+        content: '**text**',
+        inline: true
+      }
+    })
+
+    const container = wrapper.find('.SMarkdown-container')
+    expect(container.element.nodeName.toLowerCase()).toEqual('span')
+  })
+
+  it('should render external link', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        content: '[Sefirot](https://sefirot.globalbrains.com)'
+      }
+    })
+
+    const attrs = expect.objectContaining({
+      target: '_blank',
+      rel: 'noopener noreferrer'
+    })
+    expect(wrapper.find('.SMarkdown-container .SMarkdown-link').attributes()).toEqual(attrs)
+  })
+
+  it('should render callbacks', () => {
+    const wrapper = createWrapper({
+      propsData: {
+        content: '[text]({0}) [text]({1})'
+      }
+    })
+
+    const links = wrapper.findAll('.SMarkdown-container .SMarkdown-link')
+    expect(links.at(0).attributes('data-callback-id')).toBe('0')
+    expect(links.at(1).attributes('data-callback-id')).toBe('1')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,6 +2580,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 argv@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
@@ -4743,6 +4748,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.8"
@@ -7324,6 +7334,13 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
+linkify-it@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
+  integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -7604,6 +7621,17 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+markdown-it@^12.0.4:
+  version "12.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.0.4.tgz#eec8247d296327eac3ba9746bdeec9cfcc751e33"
+  integrity sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~2.1.0"
+    linkify-it "^3.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
 
 markdown-it@^8.3.1:
   version "8.4.2"


### PR DESCRIPTION
## Overview

This PR introduces a standalone component to support markdown rendering. The component requires and implements [markdown-it](https://github.com/markdown-it/markdown-it) as it's choice of renderer. The component can be immersed within existing components as well as externals. The composition is designed to work flexibly to allow custom implementations if necessary.

Basic example:
```vue
<SMarkdown content="Hello **world**" />

<div class="SMarkdown-container">
  <p>Hello <strong>world</strong></p>
</div>
```

## Props

| Prop | Type | Default | Description
| --- | :---: | :---: | --- |
| `content` | String | – | **Required** - the raw markdown string. 
| `inline` | Boolean | `false` | Renders content without wrapping in `<p>` tags.
| `tag` | String | `'div'` | Renders a custom root element. Useful when combined with `inline`.
| `callbacks` | Array | `[]` | A list of callbacks for custom links. Callbacks are referenced in markdown links by their index within curly braces. References can be repeated as many times e.g. `[link1]({0}) [link2]({1}) [link3]({0})`. Undefined or out-of-range references will throw.

## Slots

By way of simplicity, the component will render markdown using the `v-html` directive. This means component children will be replaced by the rendered HTML. Subsequently, the component exposes some slot props to help customize the component and its dependents. This allows for greater flexibility for nested components.

```vue
<SMarkdown v-slot="{ rendered, selector }" v-bind="{ content, inline, callbacks }">
  <SCard>
    <SIconCode />
    <p :class="selector" v-html="rendered" />
  </SCard>
</SMarkdown>
```

### Slot Props

| Prop | Type | Description
| --- | :---: | --- |
| `selector` | String | The class name that should be applied to a wrapping element of the rendered html. This is necessary to prevent event listener pollution in the DOM and avoids any side-effects where listeners may hijack anchors they are not supposed to.
| `rendered` | String | The rendered markdown markup. To be used with the `v-html` directive.

## Events

#### `clicked`

Emitted when a link is clicked. Allows for arbitrary code execution in components to extend functionality.

```vue
<SMarkdown content="[link](/route)" @clicked="(payload) => console.log(payload)" />
```

See the `useLink` subscribe example below for info on payload types.

## Composition

There are two composition functions exposing APIs which are used by the component and can also be freely used to compose custom components. In addition, the compositions possess additional API functionality for more bespoke handling.

### `useMarkdown`

Options: `{ linkAttrs?: LinkAttrs; config?: (md: MarkdownIt) => void }`
Returns: `(source: string, inline: boolean) => string`

Instantiate and (optionally) configure the markdown renderer. The `markdown-it` instance can be manipulated further by passing a config callback to the initiator:

```ts
// configure renderer
useMarkdown({
  config: (md) => {
    md.use(somePlugin)
      .set({ breaks: true })
  }
})
```

Returns a factory method that, when invoked, will render the given source (markdown string). The second argument, default `false`, renders the source as inline.

### `useLink`

Options: `{ callbacks?: LinkEvent[] }`
Returns: `{ selector: string; addListeners: Function; removeListeners: Function; subscribe: Function }`

Exposes an API to aid event listening for rendered links. The internal handler does nothing if 1) there is no `href` present in a link, and 2) if it's an external link. If a callback link is triggered, it will invoke the respective callback, and will throw if one is not found. Otherwise, the router will handle the result.

The `selector` is a computed string with a UUID suffix to distinguish between multiple DOM elements (e.g. `SMarkdown-ah42wenv`).

The `addListeners` and `removeListeners` bind/unbind the necessary event listeners to links within containment. Listeners are removed automatically when a component is destroyed but the method is exposed for flexibility.

The `subscribe` method allows for arbitrary subscription to events. All subscriptions receive a payload and are executed before the internal handler decides what to do. This offers code execution that is decoupled from the standard handler behaviour.

```ts
const { subscribe } = useLink({ ... })

subscribe(({ event, target, isExternal, isCallback }) => {
  console.log(event.type) // 'click'
  console.log(target)     // HTMLAnchorElement
  console.log(isExternal) // boolean
  console.log(isCallback) // boolean
})
```

## Progress
- [x] Component
- [x] Composition
- [x] Spec
- [ ] Documentation