### PR TITLE
feat: add tabindex to input-selent and input-dropdown

### DIFF
--- a/lib/components/SDropdown.vue
+++ b/lib/components/SDropdown.vue
@@ -14,13 +14,27 @@
         :placeholder="options.search.placeholder"
         :value="options.search.value.value"
         @input="v => options.search.onInput(v)"
+        @down="focusFirstItem"
+        @escape="$emit('close')"
       />
     </div>
 
     <div class="container">
       <ul v-if="options.items.value.length > 0" class="list">
-        <li v-for="(item, index) in options.items.value" :key="index" class="item">
-          <SDropdownItem :selected="options.selected" :item="item" @click="onClick(item)" />
+        <li
+          v-for="(item, index) in options.items.value"
+          :key="index"
+          class="item"
+          tabindex="0"
+          @keydown.up.prevent
+          @keydown.down.prevent
+          @keyup.up.prevent="focusPrev"
+          @keyup.down.prevent="focusNext"
+          @keyup.enter="onClick(item)"
+          @keyup.escape="$emit('close')"
+          @click="onClick(item)"
+        >
+          <SDropdownItem :selected="options.selected" :item="item" />
         </li>
       </ul>
 
@@ -51,6 +65,19 @@ export default defineComponent({
   },
 
   setup(props, { emit }) {
+    function focusFirstItem(): void {
+      const el = document.querySelector('.SDropdown .item:first-child') as HTMLElement | null
+      el?.focus?.()
+    }
+
+    function focusPrev(event: any): void {
+      event.target.previousSibling?.focus()
+    }
+
+    function focusNext(event: any): void {
+      event.target.nextSibling?.focus()
+    }
+
     function onClick(item: Item): void {
       if (item.callback) {
         item.callback()
@@ -64,6 +91,9 @@ export default defineComponent({
     }
 
     return {
+      focusFirstItem,
+      focusPrev,
+      focusNext,
       onClick
     }
   }
@@ -123,8 +153,10 @@ export default defineComponent({
 }
 
 .item {
-  &:hover {
+  &:hover,
+  &:focus {
     background-color: var(--dropdown-item-hover-bg);
+    outline: none;
   }
 }
 

--- a/lib/components/SInputDropdown.vue
+++ b/lib/components/SInputDropdown.vue
@@ -9,7 +9,15 @@
     :validation="validation"
   >
     <div ref="container" class="SInputDropdown-container">
-      <div class="SInputDropdown-box" role="button" tabindex="0" @click="handleOpen">
+      <div
+        class="SInputDropdown-box"
+        role="button"
+        tabindex="0"
+        @click="handleOpen"
+        @keydown.down.prevent
+        @keyup.enter="handleOpen"
+        @keyup.down="handleOpen"
+      >
         <div class="SInputDropdown-box-content">
           <SInputDropdownItem v-if="hasSelected" :item="selected" @remove="handleCallback" />
           <span v-else class="SInputDropdown-box-placeholder">{{ placeholder }}</span>

--- a/lib/components/SInputDropdown.vue
+++ b/lib/components/SInputDropdown.vue
@@ -9,7 +9,7 @@
     :validation="validation"
   >
     <div ref="container" class="SInputDropdown-container">
-      <div class="SInputDropdown-box" role="button" @click="handleOpen">
+      <div class="SInputDropdown-box" role="button" tabindex="0" @click="handleOpen">
         <div class="SInputDropdown-box-content">
           <SInputDropdownItem v-if="hasSelected" :item="selected" @remove="handleCallback" />
           <span v-else class="SInputDropdown-box-placeholder">{{ placeholder }}</span>
@@ -200,6 +200,11 @@ export default defineComponent({
     &:hover {
       border-color: var(--input-focus-border);
     }
+
+    &:focus:not(:focus-visible) {
+      border-color: var(--input-focus-border);
+      outline: 0;
+    }
   }
 }
 
@@ -209,6 +214,11 @@ export default defineComponent({
 
     &:hover {
       border-color: var(--input-focus-border);
+    }
+
+    &:focus:not(:focus-visible) {
+      border-color: var(--input-focus-border);
+      outline: 0;
     }
   }
 }

--- a/lib/components/SInputSelect.vue
+++ b/lib/components/SInputSelect.vue
@@ -8,11 +8,12 @@
     :help="help"
     :validation="validation"
   >
-    <div class="box">
+    <div class="box" tabindex="0">
       <select
         :id="name"
         class="select"
         :class="{ 'is-not-selected': isNotSelected }"
+        tabindex="-1"
         @change="emitChange"
       >
         <option
@@ -160,6 +161,11 @@ export default defineComponent({
     &:hover {
       border-color: var(--input-focus-border);
     }
+
+    &:focus:not(:focus-visible) {
+      border-color: var(--input-focus-border);
+      outline: 0;
+    }
   }
 }
 
@@ -169,6 +175,11 @@ export default defineComponent({
 
     &:hover {
       border-color: var(--input-focus-border);
+    }
+
+    &:focus:not(:focus-visible) {
+      border-color: var(--input-focus-border);
+      outline: 0;
     }
   }
 }

--- a/lib/components/SInputSelect.vue
+++ b/lib/components/SInputSelect.vue
@@ -8,12 +8,13 @@
     :help="help"
     :validation="validation"
   >
-    <div class="box" tabindex="0">
+    <div class="box" :class="{ focus: isFocused }">
       <select
         :id="name"
         class="select"
         :class="{ 'is-not-selected': isNotSelected }"
-        tabindex="-1"
+        @focus="focus"
+        @blur="blur"
         @change="emitChange"
       >
         <option
@@ -44,7 +45,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, PropType } from '@vue/composition-api'
+import { PropType, defineComponent, ref, computed } from '@vue/composition-api'
 import { SyntheticInputEvent } from '../types/Utils'
 import SIconChevronUp from './icons/SIconChevronUp.vue'
 import SIconChevronDown from './icons/SIconChevronDown.vue'
@@ -84,6 +85,8 @@ export default defineComponent({
   },
 
   setup(props, { emit }) {
+    const isFocused = ref(false)
+
     const classes = computed(() => ({
       medium: props.size === 'medium',
       mini: props.size === 'mini',
@@ -99,6 +102,14 @@ export default defineComponent({
       return option.value === props.value
     }
 
+    function focus() {
+      isFocused.value = true
+    }
+
+    function blur() {
+      isFocused.value = false
+    }
+
     function emitChange(e: SyntheticInputEvent): void {
       props.validation && props.validation.$touch()
 
@@ -108,9 +119,12 @@ export default defineComponent({
     }
 
     return {
+      isFocused,
       classes,
       isNotSelected,
       isSelectedOption,
+      focus,
+      blur,
       emitChange
     }
   }
@@ -158,13 +172,9 @@ export default defineComponent({
   .box {
     background-color: var(--input-filled-bg);
 
-    &:hover {
+    &:hover,
+    &.focus {
       border-color: var(--input-focus-border);
-    }
-
-    &:focus:not(:focus-visible) {
-      border-color: var(--input-focus-border);
-      outline: 0;
     }
   }
 }
@@ -173,7 +183,8 @@ export default defineComponent({
   .box {
     border-color: var(--input-outlined-border);
 
-    &:hover {
+    &:hover,
+    &.focus {
       border-color: var(--input-focus-border);
     }
 

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -38,6 +38,8 @@
           @input="emitInput"
           @blur="emitBlur"
           @keypress.enter="emitEnter"
+          @keyup.down="$emit('down')"
+          @keyup.escape="$emit('escape')"
         >
 
         <div v-if="icon" class="icon" role="button" @click="focus">

--- a/test/components/SInputSelect.spec.ts
+++ b/test/components/SInputSelect.spec.ts
@@ -50,4 +50,18 @@ describe('components/SInputSelect', () => {
     await option.setSelected()
     expect(validation.item.$isDirty.value).toBe(true)
   })
+
+  it('should toggle focus on `focus` and `blur` event', async () => {
+    const wrapper = createWrapper({
+      propsData: { value: 1 }
+    })
+
+    expect(wrapper.vm.isFocused).toBe(false)
+
+    await wrapper.find('.SInputSelect .select').trigger('focus')
+    expect(wrapper.vm.isFocused).toBe(true)
+
+    await wrapper.find('.SInputSelect .select').trigger('blur')
+    expect(wrapper.vm.isFocused).toBe(false)
+  })
 })


### PR DESCRIPTION
Now `SInputSelect` and `SInputDropdown` can't be focused with tab key.
So enable to focus with tab key by attaching `tabindex`.

## Images
### Select
**mode:filled**
![Screen Shot 2021-04-28 at 20 56 16](https://user-images.githubusercontent.com/62658104/116402458-6e444d80-a867-11eb-8d9b-3d68a20ce992.png)
**mode:outlined**
![Screen Shot 2021-04-28 at 20 54 10](https://user-images.githubusercontent.com/62658104/116402517-7a300f80-a867-11eb-846a-7df85288786b.png)

### Dropdown
**mode:filled**
![Screen Shot 2021-04-28 at 21 24 54](https://user-images.githubusercontent.com/62658104/116403151-312c8b00-a868-11eb-8e11-770d73b761f3.png)
**mode:outlined**
![Screen Shot 2021-04-28 at 21 23 28](https://user-images.githubusercontent.com/62658104/116402995-02161980-a868-11eb-9f76-46ea15dc32fc.png)
