### PR TITLE
feat: add custom component cell for STable

### DIFF
--- a/lib/components/STableCell.vue
+++ b/lib/components/STableCell.vue
@@ -57,6 +57,13 @@ defineProps<{
       :avatars="cell.avatars"
       :color="cell.color"
     />
+    <component
+      v-else-if="cell.type === 'component'"
+      :is="cell.component"
+      :value="value"
+      :record="record"
+      v-bind="cell.props"
+    />
   </div>
 </template>
 

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -82,7 +82,7 @@ export interface TableCellAvatars extends TableCellBase {
 export interface TableCellComponent extends TableCellBase {
   type: 'component'
   component: Component
-  props: Record<string, any>
+  props?: Record<string, any>
 }
 
 export interface TableCellAvatarsOption {

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -1,5 +1,5 @@
 import { MaybeRef } from '@vueuse/core'
-import { reactive } from 'vue'
+import { Component, reactive } from 'vue'
 import { DropdownSection } from './Dropdown'
 
 export interface Table {
@@ -34,8 +34,9 @@ export type TableCell =
   | TableCellPill
   | TableCellAvatar
   | TableCellAvatars
+  | TableCellComponent
 
-export type TableCellType = 'text' | 'day' | 'pill' | 'avatar' | 'avatars'
+export type TableCellType = 'text' | 'day' | 'pill' | 'avatar' | 'avatars' | 'component'
 
 export interface TableCellBase {
   type: TableCellType
@@ -76,6 +77,12 @@ export interface TableCellAvatars extends TableCellBase {
   type: 'avatars'
   avatars(value: any, record: any): TableCellAvatarsOption[]
   color?: 'neutral' | 'soft' | 'mute'
+}
+
+export interface TableCellComponent extends TableCellBase {
+  type: 'component'
+  component: Component
+  props: Record<string, any>
 }
 
 export interface TableCellAvatarsOption {


### PR DESCRIPTION
This PR implements the `component` option for STableCell's type, which can be used for adding custom cell to STable.

The usage is like below.

```vue
<script setup lang="ts">
const table = useTable({
  orders: [
    'message',
    ...
  ],

  columns: {
    message: {
      label: 'Message',
      cell: {
        type: 'component',
        component: markRaw(VTableCellMessage),
        props: {
          color: 'info',
          message: (value: any) => `${value}`
        }
      }
    }, ...
  },

  ...
})
</script>
```

```vue
// VTableCellMessage.vue (the component that you make)
<script setup lang="ts">
import { computed } from 'vue'

const props = defineProps<{
  color: 'info' | 'success'
  message: string | ((value: any) => string)
  value?: any
  record: any
}>()

const _message = computed(() => {
  return typeof props.message === 'function' ? props.message(props.value) : props.message
})
</script>

<template>
  <div class="VTableCellMessage">
    Someone says "{{ _message }}"
  </div>
</template>
```