### PR TITLE
fix(SInputDropdown): prevent text wrapping in placeholder

### DIFF
--- a/lib/components/SInputDropdown.vue
+++ b/lib/components/SInputDropdown.vue
@@ -266,6 +266,8 @@ function handleArray(value: OptionValue) {
   padding: 2px 4px;
   font-weight: 500;
   color: var(--c-text-3);
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .box-icon {


### PR DESCRIPTION
fixes #159 