### PR TITLE
feat: add callback option to STableCellText

### DIFF
--- a/lib/components/STableCell.vue
+++ b/lib/components/STableCell.vue
@@ -24,7 +24,7 @@ defineProps<{
       :icon="cell?.icon"
       :getter="cell?.value"
       :link="cell?.link"
-      :callback="cell?.callback"
+      :on-click="cell?.onClick"
       :color="cell?.color"
       :icon-color="cell?.iconColor"
     />

--- a/lib/components/STableCell.vue
+++ b/lib/components/STableCell.vue
@@ -24,6 +24,7 @@ defineProps<{
       :icon="cell?.icon"
       :getter="cell?.value"
       :link="cell?.link"
+      :callback="cell?.callback"
       :color="cell?.color"
       :icon-color="cell?.iconColor"
     />

--- a/lib/components/STableCellPill.vue
+++ b/lib/components/STableCellPill.vue
@@ -32,7 +32,7 @@ const _color = computed(() => {
 
 <template>
   <div class="STableCellPill" :class="[_color ?? 'mute']">
-    <div class="value">{{ _value }}</div>
+    <div v-if="_value" class="value">{{ _value }}</div>
   </div>
 </template>
 

--- a/lib/components/STableCellText.vue
+++ b/lib/components/STableCellText.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
   color?: 'neutral' | 'soft' | 'mute'
   iconColor?: 'neutral' | 'soft' | 'mute'
   link?(value: any, record: any): string
-  callback?(value: any, record: any): void
+  onClick?(value: any, record: any): void
 }>()
 
 const _value = computed(() => {
@@ -24,17 +24,17 @@ const _value = computed(() => {
 })
 
 function handleClick() {
-  props.callback && props.callback(props.value, props.record)
+  props.onClick && props.onClick(props.value, props.record)
 }
 </script>
 
 <template>
-  <div class="STableCellText" :class="[{ link: link || callback }, color ?? 'neutral']">
+  <div class="STableCellText" :class="[{ link: link || onClick }, color ?? 'neutral']">
     <SLink v-if="_value" class="container" :href="link?.(value, record)">
       <div v-if="icon" class="icon" :class="[iconColor ?? color ?? 'neutral']">
         <component class="svg" :is="icon" />
       </div>
-      <div class="text" :class="[color ?? 'neutral']" :role="callback && 'button'" @click="handleClick">
+      <div class="text" :class="[color ?? 'neutral']" :role="onClick && 'button'" @click="handleClick">
         {{ _value }}
       </div>
     </SLink>

--- a/lib/components/STableCellText.vue
+++ b/lib/components/STableCellText.vue
@@ -10,6 +10,7 @@ const props = defineProps<{
   color?: 'neutral' | 'soft' | 'mute'
   iconColor?: 'neutral' | 'soft' | 'mute'
   link?(value: any, record: any): string
+  callback?(value: any, record: any): void
 }>()
 
 const _value = computed(() => {
@@ -21,15 +22,19 @@ const _value = computed(() => {
     ? props.getter
     : props.getter(props.value)
 })
+
+function handleClick() {
+  props.callback && props.callback(props.value, props.record)
+}
 </script>
 
 <template>
-  <div class="STableCellText" :class="[{ link }, color ?? 'neutral']">
+  <div class="STableCellText" :class="[{ link: link || callback }, color ?? 'neutral']">
     <SLink v-if="_value" class="container" :href="link?.(value, record)">
       <div v-if="icon" class="icon" :class="[iconColor ?? color ?? 'neutral']">
         <component class="svg" :is="icon" />
       </div>
-      <div class="text" :class="[color ?? 'neutral']">
+      <div class="text" :class="[color ?? 'neutral']" :role="callback && 'button'" @click="handleClick">
         {{ _value }}
       </div>
     </SLink>

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -79,6 +79,7 @@ export interface TableCellText extends TableCellBase {
   icon?: any
   value?: string | ((value: any) => string)
   link?(value: any, record: any): string
+  callback?(value: any, record: any): void
   color?: 'neutral' | 'soft' | 'mute'
   iconColor?: 'neutral' | 'soft' | 'mute'
 }

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -79,7 +79,7 @@ export interface TableCellText extends TableCellBase {
   icon?: any
   value?: string | ((value: any) => string)
   link?(value: any, record: any): string
-  callback?(value: any, record: any): void
+  onClick?(value: any, record: any): void
   color?: 'neutral' | 'soft' | 'mute'
   iconColor?: 'neutral' | 'soft' | 'mute'
 }


### PR DESCRIPTION
Implement `onClick` option to STableCellText.


###  Usage
```ts
const table = {
  orders: ...,
  columns: [
    name: {
      label: 'Name',
      dropdown: dropdownName,
      cell: {
        type: 'text', 
        onClick: (value, record) => { ... }
      }
    }
  ]
}
```