### PR TITLE
test: `sleep` utility coverage

### DIFF
--- a/lib/support/Time.ts
+++ b/lib/support/Time.ts
@@ -1,13 +1,9 @@
-type Awaited<T> = T extends undefined
-  ? T
-  : T extends PromiseLike<infer U> ? U : T
-
 export function sleep(ms = 500): Promise<undefined> {
   return new Promise<undefined>((resolve) => setTimeout(resolve, ms))
 }
 
-export function delay<T extends any[]>(
-  iterable: T,
+export function delay<T extends unknown[]>(
+  iterable: [...T],
   ms?: number
 ): Promise<{ [P in keyof T]: Awaited<T[P]> }> {
   return Promise.all([...iterable, sleep(ms)]) as any

--- a/tests/support/Time.spec.ts
+++ b/tests/support/Time.spec.ts
@@ -1,6 +1,32 @@
 import * as Time from 'sefirot/support/Time'
 
 describe('support/Time', () => {
+  describe('sleep', () => {
+    test('sleep for 500ms by default', async () => {
+      expect.assertions(1)
+
+      vi.useFakeTimers()
+
+      Time.sleep().then(() => {
+        expect(true).toBe(true)
+      })
+
+      vi.advanceTimersByTime(500)
+    })
+
+    test('sleep for a given time', async () => {
+      expect.assertions(1)
+
+      vi.useFakeTimers()
+
+      Time.sleep(1000).then(() => {
+        expect(true).toBe(true)
+      })
+
+      vi.advanceTimersByTime(1000)
+    })
+  })
+
   describe('delay', () => {
     test('delay callback execution for 500ms by default', async () => {
       expect.assertions(1)


### PR DESCRIPTION
resolves #185

- adds coverage for `sleep` utility
- replace `Awaited<T>` with builtin utility type