### PR TITLE
feat: add z-index for SToolTip

### DIFF
--- a/docs/assets/styles/variables/z-indexes.css
+++ b/docs/assets/styles/variables/z-indexes.css
@@ -3,9 +3,9 @@
   --z-index-header: 1100;
   --z-index-footer: 1100;
   --z-index-tooltip: 2000;
-  --z-index-dropdown: 2000;
-  --z-index-screen: 3000;
-  --z-index-backdrop: 4000;
-  --z-index-modal: 4010;
-  --z-index-snackbar: 5000;
+  --z-index-dropdown: 3000;
+  --z-index-screen: 4000;
+  --z-index-backdrop: 5000;
+  --z-index-modal: 5100;
+  --z-index-snackbar: 6000;
 }

--- a/docs/assets/styles/variables/z-indexes.css
+++ b/docs/assets/styles/variables/z-indexes.css
@@ -2,6 +2,7 @@
   --z-index-sidebar: 1000;
   --z-index-header: 1100;
   --z-index-footer: 1100;
+  --z-index-tooltip: 2000;
   --z-index-dropdown: 2000;
   --z-index-screen: 3000;
   --z-index-backdrop: 4000;

--- a/lib/assets/styles/variables/z-indexes.css
+++ b/lib/assets/styles/variables/z-indexes.css
@@ -1,4 +1,5 @@
 :root {
+  --z-index-tooltip: 1000;
   --z-index-dropdown: 1000;
   --z-index-screen: 2000;
   --z-index-backdrop: 3000;

--- a/lib/assets/styles/variables/z-indexes.css
+++ b/lib/assets/styles/variables/z-indexes.css
@@ -1,8 +1,8 @@
 :root {
   --z-index-tooltip: 1000;
-  --z-index-dropdown: 1000;
-  --z-index-screen: 2000;
-  --z-index-backdrop: 3000;
-  --z-index-modal: 3010;
-  --z-index-snackbar: 4000;
+  --z-index-dropdown: 2000;
+  --z-index-screen: 3000;
+  --z-index-backdrop: 4000;
+  --z-index-modal: 4100;
+  --z-index-snackbar: 5000;
 }

--- a/lib/components/STooltip.vue
+++ b/lib/components/STooltip.vue
@@ -67,6 +67,7 @@ export default defineComponent({
   position: absolute;
   display: block;
   transition: opacity .25s;
+  z-index: var(--z-index-tooltip);
 }
 
 .STooltip-container.fade-enter,


### PR DESCRIPTION
Currently, there is a possibility that the z-index o tooltips is overlapping with other components.
So make it possible to set a z-index for it.