### PR TITLE
fix: align columns in case of minus width

### DIFF
--- a/lib/components/STableColumn.vue
+++ b/lib/components/STableColumn.vue
@@ -56,8 +56,9 @@ function grip(e: any) {
 
 function resize(e: MouseEvent) {
   const movedWidth = e.pageX - startPoint
+  const resized = startWidth + movedWidth
 
-  emit('resize', `${startWidth + movedWidth}px`)
+  emit('resize', resized > -1 ? `${resized}px` : 'var(--table-col-width)')
 }
 
 function done() {


### PR DESCRIPTION
(to `wip`)
Fix the broken align of the column when grips header to the minus width.