### PR TITLE
feat: add icon component and support using iconify in button

### DIFF
--- a/lib/components/SButton.vue
+++ b/lib/components/SButton.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import SIcon from './SIcon.vue'
 import SIconPreloader from './icons/SIconPreloader.vue'
 
 export type Size = 'mini' | 'small' | 'medium' | 'large' | 'jumbo'
@@ -21,7 +22,7 @@ const props = defineProps<{
   size?: Size
   type?: Type
   mode?: Mode
-  icon?: object
+  icon?: any
   label?: string
   href?: string
   loading?: boolean
@@ -61,7 +62,8 @@ function handleClick(): void {
     @click="handleClick"
   >
     <span class="content">
-      <span v-if="icon" class="icon"><component :is="icon" class="icon-svg" /></span>
+      <span v-if="icon && 'body' in icon" class="icon"><SIcon :icon="icon" class="icon-svg" /></span>
+      <span v-else-if="icon" class="icon"><component :is="icon" class="icon-svg" /></span>
       <span v-if="label" class="label">{{ label }}</span>
     </span>
 

--- a/lib/components/SButton.vue
+++ b/lib/components/SButton.vue
@@ -62,8 +62,7 @@ function handleClick(): void {
     @click="handleClick"
   >
     <span class="content">
-      <span v-if="icon && 'body' in icon" class="icon"><SIcon :icon="icon" class="icon-svg" /></span>
-      <span v-else-if="icon" class="icon"><component :is="icon" class="icon-svg" /></span>
+      <span v-if="icon" class="icon"><SIcon :icon="icon" class="icon-svg" /></span>
       <span v-if="label" class="label">{{ label }}</span>
     </span>
 

--- a/lib/components/SIcon.vue
+++ b/lib/components/SIcon.vue
@@ -1,11 +1,13 @@
+<script setup lang="ts">
+import { Icon, IconifyIcon } from '@iconify/vue/dist/offline'
+import type { DefineComponent } from 'vue'
+
+defineProps<{
+  icon: IconifyIcon | DefineComponent
+}>()
+</script>
+
 <template>
   <Icon v-if="typeof icon['body'] === 'string'" :icon="(icon as IconifyIcon)" />
   <component v-else :is="icon" />
 </template>
-
-<script setup lang="ts">
-import { Icon, IconifyIcon } from '@iconify/vue/dist/offline'
-import { DefineComponent } from 'vue'
-
-defineProps<{ icon: IconifyIcon | DefineComponent }>()
-</script>

--- a/lib/components/SIcon.vue
+++ b/lib/components/SIcon.vue
@@ -1,0 +1,9 @@
+<template>
+  <Icon :icon="icon" />
+</template>
+
+<script setup lang="ts">
+import { Icon, IconifyIcon } from '@iconify/vue/dist/offline'
+
+defineProps<{ icon: IconifyIcon }>()
+</script>

--- a/lib/components/SIcon.vue
+++ b/lib/components/SIcon.vue
@@ -1,9 +1,11 @@
 <template>
-  <Icon :icon="icon" />
+  <Icon v-if="typeof icon['body'] === 'string'" :icon="(icon as IconifyIcon)" />
+  <component v-else :is="icon" />
 </template>
 
 <script setup lang="ts">
 import { Icon, IconifyIcon } from '@iconify/vue/dist/offline'
+import { DefineComponent } from 'vue'
 
-defineProps<{ icon: IconifyIcon }>()
+defineProps<{ icon: IconifyIcon | DefineComponent }>()
 </script>

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/globalbrain/sefirot/issues"
   },
   "peerDependencies": {
+    "@iconify/vue": "^4.0.0",
     "@types/body-scroll-lock": "^3.1.0",
     "@types/lodash-es": "^4.17.6",
     "@vuelidate/core": "^2.0.0-alpha.38",
@@ -55,6 +56,7 @@
   },
   "devDependencies": {
     "@histoire/plugin-vue": "^0.10.7",
+    "@iconify/vue": "^4.0.0",
     "@types/body-scroll-lock": "^3.1.0",
     "@types/lodash-es": "^4.17.6",
     "@types/markdown-it": "^12.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@histoire/plugin-vue': ^0.10.7
+  '@iconify/vue': ^4.0.0
   '@types/body-scroll-lock': ^3.1.0
   '@types/lodash-es': ^4.17.6
   '@types/markdown-it': ^12.2.3
@@ -44,6 +45,7 @@ specifiers:
 
 devDependencies:
   '@histoire/plugin-vue': 0.10.7_gr7xrgksnqnbing6b46ua5jkoi
+  '@iconify/vue': 4.0.0_vue@3.2.39
   '@types/body-scroll-lock': 3.1.0
   '@types/lodash-es': 4.17.6
   '@types/markdown-it': 12.2.3
@@ -231,6 +233,19 @@ packages:
   /@hutson/parse-repository-url/3.0.2:
     resolution: {integrity: sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==}
     engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@iconify/types/2.0.0:
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+    dev: true
+
+  /@iconify/vue/4.0.0_vue@3.2.39:
+    resolution: {integrity: sha512-73z81Yf2HISfehu3qvN9GqL1OnUO7wEMKkiFwVGJ2pqAdGCR8FrVylhRhka+6U+gFLlng0ynnT20svk3jJYwow==}
+    peerDependencies:
+      vue: '>=3'
+    dependencies:
+      '@iconify/types': 2.0.0
+      vue: 3.2.39
     dev: true
 
   /@istanbuljs/schema/0.1.3:


### PR DESCRIPTION
partially resolves #140

Migration path:

```diff
- import SIconImage from 'sefirot/components/icons/SIconImage.vue'
+ import iconImageSquare from '@iconify-icons/ph/image-square'

- <SButton :icon="SIconImage" />
+ <SButton :icon="iconImageSquare" />

# ---

- import SIconCheck from './icons/SIconCheck.vue'
+ import SIcon from './SIcon.vue'
+ import iconCheck from '@iconify-icons/ph/check'

- <SIconCheck class="check-icon" />
+ <SIcon :icon="iconCheck" class="check-iron" />

# after migration remove lib/components/icons
```

Custom icons can be defined like this:

```ts
export const customIcon = {
  // Icon body: <path d="..." />, required.
  body: '<path d="..." />',

  // optional:

  // Left position of viewBox.
  // Defaults to 0.
  left: 0, // number

  // Top position of viewBox.
  // Defaults to 0.
  top: 0, // number

  // Width of viewBox.
  // Defaults to 16.
  width: 24, // number

  // Height of viewBox.
  // Defaults to 16.
  height: 24 // number
}
```

Stuff in `SIcon.vue` can be added/customized later. Currently it just wraps the Iconify icon component.

🚨 `@iconify/vue@^4` is now a required peer dependency.