### PR TITLE
fix: Broken style on dark mode

### DIFF
--- a/docs/assets/styles/variables.css
+++ b/docs/assets/styles/variables.css
@@ -327,6 +327,10 @@
   --input-outlined-bg-disabled: var(--c-black-mute);
   --input-outlined-border-focus: var(--c-gray);
 
+  --input-action-outlined-bg: var(--c-black-mute);
+  --input-action-outlined-bg-hover: var(--c-gray-dark-3);
+  --input-action-outlined-bg-focus: var(--c-gray-dark-2);
+
   --input-focus-border: var(--c-gray);
 }
 

--- a/docs/assets/styles/variables.css
+++ b/docs/assets/styles/variables.css
@@ -301,11 +301,12 @@
   --input-filled-bg-focus: var(--c-bg);
   --input-filled-bg-disabled: var(--c-gray-light-4);
 
+  --input-outlined-bg-focus: var(--c-bg);
   --input-outlined-bg-disabled: var(--c-white-mute);
   --input-outlined-border: var(--c-divider);
   --input-outlined-border-focus: var(--c-black);
 
-  --input-clear-bg-disabled: var(--c-white);
+  --input-clear-bg-disabled: var(--c-bg);
 
   --input-focus-border: var(--c-black);
   --input-focus-bg: var(--c-white);

--- a/docs/assets/styles/variables.css
+++ b/docs/assets/styles/variables.css
@@ -335,8 +335,8 @@
  * -------------------------------------------------------------------------- */
 
 :root {
-  --card-bg: var(--c-white);
-  --card-bg-mute: var(--c-white-soft);
+  --card-bg: var(--c-bg);
+  --card-bg-mute: var(--c-bg-soft);
   --card-shadow-depth-1: var(--shadow-depth-1);
   --card-shadow-depth-2: var(--shadow-depth-2);
   --card-shadow-depth-3: var(--shadow-depth-3);

--- a/docs/assets/styles/variables.css
+++ b/docs/assets/styles/variables.css
@@ -327,6 +327,8 @@
   --input-outlined-bg-disabled: var(--c-black-mute);
   --input-outlined-border-focus: var(--c-gray);
 
+  --input-filled-bg-disabled: var(--c-gray-dark-3);
+
   --input-action-outlined-bg: var(--c-black-mute);
   --input-action-outlined-bg-hover: var(--c-gray-dark-3);
   --input-action-outlined-bg-focus: var(--c-gray-dark-2);

--- a/docs/components/SpecEvents.vue
+++ b/docs/components/SpecEvents.vue
@@ -61,7 +61,7 @@ export default defineComponent({
   line-height: 20px;
   font-size: 12px;
   font-weight: 500;
-  color: var(--c-text-light-2);
+  color: var(--c-text-2);
 
   @media (min-width: 512px) {
     width: 96px;

--- a/docs/components/SpecProps.vue
+++ b/docs/components/SpecProps.vue
@@ -73,7 +73,7 @@ export default defineComponent({
   line-height: 20px;
   font-size: 12px;
   font-weight: 500;
-  color: var(--c-text-light-2);
+  color: var(--c-text-2);
 
   @media (min-width: 512px) {
     width: 96px;
@@ -103,7 +103,7 @@ export default defineComponent({
   font-family: var(--font-family-mono);
   font-weight: 500;
   color: var(--c-info-light);
-  background-color: var(--c-white-mute);
+  background-color: var(--c-bg-mute);
   word-break: break-all;
 }
 

--- a/lib/assets/styles/variables.css
+++ b/lib/assets/styles/variables.css
@@ -298,11 +298,12 @@
   --input-filled-bg-focus: var(--c-bg);
   --input-filled-bg-disabled: var(--c-gray-light-4);
 
+  --input-outlined-bg-focus: var(--c-bg);
   --input-outlined-bg-disabled: var(--c-white-mute);
   --input-outlined-border: var(--c-divider);
   --input-outlined-border-focus: var(--c-black);
 
-  --input-clear-bg-disabled: var(--c-white);
+  --input-clear-bg-disabled: var(--c-bg);
 
   --input-focus-border: var(--c-black);
   --input-focus-bg: var(--c-white);

--- a/lib/assets/styles/variables.css
+++ b/lib/assets/styles/variables.css
@@ -324,6 +324,8 @@
   --input-outlined-bg-disabled: var(--c-black-mute);
   --input-outlined-border-focus: var(--c-gray);
 
+  --input-filled-bg-disabled: var(--c-gray-dark-3);
+
   --input-action-outlined-bg: var(--c-black-mute);
   --input-action-outlined-bg-hover: var(--c-gray-dark-3);
   --input-action-outlined-bg-focus: var(--c-gray-dark-2);

--- a/lib/assets/styles/variables.css
+++ b/lib/assets/styles/variables.css
@@ -324,6 +324,10 @@
   --input-outlined-bg-disabled: var(--c-black-mute);
   --input-outlined-border-focus: var(--c-gray);
 
+  --input-action-outlined-bg: var(--c-black-mute);
+  --input-action-outlined-bg-hover: var(--c-gray-dark-3);
+  --input-action-outlined-bg-focus: var(--c-gray-dark-2);
+
   --input-focus-border: var(--c-gray);
 }
 

--- a/lib/assets/styles/variables.css
+++ b/lib/assets/styles/variables.css
@@ -332,8 +332,8 @@
  * -------------------------------------------------------------------------- */
 
 :root {
-  --card-bg: var(--c-white);
-  --card-bg-mute: var(--c-white-soft);
+  --card-bg: var(--c-bg);
+  --card-bg-mute: var(--c-bg-soft);
   --card-shadow-depth-1: var(--shadow-depth-1);
   --card-shadow-depth-2: var(--shadow-depth-2);
   --card-shadow-depth-3: var(--shadow-depth-3);

--- a/lib/components/SGrid.vue
+++ b/lib/components/SGrid.vue
@@ -120,7 +120,7 @@ export default defineComponent({
     padding: 16px 12px 12px;
     font-size: 12px;
     font-weight: 700;
-    color: var(--c-text-light-2);
+    color: var(--c-text-2);
   }
 }
 
@@ -148,7 +148,7 @@ export default defineComponent({
     }
 
     &:hover {
-      background-color: var(--c-white-soft);
+      background-color: var(--c-bg-soft);
     }
 
     &.clickable {
@@ -162,7 +162,7 @@ export default defineComponent({
     padding: 0 12px;
     line-height: 20px;
     font-size: 14px;
-    color: var(--c-text-light-1);
+    color: var(--c-text-1);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -190,7 +190,7 @@ export default defineComponent({
     width: 100%;
     font-size: 12px;
     font-weight: 500;
-    color: var(--c-text-light-2);
+    color: var(--c-text-2);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/lib/components/SInputCheckbox.vue
+++ b/lib/components/SInputCheckbox.vue
@@ -79,15 +79,15 @@ export default defineComponent({
 
   &:hover {
     .box {
-      border-color: var(--c-black);
+      border-color: var(--input-focus-border);
     }
   }
 }
 
 .input.on {
   .box {
-    border-color: var(--c-black);
-    background-color: var(--c-black);
+    border-color: var(--c-text-1);
+    background-color: var(--c-text-1);
     box-shadow: var(--shadow-depth-3);
   }
 
@@ -121,7 +121,7 @@ export default defineComponent({
 .check-icon {
   width: 10px;
   height: 10px;
-  fill: var(--c-white);
+  fill: var(--c-text-inverse-1);
 }
 
 .text {

--- a/lib/components/SInputDate.vue
+++ b/lib/components/SInputDate.vue
@@ -136,9 +136,13 @@ export default defineComponent({
   .input {
     background-color: var(--input-filled-bg);
 
+    &:hover {
+      border-color: var(--input-focus-border);
+    }
+
     &:focus {
       border-color: var(--input-focus-border);
-      background-color: var(--input-focus-bg);
+      background-color: var(--input-filled-bg-focus);
     }
   }
 
@@ -150,10 +154,14 @@ export default defineComponent({
 .SInputDate.outlined {
   .input {
     border-color: var(--input-outlined-border);
+    background-color: transparent;
+
+    &:hover {
+      border-color: var(--input-focus-border);
+    }
 
     &:focus {
       border-color: var(--input-focus-border);
-      background-color: var(--input-focus-bg);
     }
   }
 

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -518,7 +518,7 @@ export default defineComponent({
 
   .input-area:focus + .input {
     border-color: var(--input-focus-border);
-    background-color: var(--input-filled-bg-focus);
+    background-color: var(--input-outlined-bg-focus);
   }
 
   &.disabled .box:hover .input {

--- a/lib/components/SInputTextarea.vue
+++ b/lib/components/SInputTextarea.vue
@@ -115,9 +115,13 @@ export default defineComponent({
   .input {
     background-color: var(--input-filled-bg);
 
+    &:hover {
+      border-color: var(--input-focus-border);
+    }
+
     &:focus {
       border-color: var(--input-focus-border);
-      background-color: var(--input-focus-bg);
+      background-color: var(--input-filled-bg-focus);
     }
   }
 
@@ -152,6 +156,7 @@ export default defineComponent({
 .SInputTextarea.clear {
   .input {
     padding: 0;
+    background-color: transparent;
   }
 
   &.disabled .input {

--- a/lib/components/SPlaceholderBlank.vue
+++ b/lib/components/SPlaceholderBlank.vue
@@ -3,7 +3,7 @@
     <transition name="fade">
       <div v-if="!loaded" class="loader">
         <div class="icon">
-          <SIconPreloaderDark class="icon-svg" />
+          <SIconPreloader class="icon-svg" />
         </div>
       </div>
     </transition>
@@ -16,11 +16,11 @@
 
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api'
-import SIconPreloaderDark from './icons/SIconPreloaderDark.vue'
+import SIconPreloader from './icons/SIconPreloader.vue'
 
 export default defineComponent({
   components: {
-    SIconPreloaderDark
+    SIconPreloader
   },
 
   props: {

--- a/lib/components/SPlaceholderBlank.vue
+++ b/lib/components/SPlaceholderBlank.vue
@@ -3,8 +3,7 @@
     <transition name="fade">
       <div v-if="!loaded" class="loader">
         <div class="icon">
-          <SIconPreloaderLight v-if="$colorMode && $colorMode.value === 'dark'" class="icon-svg" />
-          <SIconPreloaderDark v-else class="icon-svg" />
+          <SIconPreloaderDark class="icon-svg" />
         </div>
       </div>
     </transition>
@@ -18,12 +17,10 @@
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api'
 import SIconPreloaderDark from './icons/SIconPreloaderDark.vue'
-import SIconPreloaderLight from './icons/SIconPreloaderLight.vue'
 
 export default defineComponent({
   components: {
-    SIconPreloaderDark,
-    SIconPreloaderLight
+    SIconPreloaderDark
   },
 
   props: {

--- a/lib/components/SPlaceholderBlank.vue
+++ b/lib/components/SPlaceholderBlank.vue
@@ -3,7 +3,8 @@
     <transition name="fade">
       <div v-if="!loaded" class="loader">
         <div class="icon">
-          <SIconPreloaderDark class="icon-svg" />
+          <SIconPreloaderLight v-if="$colorMode && $colorMode.value === 'dark'" class="icon-svg" />
+          <SIconPreloaderDark v-else class="icon-svg" />
         </div>
       </div>
     </transition>
@@ -17,10 +18,12 @@
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api'
 import SIconPreloaderDark from './icons/SIconPreloaderDark.vue'
+import SIconPreloaderLight from './icons/SIconPreloaderLight.vue'
 
 export default defineComponent({
   components: {
-    SIconPreloaderDark
+    SIconPreloaderDark,
+    SIconPreloaderLight
   },
 
   props: {

--- a/lib/components/SSnackbar.vue
+++ b/lib/components/SSnackbar.vue
@@ -11,7 +11,7 @@
         <SButton
           :type="action.type"
           :label="action.label"
-          inverse
+          :inverse="$colorMode.value === 'light'"
           @click="action.callback"
         />
       </div>


### PR DESCRIPTION
Some color styles are broken below in dark mode.
- STextInput
- STextareaInput
- SDateInput
- SGrid
- SCheckbox
- SCard
- SPlaceholder
- SSnackbar
- (docs) `props` and `events` section

Basically, this fixes is just replacing the CSS variables which does not support dark-mode to the one which does.