### PR TITLE
feat: add disabled option for select and dropdown

### DIFF
--- a/docs/components/inputs/StoryInputDropdownEXDisabledOptions.vue
+++ b/docs/components/inputs/StoryInputDropdownEXDisabledOptions.vue
@@ -1,0 +1,125 @@
+<template lang="md">
+<StoryBase>
+  <div class="input">
+    <SInputDropdown
+      v-model="value"
+      size="mini"
+      mode="outlined"
+      name="dropdown-input"
+      label="Disabling options"
+      placeholder="Please select items"
+      :search="search"
+      :options="options"
+    />
+  </div>
+</StoryBase>
+
+```vue
+<template>
+  <div class="input">
+    <SInputDropdown
+      v-model="value"
+      size="mini"
+      mode="outlined"
+      name="dropdown-input"
+      label="Dropdown input"
+      placeholder="Please select items"
+      :search="search"
+      :options="options"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from '@vue/composition-api'
+import { useSearch, useTextOption } from '@globalbrain/sefirot/lib/composables/InputDropdown'
+import SInputDropdown from '@globalbrain/sefirot/lib/components/SInputDropdown.vue'
+
+export default defineComponent({
+  components: {
+    SInputDropdown
+  },
+
+  setup() {
+    const value = ref(['disabled-option', 'vuejs'])
+
+    const search = useSearch({
+      placeholder: 'Search items',
+      missing: 'No items found.'
+    })
+
+    const options = [
+      useTextOption({ text: 'Vue.js', value: 'vuejs' }),
+      useTextOption({ text: 'Adonis', value: 'adonis' }),
+      useTextOption({ text: 'Rails', value: 'rails' }),
+      useTextOption({ text: 'Sinatra', value: 'sinatra' }),
+      useTextOption({ text: 'Laravel', value: 'laravel' }),
+      useTextOption({ text: 'Phoenix', value: 'phoenix' }),
+      useTextOption({ text: 'Disabled option', value: 'disabled-option', disabled: true })
+    ]
+
+    return {
+      value,
+      search,
+      options
+    }
+  }
+})
+</script>
+
+<style lang="postcss" scoped>
+@import "@/assets/styles/variables";
+
+.input {
+  max-width: 320px;
+}
+</style>
+```
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from '@nuxtjs/composition-api'
+import { useSearch, useTextOption } from '@@/lib/composables/InputDropdown'
+import SInputDropdown from '@@/lib/components/SInputDropdown.vue'
+import StoryBase from '@/components/StoryBase.vue'
+
+export default defineComponent({
+  components: {
+    SInputDropdown,
+    StoryBase
+  },
+
+  setup() {
+    const value = ref(['disabled-option', 'vuejs'])
+
+    const search = useSearch({
+      placeholder: 'Search items',
+      missing: 'No items found.'
+    })
+
+    const options = [
+      useTextOption({ text: 'Vue.js', value: 'vuejs' }),
+      useTextOption({ text: 'Adonis', value: 'adonis' }),
+      useTextOption({ text: 'Rails', value: 'rails' }),
+      useTextOption({ text: 'Sinatra', value: 'sinatra' }),
+      useTextOption({ text: 'Laravel', value: 'laravel' }),
+      useTextOption({ text: 'Phoenix', value: 'phoenix' }),
+      useTextOption({ text: 'Disabled option', value: 'disabled-option', disabled: true })
+    ]
+
+    return {
+      value,
+      search,
+      options
+    }
+  }
+})
+</script>
+
+<style lang="postcss" scoped>
+.input {
+  position: relative;
+  z-index: 100;
+  max-width: 320px;
+}
+</style>

--- a/docs/components/inputs/StoryInputSelectEXDisabledOptions.vue
+++ b/docs/components/inputs/StoryInputSelectEXDisabledOptions.vue
@@ -1,0 +1,95 @@
+<template lang="md">
+<StoryBase>
+  <div class="input">
+    <SInputSelect
+      v-model="input"
+      name="input-select-disabled"
+      label="Disabling options"
+      placeholder="Please select an item"
+      :options="options"
+    />
+  </div>
+</StoryBase>
+
+```vue
+<template>
+  <div class="input">
+    <SInputSelect
+      v-model="input"
+      name="input-select-disabled"
+      label="Disabling options"
+      placeholder="Please select an item"
+      :options="options"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from '@nuxtjs/composition-api'
+import SInputSelect from '@globalbrain/sefirot/lib/components/SInputSelect.vue'
+
+export default defineComponent({
+  components: {
+    SInputSelect
+  },
+
+  setup() {
+    const input = ref<number | null>(4)
+
+    const options = [
+      { label: 'First option', value: 1 },
+      { label: 'Second option', value: 2 },
+      { label: 'Third option', value: 3 },
+      { label: 'Disabled option', value: 4, disabled: true }
+    ]
+
+    return {
+      input,
+      options
+    }
+  }
+})
+</script>
+
+<style lang="postcss" scoped>
+.input {
+  max-width: 320px;
+}
+</style>
+```
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from '@nuxtjs/composition-api'
+import SInputSelect from '@@/lib/components/SInputSelect.vue'
+import StoryBase from '@/components/StoryBase.vue'
+
+export default defineComponent({
+  components: {
+    SInputSelect,
+    StoryBase
+  },
+
+  setup() {
+    const input = ref<number | null>(4)
+
+    const options = [
+      { label: 'First option', value: 1 },
+      { label: 'Second option', value: 2 },
+      { label: 'Third option', value: 3 },
+      { label: 'Disabled option', value: 4, disabled: true }
+    ]
+
+    return {
+      input,
+      options
+    }
+  }
+})
+</script>
+
+<style lang="postcss" scoped>
+.input {
+  max-width: 320px;
+}
+</style>

--- a/docs/pages/components/inputs-dropdown/index.vue
+++ b/docs/pages/components/inputs-dropdown/index.vue
@@ -11,6 +11,14 @@ Set `disabled` props to disable the input. While the input is disabled, it will 
 
 <StoryInputDropdownEXDisabled />
 
+## Disabling certain options
+
+You may define `disabled: true` to hide certain option items from showing up in the select list. Disabled options can still be shown as "selected" item.
+
+For example, this is useful when you want to deprecate some options, but you still have past data using those options.
+
+<StoryInputDropdownEXDisabledOptions />
+
 ## API
 
 <SpecProps :props="props" />
@@ -21,6 +29,7 @@ Set `disabled` props to disable the input. While the input is disabled, it will 
 import { defineComponent } from '@nuxtjs/composition-api'
 import StoryInputDropdownShowcase from '@/components/inputs/StoryInputDropdownShowcase.vue'
 import StoryInputDropdownEXDisabled from '@/components/inputs/StoryInputDropdownEXDisabled.vue'
+import StoryInputDropdownEXDisabledOptions from '@/components/inputs/StoryInputDropdownEXDisabledOptions.vue'
 import SpecProps from '@/components/SpecProps.vue'
 import SpecEvents from '@/components/SpecEvents.vue'
 import { useSpec } from '@/composables/Spec'
@@ -29,6 +38,7 @@ export default defineComponent({
   components: {
     StoryInputDropdownShowcase,
     StoryInputDropdownEXDisabled,
+    StoryInputDropdownEXDisabledOptions,
     SpecProps,
     SpecEvents
   },

--- a/docs/pages/components/inputs-select/index.vue
+++ b/docs/pages/components/inputs-select/index.vue
@@ -114,7 +114,7 @@ export default defineComponent({
           type: 'Array',
           required: true,
           default: '—',
-          description: 'The available options for the select options. The array should contain object with properties of `label` and `value`. `label` is used as a text for the radio button, and `value` is the value corresponding to the select option.'
+          description: 'The available options for the select options. The array should contain object with properties of `label` and `value`. `label` is used as a text for the radio button, and `value` is the value corresponding to the select option. There is an optional property `disabled` can be used for the select options which should not be displayed.'
         },
         {
           name: 'value',

--- a/docs/pages/components/inputs-select/index.vue
+++ b/docs/pages/components/inputs-select/index.vue
@@ -17,6 +17,14 @@ The select input comes in several different sizes. You may pass `size` prop to c
 
 <StoryInputSelectEXSizes />
 
+## Disabling certain options
+
+You may define `disabled: true` to hide certain option items from showing up in the select list. Disabled options can still be shown as "selected" item.
+
+For example, this is useful when you want to deprecate some options, but you still have past data using those options.
+
+<StoryInputSelectEXDisabledOptions />
+
 ## API
 
 <SpecProps :props="props" />
@@ -28,6 +36,7 @@ import { defineComponent } from '@nuxtjs/composition-api'
 import StoryInputSelectShowcase from '@/components/inputs/StoryInputSelectShowcase.vue'
 import StoryInputSelectEXOutlined from '@/components/inputs/StoryInputSelectEXOutlined.vue'
 import StoryInputSelectEXSizes from '@/components/inputs/StoryInputSelectEXSizes.vue'
+import StoryInputSelectEXDisabledOptions from '@/components/inputs/StoryInputSelectEXDisabledOptions.vue'
 import SpecProps from '@/components/SpecProps.vue'
 import SpecEvents from '@/components/SpecEvents.vue'
 import { useSpec } from '@/composables/Spec'
@@ -37,6 +46,7 @@ export default defineComponent({
     StoryInputSelectShowcase,
     StoryInputSelectEXOutlined,
     StoryInputSelectEXSizes,
+    StoryInputSelectEXDisabledOptions,
     SpecProps,
     SpecEvents
   },
@@ -114,7 +124,7 @@ export default defineComponent({
           type: 'Array',
           required: true,
           default: '—',
-          description: 'The available options for the select options. The array should contain object with properties of `label` and `value`. `label` is used as a text for the radio button, and `value` is the value corresponding to the select option. There is an optional property `disabled` can be used for the select options which should not be displayed.'
+          description: 'The available options for the select options. The array should contain object with properties of `label` and `value`. `label` is used as a text for the radio button, and `value` is the value corresponding to the select option. There is an optional property `disabled`. You may use this option to hide certain options.'
         },
         {
           name: 'value',

--- a/lib/components/SInputDropdown.vue
+++ b/lib/components/SInputDropdown.vue
@@ -96,9 +96,13 @@ export default defineComponent({
       { disabled: props.disabled }
     ])
 
+    const enabledItems = computed(() => {
+      return props.options.filter(option => !option.disabled)
+    })
+
     const dropdownOptions = useDropdown({
       search: props.search,
-      items: computed(() => props.options),
+      items: enabledItems,
       closeOnClick: props.closeOnClick,
       selected: computed(() => props.value),
       callback: handleCallback

--- a/lib/components/SInputSelect.vue
+++ b/lib/components/SInputSelect.vue
@@ -28,7 +28,7 @@
         </option>
 
         <option
-          v-for="option in options"
+          v-for="option in enabledOptions"
           :key="option.value"
           :value="JSON.stringify(option)"
           :selected="isSelectedOption(option)"
@@ -58,6 +58,7 @@ type Mode = 'filled' | 'outlined'
 interface Option {
   label: string
   value: boolean | number | string
+  disabled?: boolean
 }
 
 export default defineComponent({
@@ -101,6 +102,10 @@ export default defineComponent({
       return props.value === undefined || props.value === null || props.value === ''
     })
 
+    const enabledOptions = computed(() => {
+      return props.options.filter(option => !option.disabled)
+    })
+
     function isSelectedOption(option: Option): boolean {
       return option.value === props.value
     }
@@ -125,6 +130,7 @@ export default defineComponent({
       isFocused,
       classes,
       isNotSelected,
+      enabledOptions,
       isSelectedOption,
       focus,
       blur,

--- a/lib/components/SInputSelect.vue
+++ b/lib/components/SInputSelect.vue
@@ -28,8 +28,9 @@
         </option>
 
         <option
-          v-for="option in enabledOptions"
+          v-for="option in options"
           :key="option.value"
+          :style="{ display: option.disabled ? 'none' : null }"
           :value="JSON.stringify(option)"
           :selected="isSelectedOption(option)"
         >
@@ -102,10 +103,6 @@ export default defineComponent({
       return props.value === undefined || props.value === null || props.value === ''
     })
 
-    const enabledOptions = computed(() => {
-      return props.options.filter(option => !option.disabled)
-    })
-
     function isSelectedOption(option: Option): boolean {
       return option.value === props.value
     }
@@ -130,7 +127,6 @@ export default defineComponent({
       isFocused,
       classes,
       isNotSelected,
-      enabledOptions,
       isSelectedOption,
       focus,
       blur,

--- a/lib/composables/Dropdown.ts
+++ b/lib/composables/Dropdown.ts
@@ -22,6 +22,7 @@ export type Item = TextItem | UserItem
 export interface ItemBase {
   type: string
   value: any
+  disabled?: boolean
   callback?: Function
 }
 

--- a/test/components/SInputDropdown.spec.ts
+++ b/test/components/SInputDropdown.spec.ts
@@ -90,7 +90,7 @@ describe('components/SInputDropdown', () => {
       .toBe(document.activeElement)
   })
 
-  it('should display only options which is not disabled', async () => {
+  it('should hide disabled options', async () => {
     const wrapper = createWrapper({
       propsData: {
         value: 1
@@ -98,7 +98,12 @@ describe('components/SInputDropdown', () => {
     })
 
     await wrapper.vm.handleOpen()
-    const options = wrapper.find('.SInputDropdown .SDropdown .container .list').findAll('.item')
+
+    const options = wrapper
+      .find('.SInputDropdown .SDropdown .container .list')
+      .findAll('.item')
+      .filter(item => item.isVisible())
+
     expect(options.length).toBe(3)
   })
 })

--- a/test/components/SInputDropdown.spec.ts
+++ b/test/components/SInputDropdown.spec.ts
@@ -15,7 +15,8 @@ describe('components/SInputDropdown', () => {
         options: [
           useTextOption({ text: 'Option 1', value: 1 }),
           useTextOption({ text: 'Option 2', value: 2 }),
-          useTextOption({ text: 'Option 3', value: 3 })
+          useTextOption({ text: 'Option 3', value: 3 }),
+          useTextOption({ text: 'Option 4', value: 4, disabled: true })
         ],
         ...options.propsData
       }
@@ -87,5 +88,17 @@ describe('components/SInputDropdown', () => {
     await wrapper.vm.handleOpen()
     expect(wrapper.find('.SInputDropdown .SDropdown .search .SInputText input').element)
       .toBe(document.activeElement)
+  })
+
+  it('should display only options which is not disabled', async () => {
+    const wrapper = createWrapper({
+      propsData: {
+        value: 1
+      }
+    })
+
+    await wrapper.vm.handleOpen()
+    const options = wrapper.find('.SInputDropdown .SDropdown .container .list').findAll('.item')
+    expect(options.length).toBe(3)
   })
 })

--- a/test/components/SInputSelect.spec.ts
+++ b/test/components/SInputSelect.spec.ts
@@ -33,12 +33,16 @@ describe('components/SInputSelect', () => {
     expect(wrapper.emitted('change')).toHaveEmittedWith(2)
   })
 
-  it('should display only options which is not disabled', () => {
+  it('should hide disabled options', () => {
     const wrapper = createWrapper({
       propsData: { value: 1 }
     })
 
-    const options = wrapper.find('.SInputSelect .select').findAll('option')
+    const options = wrapper
+      .find('.SInputSelect .select')
+      .findAll('option')
+      .filter(option => option.isVisible())
+
     expect(options.length).toBe(3)
   })
 

--- a/test/components/SInputSelect.spec.ts
+++ b/test/components/SInputSelect.spec.ts
@@ -14,7 +14,8 @@ describe('components/SInputSelect', () => {
         options: [
           { label: 'Option 1', value: 1 },
           { label: 'Option 2', value: 2 },
-          { label: 'Option 3', value: 3 }
+          { label: 'Option 3', value: 3 },
+          { label: 'Option 4', value: 4, disabled: true }
         ],
         ...options.propsData
       }
@@ -30,6 +31,15 @@ describe('components/SInputSelect', () => {
       JSON.stringify({ label: 'Option 2', value: 2 })
     )
     expect(wrapper.emitted('change')).toHaveEmittedWith(2)
+  })
+
+  it('should display only options which is not disabled', () => {
+    const wrapper = createWrapper({
+      propsData: { value: 1 }
+    })
+
+    const options = wrapper.find('.SInputSelect .select').findAll('option')
+    expect(options.length).toBe(3)
   })
 
   it('should invoke validation on input change', async () => {


### PR DESCRIPTION
This PR implements a `disabled` option for the select options of `Select` and `Dropdown`.
The options which `disabled` option is true are not displayed as select options.