### PR TITLE
fix: add option to toLocaleString for not rounding decimal

### DIFF
--- a/lib/components/SInputNumber.vue
+++ b/lib/components/SInputNumber.vue
@@ -66,7 +66,7 @@ export default defineComponent({
 
       return props.value >= 100000000000000000000
         ? 'The number is too big'
-        : props.value.toLocaleString()
+        : props.value.toLocaleString('en-US', { maximumFractionDigits: 20 })
     })
 
     function emitInput(value: number): void {

--- a/test/components/SInputNumber.spec.ts
+++ b/test/components/SInputNumber.spec.ts
@@ -17,8 +17,8 @@ describe('components/SInputNumber', () => {
       }
     })
 
-    await wrapper.setProps({ value: 1000000000 })
-    expect(wrapper.vm.valueWithSeparator).toBe('1,000,000,000')
+    await wrapper.setProps({ value: 1000000000.2222 })
+    expect(wrapper.vm.valueWithSeparator).toBe('1,000,000,000.2222')
   })
 
   it('should not format help text with excessive value', async () => {


### PR DESCRIPTION
The problem is that the value of help text under Input number is rounded.

Before fix
![image](https://user-images.githubusercontent.com/62658104/125551644-7b29b826-77ce-4032-b538-eda3a0599ce1.png)

After fix
![image](https://user-images.githubusercontent.com/62658104/125551602-a5ca5f02-0b17-497f-8360-753c175791e5.png)
