### PR TITLE
feat(table): allow adding summary row

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -242,14 +242,30 @@ const options = useTable({
 
 ## Table Header & Footer
 
-The Table Header and Footer is the part where it shows additional information such as total number of records or pagnation. The header and footer gets displayed depending on it has any data to display or not. For example, header gets displayed when there's `total` or `reset` option is set.
+The Table Header and Footer is the part where it shows additional information such as total number of records or pagination. The header and footer gets displayed depending on it has any data to display or not. For example, header gets displayed when there's `total` or `reset` option is set.
 
-If you would like to diaplay or hide the header and footer regardless of the other options presense, set `boolean` to `header` or `footer` option.
+If you would like to display or hide the header and footer regardless of the other options present, set `boolean` to `header` or `footer` option.
 
 ```ts
 const options = useTable({
   header: true,
   footer: true
+})
+```
+
+## Summary Row
+
+You may define `summary` option to display a summary row at the bottom of the table. The summary row is a special row that gets displayed at the bottom of the table. It is useful to display the total of each column.
+
+```ts
+const options = useTable({
+  orders: ['name', 'amount'],
+  columns: {...},
+
+  summary: {
+    name: 'Total',
+    amount: 100
+  }
 })
 ```
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -255,7 +255,7 @@ const options = useTable({
 
 ## Summary Row
 
-You may define `summary` option to display a summary row at the bottom of the table. The summary row is a special row that gets displayed at the bottom of the table. It is useful to display the total of each column.
+You may define `summary` option to display a summary row at the bottom of the table. It is useful to display information such as the total of each column.
 
 ```ts
 const options = useTable({

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -253,14 +253,14 @@ const options = useTable({
 })
 ```
 
-## Summary Row
+## Summary row
 
-You may define `summary` option to display a summary row at the bottom of the table. It is useful to display information such as the total of each column.
+You may define `summary` option to display a summary row at the bottom of the table. It's useful to display information such as the total of each column.
 
 ```ts
 const options = useTable({
   orders: ['name', 'amount'],
-  columns: {...},
+  columns: { ... },
 
   summary: {
     name: 'Total',
@@ -268,6 +268,8 @@ const options = useTable({
   }
 })
 ```
+
+Each field defined at the `summary` option must match the key of the `columns` option, and the type of cell is applied as same as other records. For example, if the cell type of the `name` field is `text`, then the `name` field of the `summary` option will be displayed as `text` type.
 
 ## Props
 
@@ -293,14 +295,16 @@ interface Props {
 
 You may customize the styles by overriding `--table` prefixed CSS variables.
 
-### Global font style
+### Font style
 
-Use `--table-cell-font-size` and `--table-cell-font-weight` to customize the base font style in the table.
+Use `--table-cell-font-size` and `--table-cell-font-weight` to customize the base font style in the table. Also, you can use `--table-cell-summary-font-weight` to adjust the font weight of the cell added by `summary` option.
 
 ```css
 :root {
   --table-cell-font-size: 14px;
   --table-cell-font-weight: 400;
+
+  --table-cell-summary-font-weight: 600;
 }
 ```
 

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -30,6 +30,13 @@ const {
   onReset
 } = toRefs(props.options)
 
+const recordsWithSummary = computed(() => {
+  if (records?.value && summary?.value) {
+    return [...records?.value, summary?.value]
+  }
+  return records?.value ?? []
+})
+
 const head = shallowRef<HTMLElement | null>(null)
 const body = shallowRef<HTMLElement | null>(null)
 
@@ -161,7 +168,12 @@ function updateColWidth(key: string, value: string) {
           @scroll="syncBodyScroll"
         >
           <div class="block">
-            <div v-for="(record, rIndex) in records" :key="rIndex" class="row">
+            <div
+              v-for="(record, rIndex) in recordsWithSummary"
+              :key="rIndex"
+              class="row"
+              :class="rIndex === records?.length && 'summary'"
+            >
               <STableItem
                 v-for="key in orders"
                 :key="key"
@@ -175,24 +187,6 @@ function updateColWidth(key: string, value: string) {
                   :cell="columns[key].cell"
                   :value="record[key]"
                   :record="record"
-                  :records="records"
-                />
-              </STableItem>
-            </div>
-            <div v-if="summary" class="row summary">
-              <STableItem
-                v-for="key in orders"
-                :key="key"
-                :name="key"
-                :class-name="columns[key].className"
-                :width="colWidths[key]"
-              >
-                <STableCell
-                  :name="key"
-                  :class-name="columns[key].className"
-                  :cell="columns[key].cell"
-                  :value="summary[key]"
-                  :record="summary"
                   :records="records"
                 />
               </STableItem>

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -30,13 +30,6 @@ const {
   onReset
 } = toRefs(props.options)
 
-const recordsWithSummary = computed(() => {
-  if (records?.value && summary?.value) {
-    return [...records?.value, summary?.value]
-  }
-  return records?.value ?? []
-})
-
 const head = shallowRef<HTMLElement | null>(null)
 const body = shallowRef<HTMLElement | null>(null)
 
@@ -78,6 +71,12 @@ const classes = computed(() => ({
   'has-footer': showFooter.value,
   'borderless': borderless?.value
 }))
+
+const recordsWithSummary = computed(() => {
+  return (records?.value && summary?.value)
+    ? [...records?.value, summary?.value]
+    : records?.value ?? []
+})
 
 watch(() => records?.value, () => {
   headLock = true
@@ -183,6 +182,7 @@ function updateColWidth(key: string, value: string) {
               >
                 <STableCell
                   :name="key"
+                  :class="rIndex === records?.length && 'summary'"
                   :class-name="columns[key].className"
                   :cell="columns[key].cell"
                   :value="record[key]"
@@ -285,10 +285,6 @@ function updateColWidth(key: string, value: string) {
 
   .body &:last-child {
     border-bottom: 0;
-  }
-
-  &.summary {
-    --table-cell-font-weight: 600;
   }
 }
 

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -18,6 +18,7 @@ const {
   records,
   header,
   footer,
+  summary,
   total,
   page,
   perPage,
@@ -178,6 +179,24 @@ function updateColWidth(key: string, value: string) {
                 />
               </STableItem>
             </div>
+            <div v-if="summary" class="row summary">
+              <STableItem
+                v-for="key in orders"
+                :key="key"
+                :name="key"
+                :class-name="columns[key].className"
+                :width="colWidths[key]"
+              >
+                <STableCell
+                  :name="key"
+                  :class-name="columns[key].className"
+                  :cell="columns[key].cell"
+                  :value="summary[key]"
+                  :record="summary"
+                  :records="records"
+                />
+              </STableItem>
+            </div>
           </div>
         </div>
       </div>
@@ -272,6 +291,10 @@ function updateColWidth(key: string, value: string) {
 
   .body &:last-child {
     border-bottom: 0;
+  }
+
+  &.summary {
+    --table-cell-font-weight: 600;
   }
 }
 

--- a/lib/components/STableCell.vue
+++ b/lib/components/STableCell.vue
@@ -95,7 +95,11 @@ const computedCell = computed<TableCell | undefined>(() =>
   overflow: hidden;
 
   .row:hover & {
-    background-color: var(--c-bg-elv);
+    background-color: var(--c-bg-elv-1);
+  }
+
+  .summary & {
+    background-color: var(--c-bg-elv-2);
   }
 
   .STableItem:first-child & {

--- a/lib/components/STableCellDay.vue
+++ b/lib/components/STableCellDay.vue
@@ -42,5 +42,9 @@ const _value = computed(() => {
   .STableCellDay.neutral & { color: var(--c-text-1); }
   .STableCellDay.soft &    { color: var(--c-text-2); }
   .STableCellDay.mute &    { color: var(--c-text-3); }
+
+  .STableCell.summary & {
+    font-weight: var(--table-cell-summary-font-weight);
+  }
 }
 </style>

--- a/lib/components/STableCellText.vue
+++ b/lib/components/STableCellText.vue
@@ -110,6 +110,10 @@ const _iconColor = computed(() => {
   .STableCellText.link:hover &.warning { color: var(--c-warning-darker); }
   .STableCellText.link &.danger        { color: var(--c-danger); }
   .STableCellText.link:hover &.danger  { color: var(--c-danger-dark); }
+
+  .STableCell.summary & {
+    font-weight: var(--table-cell-summary-font-weight);
+  }
 }
 
 .icon {

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -34,10 +34,6 @@ export type TableColumns<
     : TableColumn<undefined, R>
 }
 
-export type TableSummary<T> = {
-  [P in keyof T]?: T[P] | null | undefined
-}
-
 export interface TableColumn<V, R> {
   label?: string
   className?: string
@@ -141,6 +137,10 @@ export interface TableCellComponent extends TableCellBase {
   type: 'component'
   component: Component
   props?: Record<string, any>
+}
+
+export type TableSummary<T> = {
+  [P in keyof T]?: T[P] | null | undefined
 }
 
 export interface UseTableOptions<O extends string, R extends Record<string, any>> {

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -4,6 +4,10 @@ import { reactive } from 'vue'
 import type { Day } from '../support/Day'
 import type { DropdownSection } from './Dropdown'
 
+type Optional<T> = {
+  [P in keyof T]?: T[P] | null | undefined
+}
+
 export interface Table<
   O extends string = any,
   R extends Record<string, any> = any
@@ -13,6 +17,7 @@ export interface Table<
   records?: R[] | null
   header?: boolean
   footer?: boolean
+  summary?: Optional<R> | null
   total?: number | null
   page?: number | null
   perPage?: number | null
@@ -144,6 +149,7 @@ export interface UseTableOptions<O extends string, R extends Record<string, any>
   records?: MaybeRef<R[] | null | undefined>
   header?: MaybeRef<boolean | undefined>
   footer?: MaybeRef<boolean | undefined>
+  summary?: MaybeRef<Optional<R> | null | undefined>
   total?: MaybeRef<number | null | undefined>
   page?: MaybeRef<number | null | undefined>
   perPage?: MaybeRef<number | null | undefined>

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -4,10 +4,6 @@ import { reactive } from 'vue'
 import type { Day } from '../support/Day'
 import type { DropdownSection } from './Dropdown'
 
-type Optional<T> = {
-  [P in keyof T]?: T[P] | null | undefined
-}
-
 export interface Table<
   O extends string = any,
   R extends Record<string, any> = any
@@ -17,7 +13,7 @@ export interface Table<
   records?: R[] | null
   header?: boolean
   footer?: boolean
-  summary?: Optional<R> | null
+  summary?: TableSummary<R> | null
   total?: number | null
   page?: number | null
   perPage?: number | null
@@ -36,6 +32,10 @@ export type TableColumns<
   [K in O]: K extends keyof R
     ? TableColumn<R[K], R>
     : TableColumn<undefined, R>
+}
+
+export type TableSummary<T> = {
+  [P in keyof T]?: T[P] | null | undefined
 }
 
 export interface TableColumn<V, R> {
@@ -149,7 +149,7 @@ export interface UseTableOptions<O extends string, R extends Record<string, any>
   records?: MaybeRef<R[] | null | undefined>
   header?: MaybeRef<boolean | undefined>
   footer?: MaybeRef<boolean | undefined>
-  summary?: MaybeRef<Optional<R> | null | undefined>
+  summary?: MaybeRef<TableSummary<R> | null | undefined>
   total?: MaybeRef<number | null | undefined>
   page?: MaybeRef<number | null | undefined>
   perPage?: MaybeRef<number | null | undefined>

--- a/lib/styles/variables.css
+++ b/lib/styles/variables.css
@@ -639,6 +639,8 @@
 
   --table-cell-font-size: 14px;
   --table-cell-font-weight: 400;
+
+  --table-cell-summary-font-weight: 600;
 }
 
 /**

--- a/tests/components/STable.spec.ts
+++ b/tests/components/STable.spec.ts
@@ -23,4 +23,30 @@ describe('components/STable', () => {
     expect(wrapper.find('.STable .head .col-item_2 .label').text()).toBe('item_2')
     expect(wrapper.find('.STable .head .col-item_3 .label').text()).toBe('item_3')
   })
+
+  test('it display summary row at bottom', () => {
+    const table = useTable({
+      orders: ['name', 'amount'],
+      columns: {
+        name: { label: 'Name' },
+        amount: { label: 'Amount' }
+      },
+      records: [
+        { name: 'Item 1', amount: 10 },
+        { name: 'Item 2', amount: 90 }
+      ],
+      summary: {
+        name: 'Total', amount: 100
+      }
+    })
+
+    const wrapper = mount(STable, {
+      props: {
+        options: table
+      }
+    })
+
+    expect(wrapper.findAll('.summary .text')[0].text()).toBe('Total')
+    expect(wrapper.findAll('.summary .text')[1].text()).toBe('100')
+  })
 })

--- a/tests/components/STable.spec.ts
+++ b/tests/components/STable.spec.ts
@@ -24,7 +24,7 @@ describe('components/STable', () => {
     expect(wrapper.find('.STable .head .col-item_3 .label').text()).toBe('item_3')
   })
 
-  test('it display summary row at bottom', () => {
+  test('it displays summary row at bottom', () => {
     const table = useTable({
       orders: ['name', 'amount'],
       columns: {


### PR DESCRIPTION
fixes #230

- Sorting and filtering does not affect the summary row (always shown).
- ~~Pagination is not working (at least not on Histoire), so not sure how it will play with that 👀~~
  - `onPrev`/`onNext` is empty there, will check if it works fine or not

Also, on filtering, there are a bunch of errors (not related to this PR):

<img width="701" alt="image" src="https://user-images.githubusercontent.com/40380293/227858906-0645b439-9746-4637-984e-dfcd53cab6b2.png">

TODO:
- [x] Update docs
- [x] Add tests