### PR TITLE
chore: enable corepack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
-        with:
-          version: 7.0.0
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@globalbrain/sefirot",
   "version": "2.14.1",
+  "packageManager": "pnpm@7.26.0",
   "description": "Vue Components for Global Brain Design System.",
   "author": "Kia Ishii <ka.ishii@globalbrains.com>",
   "license": "MIT",
@@ -106,6 +107,5 @@
         "@algolia/client-search"
       ]
     }
-  },
-  "packageManager": "pnpm@7.26.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -106,5 +106,6 @@
         "@algolia/client-search"
       ]
     }
-  }
+  },
+  "packageManager": "pnpm@7.26.0"
 }


### PR DESCRIPTION
I found that no package manager and its version are specified in the code base.

I believe it's reasonable to specify `packageManager` field in `package.json` and to use corepack, so that everyone can use same version of same package manager always.

I set everyone as reviewers to hear what you think, or just notification purpose.