### PR TITLE
fix(table): fix wrong hover color

### DIFF
--- a/lib/components/STableCell.vue
+++ b/lib/components/STableCell.vue
@@ -95,7 +95,7 @@ const computedCell = computed<TableCell | undefined>(() =>
   overflow: hidden;
 
   .row:hover & {
-    background-color: var(--c-bg-elv-1);
+    background-color: var(--c-bg-elv-2);
   }
 
   .summary & {


### PR DESCRIPTION
The title explains everything.
I checked the color in Histoire and it looks good to me.