### PR TITLE
feat: add `unit-*` props to `SInputText` and `SInputNumber`

### DIFF
--- a/docs/components/input-number.md
+++ b/docs/components/input-number.md
@@ -125,6 +125,34 @@ interface Props {
 <SInputNumber placeholder="123456789" v-model="..." />
 ```
 
+### `:unit-before`
+
+Defines the prefix to show, which is not a part of `:value` nor `:model-value`.
+
+```ts
+interface Props {
+  unitBefore?: string
+}
+```
+
+```vue-html
+<SInputNumber unit-before="¥" v-model="..." />
+```
+
+### `:unit-before`
+
+Defines the postfix to show, which is not a part of `:value` nor `:model-value`.
+
+```ts
+interface Props {
+  unitAfter?: string
+}
+```
+
+```vue-html
+<SInputNumber unit-after="yen" v-model="..." />
+```
+
 ### `:check-icon`
 
 Icon to display at corner right of label. Useful to show the status of a particular input.
@@ -166,11 +194,11 @@ interface Props {
 }
 
 type Color =
-  | 'neutral' 
-  | 'mute' 
-  | 'info' 
-  | 'success' 
-  | 'warning' 
+  | 'neutral'
+  | 'mute'
+  | 'info'
+  | 'success'
+  | 'warning'
   | 'danger'
 ```
 
@@ -315,7 +343,7 @@ Same as `info` prop. When `info` prop and this slot are defined at the same time
 
 ### `#addon-before`
 
-Inject [`<SInputAddon>`](/components/input-addon) before the input. Learn more details about addon in [Components: SInputAddon](/components/input-addon). 
+Inject [`<SInputAddon>`](/components/input-addon) before the input. Learn more details about addon in [Components: SInputAddon](/components/input-addon).
 
 ```vue-html
 <SInputNumber label="..." v-model="...">
@@ -327,7 +355,7 @@ Inject [`<SInputAddon>`](/components/input-addon) before the input. Learn more d
 
 ### `#addon-after`
 
-Inject [`<SInputAddon>`](/components/input-addon) after the input. Learn more details about addon in [Components: SInputAddon](/components/input-addon). 
+Inject [`<SInputAddon>`](/components/input-addon) after the input. Learn more details about addon in [Components: SInputAddon](/components/input-addon).
 
 ```vue-html
 <SInputNumber label="..." v-model="...">

--- a/docs/components/input-number.md
+++ b/docs/components/input-number.md
@@ -127,7 +127,7 @@ interface Props {
 
 ### `:unit-before`
 
-Defines the prefix to show, which is not a part of `:value` nor `:model-value`.
+Add a static text before the input box.
 
 ```ts
 interface Props {
@@ -136,12 +136,12 @@ interface Props {
 ```
 
 ```vue-html
-<SInputNumber unit-before="¥" v-model="..." />
+<SInputNumber unit-before="$" v-model="..." />
 ```
 
-### `:unit-before`
+### `:unit-after`
 
-Defines the postfix to show, which is not a part of `:value` nor `:model-value`.
+Add a static text after the input box.
 
 ```ts
 interface Props {
@@ -150,7 +150,7 @@ interface Props {
 ```
 
 ```vue-html
-<SInputNumber unit-after="yen" v-model="..." />
+<SInputNumber unit-after="USD" v-model="..." />
 ```
 
 ### `:check-icon`

--- a/lib/components/SInputNumber.vue
+++ b/lib/components/SInputNumber.vue
@@ -17,6 +17,8 @@ const props = defineProps<{
   note?: string
   help?: string
   placeholder?: string
+  unitBefore?: string
+  unitAfter?: string
   checkIcon?: IconifyIcon | DefineComponent
   checkText?: string
   checkColor?: Color
@@ -79,6 +81,8 @@ function emitUpdate(value: string | null) {
     :info="info"
     :help="help"
     :placeholder="placeholder"
+    :unit-before="unitBefore"
+    :unit-after="unitAfter"
     :check-icon="checkIcon"
     :check-text="checkText"
     :check-color="checkColor"

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -118,25 +118,33 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
       </div>
 
       <div class="value">
-        <div v-if="props.unitBefore" class="unit">{{ props.unitBefore }}</div>
-        <input
-          class="input entity"
-          :class="{ hide: showDisplay }"
-          :id="name"
-          :type="type ?? 'text'"
-          :placeholder="placeholder"
-          :disabled="disabled"
-          :value="modelValue"
-          ref="input"
-          @focus="onFocus"
-          @blur="emitBlur"
-          @input="emitInput"
-          @keypress.enter="emitEnter"
-        >
-        <div v-if="showDisplay" class="input display">
-          {{ displayValue }}
+        <div v-if="props.unitBefore" class="unit before">
+          {{ props.unitBefore }}
         </div>
-        <div v-if="props.unitAfter" class="unit">{{ props.unitAfter }}</div>
+
+        <div class="area">
+          <input
+            class="input entity"
+            :class="{ hide: showDisplay }"
+            :id="name"
+            :type="type ?? 'text'"
+            :placeholder="placeholder"
+            :disabled="disabled"
+            :value="modelValue"
+            ref="input"
+            @focus="onFocus"
+            @blur="emitBlur"
+            @input="emitInput"
+            @keypress.enter="emitEnter"
+          >
+          <div v-if="showDisplay" class="input display">
+            {{ displayValue }}
+          </div>
+        </div>
+
+        <div v-if="props.unitAfter" class="unit after">
+          {{ props.unitAfter }}
+        </div>
       </div>
 
       <div v-if="$slots['addon-after']" class="addon after">
@@ -151,6 +159,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 .SInputText.mini {
   .box   { min-height: 32px; }
   .value { min-height: 30px; }
+  .area  { min-height: 30px; }
 
   .input {
     padding: 3px 8px;
@@ -159,27 +168,17 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
     font-size: var(--input-font-size, var(--input-mini-font-size));
   }
 
-  .unit + .input {
-    padding-left: 4px;
-  }
-
-  .input:has(+ .unit) {
-    padding-right: 4px;
-  }
+  .unit + .area .input      { padding-left: 6px; }
+  .area:has(+ .unit) .input { padding-right: 6px; }
 
   .unit {
-    padding: 3px 4px;
+    padding: 3px 8px;
     line-height: 24px;
     font-size: var(--input-font-size, var(--input-mini-font-size));
   }
 
-  .unit:has(+ .input) {
-    padding-left: 8px;
-  }
-
-  .input + .unit {
-    padding-right: 8px;
-  }
+  .unit.before { padding-right: 0; }
+  .unit.after  { padding-left: 0; }
 
   .icon {
     width: 22px;
@@ -213,6 +212,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 .SInputText.small {
   .box   { min-height: 40px; }
   .value { min-height: 38px; }
+  .area  { min-height: 38px; }
 
   .input {
     padding: 7px 12px;
@@ -221,27 +221,17 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
     font-size: var(--input-font-size, var(--input-small-font-size));
   }
 
-  .unit + .input {
-    padding-left: 6px;
-  }
-
-  .input:has(+ .unit) {
-    padding-right: 6px;
-  }
+  .unit + .area .input      { padding-left: 8px; }
+  .area:has(+ .unit) .input { padding-right: 8px; }
 
   .unit {
-    padding: 7px 6px;
+    padding: 7px 12px;
     line-height: 24px;
     font-size: var(--input-font-size, var(--input-small-font-size));
   }
 
-  .unit:has(+ .input) {
-    padding-left: 12px;
-  }
-
-  .input + .unit {
-    padding-right: 12px;
-  }
+  .unit.before { padding-right: 0; }
+  .unit.after  { padding-left: 0; }
 
   .icon {
     width: 26px;
@@ -275,6 +265,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 .SInputText.medium {
   .box   { min-height: 48px; }
   .value { min-height: 46px; }
+  .area  { min-height: 46px; }
 
   .input {
     padding: 11px 12px;
@@ -283,27 +274,17 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
     font-size: var(--input-font-size, var(--input-medium-font-size));
   }
 
-  .unit + .input {
-    padding-left: 6px;
-  }
-
-  .input:has(+ .unit) {
-    padding-right: 6px;
-  }
+  .unit + .area .input      { padding-left: 8px; }
+  .area:has(+ .unit) .input { padding-right: 8px; }
 
   .unit {
-    padding: 11px 6px;
+    padding: 11px 12px;
     line-height: 24px;
     font-size: var(--input-font-size, var(--input-medium-font-size));
   }
 
-  .unit:has(+ .input) {
-    padding-left: 12px;
-  }
-
-  .input + .unit {
-    padding-right: 12px;
-  }
+  .unit.before { padding-right: 0; }
+  .unit.after  { padding-left: 0; }
 
   .icon {
     width: 28px;
@@ -389,7 +370,8 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
   }
 }
 
-.value {
+.value,
+.area {
   position: relative;
   display: flex;
   align-items: center;
@@ -397,7 +379,12 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 }
 
 .input {
-  flex-grow: 1;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
   color: var(--input-value-color);
   background-color: transparent;
   cursor: text;

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -18,6 +18,8 @@ const props = defineProps<{
   help?: string
   type?: string
   placeholder?: string
+  unitBefore?: string
+  unitAfter?: string
   checkIcon?: IconifyIcon | DefineComponent
   checkText?: string
   checkColor?: Color
@@ -116,6 +118,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
       </div>
 
       <div class="value">
+        <div v-if="props.unitBefore" class="unit">{{ props.unitBefore }}</div>
         <input
           class="input entity"
           :class="{ hide: showDisplay }"
@@ -133,6 +136,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
         <div v-if="showDisplay" class="input display">
           {{ displayValue }}
         </div>
+        <div v-if="props.unitAfter" class="unit">{{ props.unitAfter }}</div>
       </div>
 
       <div v-if="$slots['addon-after']" class="addon after">
@@ -153,6 +157,28 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
     letter-spacing: 0;
     line-height: 24px;
     font-size: var(--input-font-size, var(--input-mini-font-size));
+  }
+
+  .unit + .input {
+    padding-left: 4px;
+  }
+
+  .input:has(+ .unit) {
+    padding-right: 4px;
+  }
+
+  .unit {
+    padding: 3px 4px;
+    line-height: 24px;
+    font-size: var(--input-font-size, var(--input-mini-font-size));
+  }
+
+  .unit:has(+ .input) {
+    padding-left: 8px;
+  }
+
+  .input + .unit {
+    padding-right: 8px;
   }
 
   .icon {
@@ -195,6 +221,28 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
     font-size: var(--input-font-size, var(--input-small-font-size));
   }
 
+  .unit + .input {
+    padding-left: 6px;
+  }
+
+  .input:has(+ .unit) {
+    padding-right: 6px;
+  }
+
+  .unit {
+    padding: 7px 6px;
+    line-height: 24px;
+    font-size: var(--input-font-size, var(--input-small-font-size));
+  }
+
+  .unit:has(+ .input) {
+    padding-left: 12px;
+  }
+
+  .input + .unit {
+    padding-right: 12px;
+  }
+
   .icon {
     width: 26px;
     height: 38px;
@@ -233,6 +281,28 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
     letter-spacing: 0;
     line-height: 24px;
     font-size: var(--input-font-size, var(--input-medium-font-size));
+  }
+
+  .unit + .input {
+    padding-left: 6px;
+  }
+
+  .input:has(+ .unit) {
+    padding-right: 6px;
+  }
+
+  .unit {
+    padding: 11px 6px;
+    line-height: 24px;
+    font-size: var(--input-font-size, var(--input-medium-font-size));
+  }
+
+  .unit:has(+ .input) {
+    padding-left: 12px;
+  }
+
+  .input + .unit {
+    padding-right: 12px;
   }
 
   .icon {
@@ -275,7 +345,8 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
     background-color: var(--input-disabled-bg-color);
   }
 
-  .box:hover .input {
+  .box:hover .input,
+  .box:hover .unit {
     cursor: not-allowed;
   }
 }
@@ -320,16 +391,13 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 
 .value {
   position: relative;
+  display: flex;
+  align-items: center;
   flex-grow: 1;
 }
 
 .input {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
+  flex-grow: 1;
   color: var(--input-value-color);
   background-color: transparent;
   cursor: text;
@@ -351,6 +419,11 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
   bottom: 0;
   left: 0;
   width: 100%;
+}
+
+.unit {
+  font-weight: 500;
+  color: var(--c-text-2);
 }
 
 .icon {

--- a/stories/components/SInputNumber.01_Playground.story.vue
+++ b/stories/components/SInputNumber.01_Playground.story.vue
@@ -12,6 +12,8 @@ function state() {
     info: 'Some helpful information.',
     note: 'Note text',
     placeholder: '123,456,789',
+    unitBefore: '',
+    unitAfter: '',
     help: 'This is a help text.',
     align: 'left',
     separator: true,
@@ -59,6 +61,14 @@ function onInput(value: number | null) {
         v-model="state.placeholder"
       />
       <HstText
+        title="unit-before"
+        v-model="state.unitBefore"
+      />
+      <HstText
+        title="unit-after"
+        v-model="state.unitAfter"
+      />
+      <HstText
         title="help"
         v-model="state.help"
       />
@@ -94,6 +104,8 @@ function onInput(value: number | null) {
         :note="state.note"
         :help="state.help"
         :placeholder="state.placeholder"
+        :unit-before="state.unitBefore"
+        :unit-after="state.unitAfter"
         :align="state.align"
         :separator="state.separator"
         :disabled="state.disabled"

--- a/stories/components/SInputNumber.02_Addons.story.vue
+++ b/stories/components/SInputNumber.02_Addons.story.vue
@@ -101,6 +101,8 @@ function state() {
               :size="state.size"
               placeholder="1,000"
               separator
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
               v-model="data.amount1"
             >
               <template #addon-before>
@@ -117,6 +119,8 @@ function state() {
               :size="state.size"
               placeholder="1,000"
               separator
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
               v-model="data.amount2"
             >
               <template #addon-after>
@@ -132,6 +136,8 @@ function state() {
             <SInputNumber
               :size="state.size"
               placeholder="1000000"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
               v-model="data.lottery1"
             >
               <template #addon-before>
@@ -147,6 +153,8 @@ function state() {
             <SInputNumber
               :size="state.size"
               placeholder="1000000"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
               v-model="data.lottery2"
             >
               <template #addon-after>
@@ -161,10 +169,10 @@ function state() {
           <div class="grid">
             <SInputNumber
               :size="state.size"
-              :unit-before="state.unitBefore"
-              :unit-after="state.unitAfter"
               separator
               placeholder="1,000,000"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
               v-model="data.currency"
             >
               <template #addon-before>
@@ -181,6 +189,8 @@ function state() {
               :size="state.size"
               placeholder="1,000,000"
               separator
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
               v-model="data.amount3"
             >
               <template #addon-after>
@@ -195,9 +205,10 @@ function state() {
           <div class="grid">
             <SInputNumber
               :size="state.size"
-              unit-after="disabled"
               placeholder="1,000,000"
               separator
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
               disabled
               v-model="data.amount4"
             >

--- a/stories/components/SInputNumber.02_Addons.story.vue
+++ b/stories/components/SInputNumber.02_Addons.story.vue
@@ -59,7 +59,9 @@ const dropdown2 = createDropdown([
 
 function state() {
   return {
-    size: 'small'
+    size: 'small',
+    unitBefore: '',
+    unitAfter: ''
   } as const
 }
 </script>
@@ -79,6 +81,14 @@ function state() {
           medium: 'medium'
         }"
         v-model="state.size"
+      />
+      <HstText
+        title="unit-before for Addon Dropdown (Before / Single Select Dropdown)"
+        v-model="state.unitBefore"
+      />
+      <HstText
+        title="unit-after for Addon Dropdown (Before / Single Select Dropdown)"
+        v-model="state.unitAfter"
       />
     </template>
 
@@ -151,6 +161,8 @@ function state() {
           <div class="grid">
             <SInputNumber
               :size="state.size"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
               separator
               placeholder="1,000,000"
               v-model="data.currency"
@@ -166,6 +178,7 @@ function state() {
           <div class="title">Addon Dropdown (After / Dropdown Menu)</div>
           <div class="grid">
             <SInputNumber
+              :size="state.size"
               placeholder="1,000,000"
               separator
               v-model="data.amount3"
@@ -181,6 +194,8 @@ function state() {
           <div class="title">Addon Dropdown (Before / After / Disabled)</div>
           <div class="grid">
             <SInputNumber
+              :size="state.size"
+              unit-after="disabled"
               placeholder="1,000,000"
               separator
               disabled

--- a/stories/components/SInputText.01_Playground.story.vue
+++ b/stories/components/SInputText.01_Playground.story.vue
@@ -23,14 +23,14 @@ const { data, validation, init, validateAndNotify } = useForm<Data>({
   }
 })
 
-const state = ref<'loading' | 'success' | 'failure'>()
+const inputState = ref<'loading' | 'success' | 'failure'>()
 
 const check = computed(() => {
-  if (state.value === 'loading') {
+  if (inputState.value === 'loading') {
     return { icon: SSpinner as DefineComponent, text: 'Saving...', color: 'mute' as const }
-  } else if (state.value === 'success') {
+  } else if (inputState.value === 'success') {
     return { icon: IconCheckCircle, text: 'Saved', color: 'success' as const }
-  } else if (state.value === 'failure') {
+  } else if (inputState.value === 'failure') {
     return { icon: IconXCircle, text: 'Failed', color: 'danger' as const }
   } else {
     return null
@@ -42,48 +42,132 @@ let timeout: number
 async function submit() {
   clearTimeout(timeout)
 
-  state.value = 'loading'
+  inputState.value = 'loading'
 
   const valid = await validateAndNotify()
 
   if (valid) {
     timeout = setTimeout(() => {
-      state.value = 'success'
+      inputState.value = 'success'
     }, 2000) as any
   } else {
-    state.value = 'failure'
+    inputState.value = 'failure'
   }
 }
 
 function reset() {
   init()
   clearTimeout(timeout)
-  state.value = undefined
+  inputState.value = undefined
+}
+
+function state() {
+  return {
+    size: 'small',
+    label: 'Label',
+    info: 'Some helpful information.',
+    note: 'Required',
+    placeholder: 'John Doe',
+    unitBefore: '',
+    unitAfter: '',
+    help: 'Please fill in your name.',
+    align: 'left',
+    separator: true,
+    disabled: false,
+    error: false
+  } as const
 }
 </script>
 
 <template>
   <Board
     title="Components / SInputText / 01. Playground"
+    :state="state"
   >
-    <SInputText
-      name="name"
-      label="Label"
-      info="Some helpful information."
-      note="Required"
-      help="Please fill in your name."
-      placeholder="John Doe"
-      :check-icon="check?.icon"
-      :check-text="check?.text"
-      :check-color="check?.color"
-      v-model="data.name"
-      :validation="validation.name"
-    />
+    <template #controls="{ state }">
+      <HstSelect
+        title="size"
+        :options="{
+          mini: 'mini',
+          small: 'small',
+          medium: 'medium'
+        }"
+        v-model="state.size"
+      />
+      <HstText
+        title="label"
+        v-model="state.label"
+      />
+      <HstText
+        title="info"
+        v-model="state.info"
+      />
+      <HstText
+        title="note"
+        v-model="state.note"
+      />
+      <HstText
+        title="placeholder"
+        v-model="state.placeholder"
+      />
+      <HstText
+        title="unit-before"
+        v-model="state.unitBefore"
+      />
+      <HstText
+        title="unit-after"
+        v-model="state.unitAfter"
+      />
+      <HstText
+        title="help"
+        v-model="state.help"
+      />
+      <HstSelect
+        title="align"
+        :options="{
+          left: 'left',
+          center: 'center',
+          right: 'right'
+        }"
+        v-model="state.align"
+      />
+      <HstCheckbox
+        title="separator"
+        v-model="state.separator"
+      />
+      <HstCheckbox
+        title="disabled"
+        v-model="state.disabled"
+      />
+      <HstCheckbox
+        title="error"
+        v-model="state.error"
+      />
+    </template>
 
-    <div class="actions">
-      <SButton size="small" mode="info" label="Submit" @click="submit" />
-      <SButton size="small" mode="mute" label="Reset" @click="reset" />
-    </div>
+    <template #default="{ state }">
+      <SInputText
+        name="name"
+        :label="state.label"
+        :info="state.info"
+        :note="state.note"
+        :help="state.help"
+        :placeholder="state.placeholder"
+        :unit-before="state.unitBefore"
+        :unit-after="state.unitAfter"
+        :size="state.size"
+        :check-icon="check?.icon"
+        :check-text="check?.text"
+        :check-color="check?.color"
+        :validation="validation.name"
+        v-model="data.name"
+      />
+
+      <div class="actions">
+        <SButton size="small" mode="info" label="Submit" @click="submit" />
+        <SButton size="small" mode="mute" label="Reset" @click="reset" />
+      </div>
+    </template>
   </Board>
 </template>
 

--- a/stories/components/SInputText.02_Addons.story.vue
+++ b/stories/components/SInputText.02_Addons.story.vue
@@ -58,7 +58,9 @@ const dropdown2 = createDropdown([
 
 function state() {
   return {
-    size: 'small'
+    size: 'small',
+    unitBefore: '',
+    unitAfter: ''
   } as const
 }
 </script>
@@ -77,6 +79,14 @@ function state() {
           medium: 'medium'
         }"
         v-model="state.size"
+      />
+      <HstText
+        title="unit-before for Addon Dropdown (Before / Single Select Dropdown)"
+        v-model="state.unitBefore"
+      />
+      <HstText
+        title="unit-after for Addon Dropdown (Before / Single Select Dropdown)"
+        v-model="state.unitAfter"
       />
     </template>
 
@@ -129,7 +139,13 @@ function state() {
         <div class="group">
           <div class="title">Addon Dropdown (Before / Single Select Dropdown)</div>
           <div class="grid">
-            <SInputText :size="state.size" placeholder="1000" v-model="data.currency">
+            <SInputText
+              :size="state.size"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
+              placeholder="1000"
+              v-model="data.currency"
+            >
               <template #addon-before>
                 <SInputAddon :dropdown="dropdown1" />
               </template>
@@ -151,7 +167,13 @@ function state() {
         <div class="group">
           <div class="title">Addon Dropdown (Before / After / Disabled)</div>
           <div class="grid">
-            <SInputText :size="state.size" placeholder="mypassword" disabled v-model="data.password4">
+            <SInputText
+              :size="state.size"
+              unit-after="disabled"
+              placeholder="mypassword"
+              disabled
+              v-model="data.password4"
+            >
               <template #addon-before>
                 <SInputAddon :label="IconDotsThree" disabled />
               </template>

--- a/stories/components/SInputText.02_Addons.story.vue
+++ b/stories/components/SInputText.02_Addons.story.vue
@@ -95,7 +95,13 @@ function state() {
         <div class="group">
           <div class="title">Addon Text (Before)</div>
           <div class="grid">
-            <SInputText :size="state.size" placeholder="John Doe" v-model="data.name">
+            <SInputText
+              :size="state.size"
+              placeholder="John Doe"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
+              v-model="data.name"
+            >
               <template #addon-before>
                 <SInputAddon label="@" :clickable="false" />
               </template>
@@ -106,7 +112,13 @@ function state() {
         <div class="group">
           <div class="title">Addon Text (After)</div>
           <div class="grid">
-            <SInputText :size="state.size" placeholder="sample" v-model="data.domain">
+            <SInputText
+              :size="state.size"
+              placeholder="sample"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
+              v-model="data.domain"
+            >
               <template #addon-after>
                 <SInputAddon label=".com" :clickable="false" />
               </template>
@@ -117,7 +129,13 @@ function state() {
         <div class="group">
           <div class="title">Addon Button (Before / Text)</div>
           <div class="grid">
-            <SInputText :size="state.size" placeholder="mypassword" v-model="data.password1">
+            <SInputText
+              :size="state.size"
+              placeholder="mypassword"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
+              v-model="data.password1"
+            >
               <template #addon-before>
                 <SInputAddon label="Generate" @click="data.password1 = generatePassword()" />
               </template>
@@ -128,7 +146,13 @@ function state() {
         <div class="group">
           <div class="title">Addon Button (After / Icon)</div>
           <div class="grid">
-            <SInputText :size="state.size" placeholder="mypassword" v-model="data.password2">
+            <SInputText
+              :size="state.size"
+              placeholder="mypassword"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
+              v-model="data.password2"
+            >
               <template #addon-after>
                 <SInputAddon :label="IconLightbulb" @click="data.password2 = generatePassword()" />
               </template>
@@ -156,7 +180,13 @@ function state() {
         <div class="group">
           <div class="title">Addon Dropdown (After / Dropdown Menu)</div>
           <div class="grid">
-            <SInputText :size="state.size" placeholder="mypassword" v-model="data.password3">
+            <SInputText
+              :size="state.size"
+              placeholder="mypassword"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
+              v-model="data.password3"
+            >
               <template #addon-after>
                 <SInputAddon :label="IconDotsThree" :dropdown="dropdown2" :dropdown-caret="false" />
               </template>
@@ -169,8 +199,9 @@ function state() {
           <div class="grid">
             <SInputText
               :size="state.size"
-              unit-after="disabled"
               placeholder="mypassword"
+              :unit-before="state.unitBefore"
+              :unit-after="state.unitAfter"
               disabled
               v-model="data.password4"
             >


### PR DESCRIPTION
I added `unit-before` and `unit-after` props to `SInputText` and `SInputNumber`.

Additionally, I modified Histoire's story controls for us to test UI interactively.