### PR TITLE
docs(button): simplify & clear button docs

### DIFF
--- a/docs/components/buttons/StoryButtonEXBlock.vue
+++ b/docs/components/buttons/StoryButtonEXBlock.vue
@@ -1,5 +1,5 @@
 <template lang="md">
-<StoryBase title="Medium Buttons">
+<StoryBase>
   <div class="list">
     <div class="item">
       <SButton label="PRIMARY" block />

--- a/docs/components/buttons/StoryButtonEXIcon.vue
+++ b/docs/components/buttons/StoryButtonEXIcon.vue
@@ -1,5 +1,5 @@
 <template lang="md">
-<StoryBase title="With Icon">
+<StoryBase>
   <div class="list">
     <div class="item">
       <SButton :icon="SIconImage" />

--- a/docs/components/buttons/StoryButtonEXLoadingState.vue
+++ b/docs/components/buttons/StoryButtonEXLoadingState.vue
@@ -1,5 +1,5 @@
 <template lang="md">
-<StoryBase title="Loading State">
+<StoryBase>
   <div class="list">
     <div class="item">
       <SButton label="START LOAD" :loading="state.load1" @click="load('load1')" />
@@ -61,7 +61,7 @@ export default defineComponent({
     function load(target: keyof typeof state): void {
       state[target] = true
 
-      setTimeout(() => { state[target] = false }, 5000)
+      setTimeout(() => (state[target] = false), 3000)
     }
 
     return {
@@ -109,7 +109,7 @@ export default defineComponent({
     function load(target: keyof typeof state): void {
       state[target] = true
 
-      setTimeout(() => { state[target] = false }, 5000)
+      setTimeout(() => (state[target] = false), 3000)
     }
 
     return {

--- a/docs/components/buttons/StoryButtonEXModes.vue
+++ b/docs/components/buttons/StoryButtonEXModes.vue
@@ -1,5 +1,5 @@
 <template lang="md">
-<StoryBase title="Button Modes">
+<StoryBase>
   <div class="list">
     <div class="item">
       <SButton label="NEUTRAL" mode="neutral" />

--- a/docs/components/buttons/StoryButtonEXRounded.vue
+++ b/docs/components/buttons/StoryButtonEXRounded.vue
@@ -1,5 +1,5 @@
 <template lang="md">
-<StoryBase title="Rounded Button">
+<StoryBase>
   <div class="list">
     <div class="item">
       <SButton label="PRIMARY" rounded />

--- a/docs/pages/components/buttons/index.vue
+++ b/docs/pages/components/buttons/index.vue
@@ -92,49 +92,49 @@ export default defineComponent({
       props: [
         {
           name: 'label',
-          type: 'String',
+          type: 'string',
           required: false,
           default: 'null',
           description: 'The label text for the button.'
         },
         {
           name: 'tag',
-          type: 'String',
+          type: 'string',
           required: false,
           default: "'button'",
           description: 'The tag for the button. It can be any valid HTML tag including `router-link` and `nuxt-link`.'
         },
         {
           name: 'to',
-          type: 'String',
+          type: 'string',
           required: false,
           default: "'/'",
           description: 'The `to` prop for the `nuxt-link` tag. This prop is only useful when `tag` is set to `nuxt-link`.'
         },
         {
           name: 'type',
-          type: 'String',
+          type: "'primary' | 'secondary' | 'tertiary' | 'text' | 'mute'",
           required: false,
           default: "'primary'",
-          description: "The type variant of the button. Available types are: `'primary'`, `'secondary'`, `'tertiary'`, `'text'`, and `'mute'`."
+          description: 'The type variant of the button.'
         },
         {
           name: 'mode',
-          type: 'String',
+          type: "'neutral' | 'info' | 'success' | 'warning' | 'danger'",
           required: false,
           default: "'neutral'",
-          description: "The mode variant of the button. Available modes are: `'neutral'`, `'info'`, `'success'`, `'warning'`, and `'danger'`."
+          description: 'The mode variant of the button.'
         },
         {
           name: 'size',
-          type: 'String',
+          type: "'mini' | 'small' | 'medium' | 'large' | 'jumbo'",
           required: false,
           default: "'medium'",
-          description: "The size variant for the button. Available sizes are: `'mini'`, `'small'`, `'medium'`, `'large'`, and `'jumbo'`"
+          description: 'The size variant for the button.'
         },
         {
           name: 'rounded',
-          type: 'Boolean',
+          type: 'boolean',
           required: false,
           default: 'false',
           description: 'Applies a border radius to the button.'
@@ -148,21 +148,21 @@ export default defineComponent({
         },
         {
           name: 'block',
-          type: 'Boolean',
+          type: 'boolean',
           required: false,
           default: 'false',
           description: 'Applies `display: block` to the button.'
         },
         {
           name: 'inverse',
-          type: 'Boolean',
+          type: 'boolean',
           required: false,
           default: 'false',
           description: 'Inverse the button theme.'
         },
         {
           name: 'loading',
-          type: 'Boolean',
+          type: 'boolean',
           required: false,
           default: 'false',
           description: 'Display the loading indicator.'

--- a/docs/pages/components/buttons/index.vue
+++ b/docs/pages/components/buttons/index.vue
@@ -7,7 +7,7 @@ Buttons allow users to take actions, and make choices, with a single tap.
 
 ## Sizes
 
-Button has many sizes, `mini`, `small`, `medium`, `large`, and `jumbo`. You can control the sizes through `size` prop. The default size is `medium`.
+Buttons can appear in many different sizes. By default, buttons will be medium sized.
 
 <StoryButtonEXMini />
 <StoryButtonEXSmall />
@@ -15,31 +15,33 @@ Button has many sizes, `mini`, `small`, `medium`, `large`, and `jumbo`. You can 
 <StoryButtonEXLarge />
 <StoryButtonEXJumbo />
 
-## Rounded Corner
+## Rounded
 
-By setting `rounded` prop to `true`, you'll get the rounded button.
+Change the appearance of a button with rounded corners.
 
 <StoryButtonEXRounded />
 
 ## Modes
 
-The button comes with various colors, and you can control it through `mode` prop. Available values are `neutral`, `info`, `success`, `warning`, and `danger`.
+Control the color theme of a button.
 
 <StoryButtonEXModes />
 
-## Block Size
+## Block
 
-By default, buttons are displayed as `inline-block`. By passing a `block` prop, the button becomes a block-level element. Useful for controlling button sizes.
+By default, buttons will display as `inline-block`. The `block` prop transforms a button to a block-level element.
 
 <StoryButtonEXBlock />
 
-## With Icon
+## Icon
 
-You can also prepend icon by passing in Vue Component to the `icon` prop. The button can also be an icon-only button.
+Prepend a button with an icon or use the icon as its only content by omitting `label`.
 
 <StoryButtonEXIcon />
 
 ## Loading State
+
+Display a loading indicator. The indicator icon will auto-adjust its contrast depending on the `mode`, `type` and `inverse` props.
 
 <StoryButtonEXLoadingState />
 
@@ -90,80 +92,87 @@ export default defineComponent({
       props: [
         {
           name: 'label',
-          type: 'string',
+          type: 'String',
           required: false,
           default: 'null',
           description: 'The label text for the button.'
         },
         {
           name: 'tag',
-          type: 'string',
+          type: 'String',
           required: false,
-          default: '\'button\'',
-          description: 'The tag for the button. It can be any valid html tag including `nuxt-link`.'
+          default: "'button'",
+          description: 'The tag for the button. It can be any valid HTML tag including `router-link` and `nuxt-link`.'
         },
         {
           name: 'to',
-          type: 'string',
+          type: 'String',
           required: false,
-          default: '\'/\'',
+          default: "'/'",
           description: 'The `to` prop for the `nuxt-link` tag. This prop is only useful when `tag` is set to `nuxt-link`.'
         },
         {
           name: 'type',
-          type: 'string',
+          type: 'String',
           required: false,
-          default: '\'primary\'',
-          description: 'The type of the button. Available types are: `primary`, `secondary`, `tertiary`, `text`, and `mute`.'
+          default: "'primary'",
+          description: "The type variant of the button. Available types are: `'primary'`, `'secondary'`, `'tertiary'`, `'text'`, and `'mute'`."
         },
         {
           name: 'mode',
-          type: 'string',
+          type: 'String',
           required: false,
-          default: '\'neutral\'',
-          description: 'The mode of the button. Available modes are: `neutral`, `info`, `success`, `warning`, and `danger`.'
+          default: "'neutral'",
+          description: "The mode variant of the button. Available modes are: `'neutral'`, `'info'`, `'success'`, `'warning'`, and `'danger'`."
         },
         {
           name: 'size',
-          type: "'mini' | 'small' | 'medium' | 'large' | 'jumbo'",
+          type: 'String',
           required: false,
-          default: '\'medium\'',
-          description: 'The size of the button.'
+          default: "'medium'",
+          description: "The size variant for the button. Available sizes are: `'mini'`, `'small'`, `'medium'`, `'large'`, and `'jumbo'`"
+        },
+        {
+          name: 'rounded',
+          type: 'Boolean',
+          required: false,
+          default: 'false',
+          description: 'Applies a border radius to the button.'
         },
         {
           name: 'icon',
           type: 'VueComponent',
           required: false,
           default: 'null',
-          description: 'Adds given Vue Component as an icon for the button.'
+          description: 'The icon component to display in the button content.'
         },
         {
           name: 'block',
-          type: 'boolean',
+          type: 'Boolean',
           required: false,
           default: 'false',
-          description: 'Apply `display: block` to the button.'
+          description: 'Applies `display: block` to the button.'
         },
         {
           name: 'inverse',
-          type: 'boolean',
+          type: 'Boolean',
           required: false,
           default: 'false',
-          description: 'Inverse button theme.'
+          description: 'Inverse the button theme.'
         },
         {
           name: 'loading',
-          type: 'boolean',
+          type: 'Boolean',
           required: false,
           default: 'false',
-          description: 'Show loading indicator.'
+          description: 'Display the loading indicator.'
         }
       ],
 
       events: [
         {
           name: 'click',
-          description: 'Fires when an user clicks the button.'
+          description: 'Emitted when the button is clicked.'
         }
       ]
     })


### PR DESCRIPTION
This PR sets precedence for documentation of components. There is a clearer distinction in the level of detail for examples and API specs. Going forward, it will provide more clarity between component usage examples (practical explanations) and what the options are (pragmatic descriptions).

- Add missing `rounded` prop spec.
- Reduce loading state timeout for a more prompt demo.
- Clear and concise tone.
- Formatted for consistency.