### PR TITLE
feat(input-select): add error-message option for select input

### DIFF
--- a/docs/pages/components/inputs-number/index.vue
+++ b/docs/pages/components/inputs-number/index.vue
@@ -154,6 +154,13 @@ export default defineComponent({
           description: 'The input value with thousand separator that will be displayed under the input.'
         },
         {
+          name: 'error-message',
+          type: 'boolean',
+          required: false,
+          default: 'true',
+          description: 'Show the error message under the input field.'
+        },
+        {
           name: 'value',
           type: 'number',
           required: false,

--- a/docs/pages/components/inputs-select/index.vue
+++ b/docs/pages/components/inputs-select/index.vue
@@ -127,6 +127,13 @@ export default defineComponent({
           description: 'The available options for the select options. The array should contain object with properties of `label` and `value`. `label` is used as a text for the radio button, and `value` is the value corresponding to the select option. There is an optional property `disabled`. You may use this option to hide certain options.'
         },
         {
+          name: 'error-message',
+          type: 'boolean',
+          required: false,
+          default: 'true',
+          description: 'Show the error message under the input field.'
+        },
+        {
           name: 'value',
           type: 'String | Number | Boolean',
           required: false,

--- a/docs/pages/components/inputs-text/index.vue
+++ b/docs/pages/components/inputs-text/index.vue
@@ -240,6 +240,13 @@ export default defineComponent({
           description: 'The value displayed when the focus is out.'
         },
         {
+          name: 'error-message',
+          type: 'boolean',
+          required: false,
+          default: 'true',
+          description: 'Show the error message under the input field.'
+        },
+        {
           name: 'value',
           type: 'string | number',
           required: false,

--- a/docs/pages/components/inputs-ymd/index.vue
+++ b/docs/pages/components/inputs-ymd/index.vue
@@ -102,6 +102,13 @@ export default defineComponent({
           description: 'The help text that will be displayed under the input. Useful to add a little detailed information about the input.'
         },
         {
+          name: 'error-message',
+          type: 'boolean',
+          required: false,
+          default: 'true',
+          description: 'Show the error message under the input field.'
+        },
+        {
           name: 'value',
           type: 'YearMonthDate',
           required: false,

--- a/lib/components/SInputSelect.vue
+++ b/lib/components/SInputSelect.vue
@@ -7,6 +7,7 @@
     :note="note"
     :help="help"
     :validation="validation"
+    :error-message="errorMessage"
   >
     <div class="box" :class="{ focus: isFocused }">
       <select
@@ -83,6 +84,7 @@ export default defineComponent({
     help: { type: String, default: null },
     placeholder: { type: String, default: null },
     disabled: { type: Boolean, default: false },
+    errorMessage: { type: Boolean, default: true },
     options: { type: Array as PropType<Option[]>, required: true },
     validation: { type: Object, default: null },
     value: { type: [String, Number, Boolean], default: null }
@@ -194,6 +196,12 @@ export default defineComponent({
 }
 
 .SInputSelect.outlined {
+  &.has-error {
+    .box {
+      border-color: var(--c-danger);
+    }
+  }
+
   .box {
     border-color: var(--input-outlined-border);
 


### PR DESCRIPTION
This PR implements the `error-message` props for the SInputSelect component.
