### PR TITLE
fix(tooltip): setTimeout when it hides tooltip

### DIFF
--- a/lib/composables/Tooltip.ts
+++ b/lib/composables/Tooltip.ts
@@ -22,7 +22,7 @@ export function useTooltip(
   }
 
   function hide(): void {
-    on.value = false
+    setTimeout(() => { on.value = false })
   }
 
   function setPosition(): void {


### PR DESCRIPTION
There is a problem that sometimes the tooltip continues to show even after hovering out.
Especially this happens when showing multiple tooltips at about the same time.

The reason seems that `show()` which is for showing tooltip is async but `hide()` is not async so sometimes `show()` is called after `hide()`.