### PR TITLE
feat: Text color of input text and input number

### DIFF
--- a/docs/assets/styles/components/c-medium.css
+++ b/docs/assets/styles/components/c-medium.css
@@ -40,6 +40,10 @@
     font-weight: 400;
   }
 
+  section + p {
+    margin-top: 24px;
+  }
+
   a {
     color: var(--c-info-light);
     transition: color .25s;

--- a/docs/components/inputs/StoryInputTextEXColors.vue
+++ b/docs/components/inputs/StoryInputTextEXColors.vue
@@ -1,0 +1,201 @@
+<template lang="md">
+<StoryBase title="Input with colors">
+  <div class="input">
+    <SInputText
+      v-model="textNeutral"
+      name="name-color-neutral"
+      label="Neutral"
+      placeholder="John Doe"
+      :color="colorNeutral"
+    />
+  </div>
+  <div class="input">
+    <SInputText
+      v-model="textInfo"
+      name="name-color-info"
+      label="Info"
+      placeholder="John Doe"
+      :color="colorInfo"
+    />
+  </div>
+  <div class="input">
+    <SInputText
+      v-model="textSuccess"
+      name="name-color-success"
+      label="Success"
+      placeholder="John Doe"
+      :color="colorSuccess"
+    />
+  </div>
+  <div class="input">
+    <SInputText
+      v-model="textWarning"
+      name="name-color-warning"
+      label="Warning"
+      placeholder="John Doe"
+      :color="colorWarning"
+    />
+  </div>
+  <div class="input">
+    <SInputText
+      v-model="textDanger"
+      name="name-color-danger"
+      label="Danger"
+      placeholder="John Doe"
+      :color="colorDanger"
+    />
+  </div>
+</StoryBase>
+
+```vue
+<template>
+  <div class="input">
+    <SInputText
+      v-model="textNeutral"
+      name="name-color-neutral"
+      label="Neutral"
+      placeholder="John Doe"
+      :color="colorNeutral"
+    />
+  </div>
+  <div class="input">
+    <SInputText
+      v-model="textInfo"
+      name="name-color-info"
+      label="Info"
+      placeholder="John Doe"
+      :color="colorInfo"
+    />
+  </div>
+  <div class="input">
+    <SInputText
+      v-model="textSuccess"
+      name="name-color-success"
+      label="Success"
+      placeholder="John Doe"
+      :color="colorSuccess"
+    />
+  </div>
+  <div class="input">
+    <SInputText
+      v-model="textWarning"
+      name="name-color-warning"
+      label="Warning"
+      placeholder="John Doe"
+      :color="colorWarning"
+    />
+  </div>
+  <div class="input">
+    <SInputText
+      v-model="textDanger"
+      name="name-color-danger"
+      label="Danger"
+      placeholder="John Doe"
+      :color="colorDanger"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from '@nuxtjs/composition-api'
+import SInputText from '@globalbrain/sefirot/lib/components/SInputText.vue'
+
+export default defineComponent({
+  components: {
+    SInputText
+  },
+
+  setup() {
+    const textNeutral = ref('')
+    const textInfo = ref('')
+    const textSuccess = ref('')
+    const textWarning = ref('')
+    const textDanger = ref('')
+
+    const colorNeutral = (value: string) => value.length < 10 ? 'neutral' : null
+    const colorInfo = (value: string) => value.length < 10 ? 'info' : null
+    const colorSuccess = (value: string) => value.length < 10 ? 'success' : null
+    const colorWarning = (value: string) => value.length < 10 ? 'warning' : null
+    const colorDanger = (value: string) => value.length < 10 ? 'danger' : null
+
+    return {
+      textNeutral,
+      textInfo,
+      textSuccess,
+      textWarning,
+      textDanger,
+      colorNeutral,
+      colorInfo,
+      colorSuccess,
+      colorWarning,
+      colorDanger
+    }
+  }
+})
+</script>
+
+<style lang="postcss" scoped>
+@import "@/assets/styles/variables";
+
+.input {
+  max-width: 320px;
+}
+
+.input + .input {
+  padding-top: 24px;
+}
+</style>
+```
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from '@nuxtjs/composition-api'
+import SInputText from '@@/lib/components/SInputText.vue'
+import StoryBase from '@/components/StoryBase.vue'
+
+export default defineComponent({
+  components: {
+    SInputText,
+    StoryBase
+  },
+
+  setup() {
+    const textNeutral = ref('')
+    const textInfo = ref('')
+    const textSuccess = ref('')
+    const textWarning = ref('')
+    const textDanger = ref('')
+
+    const colorNeutral = (value: string) => value.length < 10 ? 'neutral' : null
+    const colorInfo = (value: string) => value.length < 10 ? 'info' : null
+    const colorSuccess = (value: string) => value.length < 10 ? 'success' : null
+    const colorWarning = (value: string) => value.length < 10 ? 'warning' : null
+    const colorDanger = (value: string) => value.length < 10 ? 'danger' : null
+
+    return {
+      textNeutral,
+      textInfo,
+      textSuccess,
+      textWarning,
+      textDanger,
+      colorNeutral,
+      colorInfo,
+      colorSuccess,
+      colorWarning,
+      colorDanger
+    }
+  }
+})
+</script>
+
+<style lang="postcss" scoped>
+@import "@/assets/styles/variables";
+
+.input {
+  max-width: 320px;
+}
+
+.input + .input {
+  padding-top: 24px;
+}
+</style>

--- a/docs/pages/components/inputs-text/index.vue
+++ b/docs/pages/components/inputs-text/index.vue
@@ -17,6 +17,12 @@ The text input comes in several different sizes. You may pass `size` prop to con
 
 <StoryInputTextEXSizes />
 
+## Colors
+
+The text input comes in several color types. You may pass `color` prop to control the color of the input.
+
+<StoryInputTextEXColors />
+
 ## With Icon
 
 You can supply an icon to the input field by passing in the icon component to the `icon` prop.
@@ -77,12 +83,14 @@ import StoryInputTextEXClearable from '@/components/inputs/StoryInputTextEXClear
 import SpecProps from '@/components/SpecProps.vue'
 import SpecEvents from '@/components/SpecEvents.vue'
 import { useSpec } from '@/composables/Spec'
+import StoryInputTextEXColors from '~/components/inputs/StoryInputTextEXColors.vue'
 
 export default defineComponent({
   components: {
     StoryInputTextShowcase,
     StoryInputTextEXOutlined,
     StoryInputTextEXSizes,
+    StoryInputTextEXColors,
     StoryInputTextEXIcon,
     StoryInputTextEXText,
     StoryInputTextEXAction,
@@ -187,6 +195,13 @@ export default defineComponent({
           required: false,
           default: 'null',
           description: 'Add the trailing text to the input.'
+        },
+        {
+          name: 'color',
+          type: '(value: string | number) => `neutral` | `info` | `success` | `warning` | `danger`',
+          required: false,
+          default: 'null',
+          description: 'The color variant of the text. The callback accepts a value as an argument.'
         },
         {
           name: 'clearable',

--- a/docs/pages/components/inputs-text/index.vue
+++ b/docs/pages/components/inputs-text/index.vue
@@ -23,6 +23,13 @@ The text input comes in several color types. You may pass `color` prop to contro
 
 <StoryInputTextEXColors />
 
+The `color` prop takes callback function to determine the color. The type of the callback function is shown below.
+
+```ts
+type Color = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+type ColorCallback = (value: string | number) => Color
+```
+
 ## With Icon
 
 You can supply an icon to the input field by passing in the icon component to the `icon` prop.
@@ -198,10 +205,10 @@ export default defineComponent({
         },
         {
           name: 'color',
-          type: '(value: string | number) => `neutral` | `info` | `success` | `warning` | `danger`',
+          type: 'ColorCallback',
           required: false,
           default: 'null',
-          description: 'The color variant of the text. The callback accepts a value as an argument.'
+          description: 'The color variant of the text. See [Colors section](#colors) for more details.'
         },
         {
           name: 'clearable',

--- a/lib/components/SInputNumber.vue
+++ b/lib/components/SInputNumber.vue
@@ -56,7 +56,7 @@ export default defineComponent({
     text: { type: String, default: null },
     textAfter: { type: String, default: null },
     action: { type: Object as PropType<Action>, default: null },
-    color: { type: Function as PropType<(value: string | number) => Color>, default: null },
+    color: { type: Function as PropType<(value: number) => Color>, default: null },
     step: { type: Number, default: 1 },
     separator: { type: Boolean, default: false },
     helpFormat: { type: Boolean, default: false },

--- a/lib/components/SInputNumber.vue
+++ b/lib/components/SInputNumber.vue
@@ -36,9 +36,7 @@
 import { defineComponent, computed, PropType } from '@vue/composition-api'
 import { isNullish } from '../support/Util'
 import { Validation } from '../validation/Validation'
-import SInputText, { Size, Mode, Action } from './SInputText.vue'
-
-export type Color = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+import SInputText, { Size, Mode, Color, Action } from './SInputText.vue'
 
 export default defineComponent({
   components: {

--- a/lib/components/SInputNumber.vue
+++ b/lib/components/SInputNumber.vue
@@ -12,6 +12,7 @@
     :text="text"
     :text-after="textAfter"
     :action="action"
+    :color="color"
     :step="step"
     :disabled="disabled"
     :validation="validation"
@@ -37,6 +38,8 @@ import { isNullish } from '../support/Util'
 import { Validation } from '../validation/Validation'
 import SInputText, { Size, Mode, Action } from './SInputText.vue'
 
+export type Color = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+
 export default defineComponent({
   components: {
     SInputText
@@ -53,6 +56,7 @@ export default defineComponent({
     text: { type: String, default: null },
     textAfter: { type: String, default: null },
     action: { type: Object as PropType<Action>, default: null },
+    color: { type: Function as PropType<(value: string | number) => Color>, default: null },
     step: { type: Number, default: 1 },
     separator: { type: Boolean, default: false },
     helpFormat: { type: Boolean, default: false },

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -30,7 +30,7 @@
           :id="name"
           ref="inputEl"
           class="input-area"
-          :class="{ 'has-icon': icon, 'is-clearable': isClearable }"
+          :class="inputAreaClasses"
           :style="inputStyles"
           :type="type"
           :step="step"
@@ -46,7 +46,7 @@
 
         <div
           class="input"
-          :class="{ 'has-icon': icon, 'is-clearable': isClearable }"
+          :class="inputClasses"
           :style="inputStyles"
         >
           <span v-if="displayValue !== null || value !== null" class="value">
@@ -97,6 +97,7 @@ import SInputBase from './SInputBase.vue'
 
 export type Size = 'medium' | 'mini'
 export type Mode = 'filled' | 'outlined'
+export type Color = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
 
 export interface Action {
   type?: 'button' | 'select'
@@ -126,6 +127,7 @@ export default defineComponent({
     icon: { type: Object, default: null },
     text: { type: String, default: null },
     textAfter: { type: String, default: null },
+    color: { type: Function as PropType<(value: string | number) => Color>, default: null },
     step: { type: Number, default: 1 },
     clearable: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
@@ -139,6 +141,7 @@ export default defineComponent({
     const inputEl = ref<HTMLElement | null>(null)
     const textEl = ref<HTMLElement | null>(null)
     const textAfterEl = ref<HTMLElement | null>(null)
+    const color = ref<Color | null>(null)
 
     const classes = computed(() => ({
       medium: props.size === 'medium',
@@ -153,11 +156,34 @@ export default defineComponent({
       paddingLeft: ''
     })
 
+    const isClearable = computed(() => props.clearable && !props.disabled)
+
+    const inputClasses = computed(() => ({
+      neutral: color.value === 'neutral',
+      info: color.value === 'info',
+      success: color.value === 'success',
+      warning: color.value === 'warning',
+      danger: color.value === 'danger',
+      'has-icon': props.icon,
+      'is-clearable': isClearable.value
+    }))
+
+    const inputAreaClasses = computed(() => ({
+      'has-icon': props.icon,
+      'is-clearable': isClearable.value
+    }))
+
     const showClearButton = computed(() => {
       return props.value !== null && props.value !== ''
     })
 
-    const isClearable = computed(() => props.clearable && !props.disabled)
+    watch(() => props.value, () => {
+      if (!props.color) {
+        return
+      }
+
+      color.value = props.color(props.value)
+    })
 
     onMounted(() => {
       setTextPadding()
@@ -218,6 +244,8 @@ export default defineComponent({
       textAfterEl,
       classes,
       inputStyles,
+      inputClasses,
+      inputAreaClasses,
       isClearable,
       showClearButton,
       focus,
@@ -501,6 +529,7 @@ export default defineComponent({
   position: relative;
   display: flex;
   flex-grow: 1;
+  max-width: 100%;
 
   &:hover .input {
     border-color: var(--input-focus-border);
@@ -516,16 +545,9 @@ export default defineComponent({
   opacity: 1;
 
   .value {
+    display: block;
     line-height: 24px;
-  }
-
-  .placeholder {
-    line-height: 24px;
-    color: var(--input-placeholder);
-  }
-
-  &::placeholder {
-    color: var(--input-placeholder);
+    overflow: hidden;
   }
 }
 
@@ -545,6 +567,15 @@ export default defineComponent({
   &:focus + .input .value {
     opacity: 0;
   }
+}
+
+.input,
+.input-area {
+  &.neutral { color: var(--c-black); }
+  &.info { color: var(--c-info); }
+  &.success { color: var(--c-success); }
+  &.warning { color: var(--c-warning); }
+  &.danger { color: var(--c-danger); }
 }
 
 .icon {

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -98,6 +98,7 @@ import SInputBase from './SInputBase.vue'
 export type Size = 'medium' | 'mini'
 export type Mode = 'filled' | 'outlined'
 export type Color = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+export type ColorCallback = (value: string | number) => Color
 
 export interface Action {
   type?: 'button' | 'select'
@@ -127,7 +128,7 @@ export default defineComponent({
     icon: { type: Object, default: null },
     text: { type: String, default: null },
     textAfter: { type: String, default: null },
-    color: { type: Function as PropType<(value: string | number) => Color>, default: null },
+    color: { type: Function as PropType<ColorCallback>, default: null },
     step: { type: Number, default: 1 },
     clearable: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
@@ -158,15 +159,11 @@ export default defineComponent({
 
     const isClearable = computed(() => props.clearable && !props.disabled)
 
-    const inputClasses = computed(() => ({
-      neutral: color.value === 'neutral',
-      info: color.value === 'info',
-      success: color.value === 'success',
-      warning: color.value === 'warning',
-      danger: color.value === 'danger',
-      'has-icon': props.icon,
-      'is-clearable': isClearable.value
-    }))
+    const inputClasses = computed(() => [
+      color.value,
+      { 'has-icon': props.icon },
+      { 'is-clearable': isClearable.value }
+    ])
 
     const inputAreaClasses = computed(() => ({
       'has-icon': props.icon,

--- a/test/components/SInputText.spec.ts
+++ b/test/components/SInputText.spec.ts
@@ -119,4 +119,19 @@ describe('components/SInputText', () => {
     wrapper.find('.SInputText .clear').trigger('click')
     expect(wrapper.emitted('clear')).toBeTruthy()
   })
+
+  it('should apply color according to input value', async () => {
+    const wrapper = createWrapper({
+      propsData: {
+        color: (value: string) => value.length > 3 ? 'success' : 'info'
+      }
+    })
+    const input = wrapper.find('.SInputText .input')
+
+    await wrapper.setProps({ value: 'abcde' })
+    expect(input.classes('success')).toBeTruthy()
+
+    await wrapper.setProps({ value: 'ab' })
+    expect(input.classes('info')).toBeTruthy()
+  })
 })

--- a/test/components/SInputText.spec.ts
+++ b/test/components/SInputText.spec.ts
@@ -126,6 +126,7 @@ describe('components/SInputText', () => {
         color: (value: string) => value.length > 3 ? 'success' : 'info'
       }
     })
+
     const input = wrapper.find('.SInputText .input')
 
     await wrapper.setProps({ value: 'abcde' })


### PR DESCRIPTION
This PR implement `color` props in InputText and InputNumber.
The API is like below.

```vue
<SInputNumber
  v-model="value"
  placeholder="1,000,000"
  :color="(value) => value >= 0 ? 'success' : 'danger'"
/>
```