### PR TITLE
fix: add padding to the size other than small

### DIFF
--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -122,36 +122,40 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 
 <style lang="postcss" scoped>
 .SInputText.mini {
-  .box { padding: 0 12px; }
+  .box {
+    padding: 0 8px;
+    min-height: 32px;
+  }
+
+  .value,
+  .input,
+  .display {
+    min-height: 30px;
+  }
 
   .input,
   .display {
-    min-height: 32px;
     padding: 3px 0;
+    letter-spacing: 0;
+    line-height: 24px;
     font-size: 14px;
-    line-height: 26px;
-
-    &.has-icon {
-      padding-left: 30px;
-    }
   }
 
   .icon {
-    top: 9px;
-    left: 10px;
-    width: 24px;
+    width: 22px;
+    height: 30px;
   }
 
   .icon-svg {
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
   }
 }
 
 .SInputText.small {
   .box {
-    min-height: 40px;
     padding: 0 12px;
+    min-height: 40px;
   }
 
   .value,
@@ -162,7 +166,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 
   .input,
   .display {
-    padding: 7px 0;
+    padding: 5px 0;
     letter-spacing: 0;
     line-height: 24px;
     font-size: 16px;
@@ -180,29 +184,33 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 }
 
 .SInputText.medium {
-  .box { padding: 0 16px; }
+  .box {
+    padding: 0 12px;
+    min-height: 48px;
+  }
+
+  .value,
+  .input,
+  .display {
+    min-height: 46px;
+  }
 
   .input,
   .display {
-    min-height: 48px;
     padding: 11px 0;
-    font-size: 20px;
-    line-height: 26px;
-
-    &.has-icon {
-      padding-left: 36px;
-    }
+    letter-spacing: 0;
+    line-height: 24px;
+    font-size: 16px;
   }
 
   .icon {
-    top: 16px;
-    left: 12px;
     width: 28px;
+    height: 46px;
   }
 
   .icon-svg {
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
   }
 }
 

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -122,11 +122,14 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 
 <style lang="postcss" scoped>
 .SInputText.mini {
+  .box { padding: 0 12px; }
+
   .input,
-  .input-area {
+  .display {
     min-height: 32px;
-    padding: 3px 12px;
+    padding: 3px 0;
     font-size: 14px;
+    line-height: 26px;
 
     &.has-icon {
       padding-left: 30px;
@@ -136,6 +139,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
   .icon {
     top: 9px;
     left: 10px;
+    width: 24px;
   }
 
   .icon-svg {
@@ -147,6 +151,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 .SInputText.small {
   .box {
     min-height: 40px;
+    padding: 0 12px;
   }
 
   .value,
@@ -157,7 +162,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 
   .input,
   .display {
-    padding: 5px 0;
+    padding: 7px 0;
     letter-spacing: 0;
     line-height: 24px;
     font-size: 16px;
@@ -175,11 +180,14 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 }
 
 .SInputText.medium {
+  .box { padding: 0 16px; }
+
   .input,
-  .input-area {
+  .display {
     min-height: 48px;
-    padding: 11px 16px;
-    font-size: 16px;
+    padding: 11px 0;
+    font-size: 20px;
+    line-height: 26px;
 
     &.has-icon {
       padding-left: 36px;
@@ -189,6 +197,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
   .icon {
     top: 16px;
     left: 12px;
+    width: 28px;
   }
 
   .icon-svg {
@@ -224,7 +233,6 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
   display: flex;
   flex-grow: 1;
   max-width: 100%;
-  padding: 0 12px;
   border: 1px solid var(--c-divider);
   border-radius: 6px;
   background-color: var(--c-bg);

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -155,10 +155,6 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
     min-height: 38px;
   }
 
-  .box {
-    padding: 0 12px;
-  }
-
   .input,
   .display {
     padding: 5px 0;
@@ -228,6 +224,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
   display: flex;
   flex-grow: 1;
   max-width: 100%;
+  padding: 0 12px;
   border: 1px solid var(--c-divider);
   border-radius: 6px;
   background-color: var(--c-bg);


### PR DESCRIPTION
This PR fix below.
- Padding of `mini` and `medium` size with icon (SInputText and SInputNumber)
- Misalignment between `value` and `displayValue` (SInputText and SInputNumber)