### PR TITLE
feat(tooltip): add markdown support

### DIFF
--- a/docs/components/tooltips/StoryTooltipEXLongText.vue
+++ b/docs/components/tooltips/StoryTooltipEXLongText.vue
@@ -1,0 +1,75 @@
+<template lang="md">
+<StoryBase>
+  <STooltip class="tooltip" :text="text">
+    Hover me
+  </STooltip>
+</StoryBase>
+
+```vue
+<template>
+  <STooltip class="tooltip" :text="text">
+    Hover me
+  </STooltip>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api'
+import STooltip from '@@/lib/components/STooltip.vue'
+
+export default defineComponent({
+  components: {
+    STooltip
+  },
+
+  setup() {
+    const text = `
+      Quite long descriptive text, with [helpful link](#) to navigate users.
+    `
+
+    return {
+      text
+    }
+  }
+})
+</script>
+
+<style lang="postcss" scoped>
+@import "@/assets/styles/variables";
+
+.tooltip {
+  text-decoration: underline;
+}
+</style>
+```
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+import STooltip from '@@/lib/components/STooltip.vue'
+import StoryBase from '@/components/StoryBase.vue'
+
+export default defineComponent({
+  components: {
+    STooltip,
+    StoryBase
+  },
+
+  setup() {
+    const text = `
+      Quite long descriptive text, with [helpful link](#) to navigate users.
+    `
+
+    return {
+      text
+    }
+  }
+})
+</script>
+
+<style lang="postcss" scoped>
+@import "@/assets/styles/variables";
+
+.tooltip {
+  text-decoration: underline;
+}
+</style>

--- a/docs/components/tooltips/StoryTooltipShowcase.vue
+++ b/docs/components/tooltips/StoryTooltipShowcase.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent } from '@vue/composition-api'
 import STooltip from '@globalbrain/sefirot/lib/components/STooltip.vue'
 
 export default defineComponent({

--- a/docs/pages/components/tooltips/index.vue
+++ b/docs/pages/components/tooltips/index.vue
@@ -5,6 +5,12 @@ Tooltips display informative text when users hover over or focus on an element.
 
 <StoryTooltipShowcase />
 
+## Long Text
+
+The tooltip may display long text to provide users more information. However, tooltip text should be short as possible. You can use markdown to provide a link to more details.
+
+<StoryTooltipEXLongText />
+
 ## API
 
 <SpecProps :props="props" />
@@ -12,13 +18,15 @@ Tooltips display informative text when users hover over or focus on an element.
 
 <script lang="ts">
 import { defineComponent } from '@nuxtjs/composition-api'
-import StoryTooltipShowcase from '@/components/StoryTooltipShowcase.vue'
+import StoryTooltipShowcase from '@/components/tooltips/StoryTooltipShowcase.vue'
+import StoryTooltipEXLongText from '@/components/tooltips/StoryTooltipEXLongText.vue'
 import SpecProps from '@/components/SpecProps.vue'
 import { useSpec } from '@/composables/Spec'
 
 export default defineComponent({
   components: {
     StoryTooltipShowcase,
+    StoryTooltipEXLongText,
     SpecProps
   },
 

--- a/lib/components/SCardHeader.vue
+++ b/lib/components/SCardHeader.vue
@@ -162,7 +162,6 @@ export default defineComponent({
 .action.warning:hover { color: var(--c-warning); }
 .action.danger:hover  { color: var(--c-danger); }
 
-
 .action.disabled:hover {
   color: var(--c-text-2);
   background-color: transparent;

--- a/lib/composables/Tooltip.ts
+++ b/lib/composables/Tooltip.ts
@@ -1,0 +1,91 @@
+import { Ref, ref } from '@vue/composition-api'
+
+export type Position = 'top' | 'right' | 'bottom' | 'left'
+
+const SCREEN_PADDING = 16
+
+/**
+ * Prevent tooltip going off-screen by adjusting the position depending on
+ * the current window size. This only applies to position `top` and
+ * `bottom` since we only care about left and right of the screen.
+ */
+export function useTooltip(
+  content: Ref<HTMLElement | null>,
+  tip: Ref<HTMLElement | null>,
+  position: Position
+) {
+  const on = ref(false)
+
+  function show(): void {
+    setPosition()
+    setTimeout(() => { on.value = true })
+  }
+
+  function hide(): void {
+    on.value = false
+  }
+
+  function setPosition(): void {
+    if (shouldPosition()) {
+      doSetPosition()
+    }
+  }
+
+  function doSetPosition(): void {
+    // Reset position first so that we can get the original position.
+    resetPosition()
+
+    // Temporally show tip to get its size.
+    tip.value!.style.display = 'block'
+
+    const contentRect = content.value!.getBoundingClientRect()
+    const tipRect = tip.value!.getBoundingClientRect()
+
+    const contentRightX = contentRect.x + contentRect.width
+    const tipRightX = tipRect.x + tipRect.width
+
+    if (tipRect.x < 0) {
+      adjustLeftPosition(contentRect.x)
+    } else if (tipRightX > window.outerWidth) {
+      adjustRightPosition(contentRightX)
+    }
+
+    tip.value!.style.display = 'none'
+  }
+
+  function adjustLeftPosition(contentRectX: number): void {
+    tip.value!.style.left = '0'
+    tip.value!.style.right = 'auto'
+    setTransform(-contentRectX + SCREEN_PADDING)
+  }
+
+  function adjustRightPosition(contentRightX: number): void {
+    tip.value!.style.left = 'auto'
+    tip.value!.style.right = '0'
+    setTransform((window.outerWidth - contentRightX) - SCREEN_PADDING)
+  }
+
+  function resetPosition(): void {
+    tip.value!.style.left = ''
+    tip.value!.style.right = ''
+    tip.value!.style.transform = ''
+  }
+
+  function setTransform(x: number): void {
+    tip.value!.style.transform = `translate(${x}px, ${position === 'top' ? -100 : 100}%)`
+  }
+
+  function shouldPosition(): boolean {
+    if (!tip.value || !content.value) {
+      return false
+    }
+
+    return position === 'top' || position === 'bottom'
+  }
+
+  return {
+    on,
+    show,
+    hide
+  }
+}


### PR DESCRIPTION
This PR adds markdown support in `Stooltip`. It also fixes issue where tooltip contents go off-screen when it is displayed near edge of the window.