### PR TITLE
perf(table): use virtualization and reduce reactivity overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /docs/.vitepress/dist
 /dist
 /node_modules
+*.log
+*.tgz

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import { Theme } from 'vitepress'
 import VitePressTheme from 'vitepress/theme'
 
+import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 import 'sefirot/styles/variables.css'
 import './styles.css'
 

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -345,6 +345,7 @@ function getCell(key: string, index: number) {
     border-radius: 0;
   }
 
+  scrollbar-width: none;
   &::-webkit-scrollbar {
     display: none;
   }

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -352,13 +352,13 @@ function getCell(key: string, index: number) {
 
 .container.body {
   border-radius: 6px 6px var(--table-border-radius) var(--table-border-radius);
+  line-height: 0;
 
   .STable.has-footer & {
     border-radius: 0;
   }
 
   .block {
-    margin-bottom: -5px;
     max-height: var(--table-max-height, 100%);
     overflow-y: auto;
   }

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -10,6 +10,7 @@ import {
   watch
 } from 'vue'
 import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller'
+import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 import type { Table } from '../composables/Table'
 import SSpinner from './SSpinner.vue'
 import STableCell from './STableCell.vue'

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -351,6 +351,7 @@ function getCell(key: string, index: number) {
 }
 
 .container.body {
+  display: flex;
   border-radius: 6px 6px var(--table-border-radius) var(--table-border-radius);
 
   .STable.has-footer & {
@@ -358,7 +359,6 @@ function getCell(key: string, index: number) {
   }
 
   .block {
-    margin-bottom: -5px;
     max-height: var(--table-max-height, 65vh);
     overflow-y: auto;
   }

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -242,6 +242,7 @@ function getCell(key: string, index: number) {
             key-field="__index"
             class="block"
             :style="blockWidth ? { width: `${blockWidth}px` } : undefined"
+            :prerender="Math.min(10, recordsWithSummary.length)"
           >
             <template #default="{ item: record, index: rIndex, active }">
               <DynamicScrollerItem

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 import { useResizeObserver } from '@vueuse/core'
-import { computed, nextTick, reactive, ref, shallowRef, unref, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  reactive,
+  ref,
+  shallowRef,
+  unref,
+  watch
+} from 'vue'
 import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller'
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 import type { Table } from '../composables/Table'
@@ -241,7 +249,9 @@ function getCell(key: string, index: number) {
                   :class="
                     isSummary(rIndex)
                       ? 'summary'
-                      : lastRow(rIndex) ? 'last' : ''
+                      : lastRow(rIndex)
+                        ? 'last'
+                        : ''
                   "
                 >
                   <STableItem
@@ -268,10 +278,11 @@ function getCell(key: string, index: number) {
         </div>
       </div>
 
-      <div v-if="!unref(options.loading) && unref(options.records) && !unref(options.records)?.length" class="missing">
-        <p class="missing-text">
-          No results matched your search.
-        </p>
+      <div
+        v-if="!unref(options.loading) && unref(options.records) && !unref(options.records)!.length"
+        class="missing"
+      >
+        <p class="missing-text">No results matched your search.</p>
       </div>
 
       <div v-if="unref(options.loading)" class="loading">

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -359,7 +359,7 @@ function getCell(key: string, index: number) {
   }
 
   .block {
-    max-height: var(--table-max-height, 65vh);
+    max-height: var(--table-max-height, 100%);
     overflow-y: auto;
   }
 }

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -351,7 +351,6 @@ function getCell(key: string, index: number) {
 }
 
 .container.body {
-  display: flex;
   border-radius: 6px 6px var(--table-border-radius) var(--table-border-radius);
 
   .STable.has-footer & {
@@ -359,6 +358,7 @@ function getCell(key: string, index: number) {
   }
 
   .block {
+    margin-bottom: -5px;
     max-height: var(--table-max-height, 100%);
     overflow-y: auto;
   }

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -261,9 +261,7 @@ function getCell(key: string, index: number) {
                   :class="
                     isSummary(rIndex)
                       ? 'summary'
-                      : lastRow(rIndex)
-                      ? 'last'
-                      : ''
+                      : lastRow(rIndex) ? 'last' : ''
                   "
                 >
                   <STableItem

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -85,7 +85,12 @@ const recordsWithSummary = computed(() => {
   const records = unref(props.options.records) ?? []
   const summary = unref(props.options.summary)
 
-  return summary ? [...records, summary] : records
+  const res = summary ? [...records, summary] : records
+  res.forEach((record, index) => {
+    record.__index = index
+  })
+
+  return res
 })
 
 watch(() => props.options.records, () => {
@@ -234,7 +239,7 @@ function getCell(key: string, index: number) {
           <DynamicScroller
             :items="recordsWithSummary"
             :min-item-size="40"
-            :key-field="unref(options.orders)[0]"
+            key-field="__index"
             class="block"
             :style="blockWidth ? { width: `${blockWidth}px` } : undefined"
           >

--- a/lib/components/STableItem.vue
+++ b/lib/components/STableItem.vue
@@ -9,7 +9,12 @@ defineProps<{
 <template>
   <div
     class="STableItem"
-    :class="[className, `col-${name}`, { adjusted: width }, { auto: width === 'auto' }]"
+    :class="[
+      className,
+      `col-${name}`,
+      { adjusted: width },
+      { auto: width === 'auto' }
+    ]"
   >
     <slot />
   </div>

--- a/lib/components/STableItem.vue
+++ b/lib/components/STableItem.vue
@@ -1,21 +1,23 @@
 <script setup lang="ts">
-defineProps<{
+import { computed } from 'vue'
+
+const props = defineProps<{
   name: string
   className?: string
   width?: string
 }>()
+
+const classes = computed(() => [
+  'STableItem',
+  props.className,
+  `col-${props.name}`,
+  { adjusted: props.width },
+  { auto: props.width === 'auto' }
+])
 </script>
 
 <template>
-  <div
-    class="STableItem"
-    :class="[
-      className,
-      `col-${name}`,
-      { adjusted: width },
-      { auto: width === 'auto' }
-    ]"
-  >
+  <div :class="classes">
     <slot />
   </div>
 </template>

--- a/lib/components/STableItem.vue
+++ b/lib/components/STableItem.vue
@@ -9,7 +9,7 @@ defineProps<{
 <template>
   <div
     class="STableItem"
-    :class="[className, `col-${name}`, { adjusted: width }]"
+    :class="[className, `col-${name}`, { adjusted: width }, { auto: width === 'auto' }]"
   >
     <slot />
   </div>
@@ -32,8 +32,11 @@ defineProps<{
 
   &.adjusted {
     width: v-bind(width) !important;
-    min-width: v-bind(width) !important;
     max-width: v-bind(width) !important;
+  }
+
+  &.adjusted:not(.auto) {
+    min-width: v-bind(width) !important;
   }
 }
 </style>

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -4,9 +4,9 @@ import type { Day } from '../support/Day'
 import type { DropdownSection } from './Dropdown'
 
 export interface Table<
-O extends string = any,
-R extends Record<string, any> = any,
-SR extends Record<string, any> = any
+  O extends string = any,
+  R extends Record<string, any> = any,
+  SR extends Record<string, any> = any
 > {
   orders: MaybeRef<O[]>
   columns: MaybeRef<TableColumns<O, R, SR>>
@@ -146,6 +146,6 @@ export function useTable<
   O extends string,
   R extends Record<string, any>,
   SR extends Record<string, any>
->(options: Table<O, R, SR>) {
+>(options: Table<O, R, SR>): Table<O, R, SR> {
   return options
 }

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -1,6 +1,6 @@
 import type { MaybeRef } from '@vueuse/core'
 import type { Component } from 'vue'
-import { reactive } from 'vue'
+import { shallowReactive } from 'vue'
 import type { Day } from '../support/Day'
 import type { DropdownSection } from './Dropdown'
 
@@ -172,5 +172,5 @@ export function useTable<
 >(
   options: UseTableOptions<O, R, SR>
 ): Table<O, R, SR> {
-  return reactive(options) as Table<O, R, SR>
+  return shallowReactive(options) as Table<O, R, SR>
 }

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -1,26 +1,25 @@
 import type { MaybeRef } from '@vueuse/core'
 import type { Component } from 'vue'
-import { shallowReactive } from 'vue'
 import type { Day } from '../support/Day'
 import type { DropdownSection } from './Dropdown'
 
 export interface Table<
-  O extends string = any,
-  R extends Record<string, any> = any,
-  SR extends Record<string, any> = any
+O extends string = any,
+R extends Record<string, any> = any,
+SR extends Record<string, any> = any
 > {
-  orders: O[]
-  columns: TableColumns<O, R, SR>
-  records?: R[] | null
-  header?: boolean
-  footer?: boolean
-  summary?: SR | null
-  total?: number | null
-  page?: number | null
-  perPage?: number | null
-  reset?: boolean
-  borderless?: boolean
-  loading?: boolean
+  orders: MaybeRef<O[]>
+  columns: MaybeRef<TableColumns<O, R, SR>>
+  records?: MaybeRef<R[] | null | undefined>
+  header?: MaybeRef<boolean | undefined>
+  footer?: MaybeRef<boolean | undefined>
+  summary?: MaybeRef<SR | null | undefined>
+  total?: MaybeRef<number | null | undefined>
+  page?: MaybeRef<number | null | undefined>
+  perPage?: MaybeRef<number | null | undefined>
+  reset?: MaybeRef<boolean | undefined>
+  borderless?: MaybeRef<boolean>
+  loading?: MaybeRef<boolean | undefined>
   onPrev?(): void
   onNext?(): void
   onReset?(): void
@@ -143,34 +142,10 @@ export interface TableCellComponent extends TableCellBase {
   props?: Record<string, any>
 }
 
-export interface UseTableOptions<
-  O extends string,
-  R extends Record<string, any>,
-  SR extends Record<string, any>
-> {
-  orders: MaybeRef<O[]>
-  columns: MaybeRef<TableColumns<O, R, SR>>
-  records?: MaybeRef<R[] | null | undefined>
-  header?: MaybeRef<boolean | undefined>
-  footer?: MaybeRef<boolean | undefined>
-  summary?: MaybeRef<SR | null | undefined>
-  total?: MaybeRef<number | null | undefined>
-  page?: MaybeRef<number | null | undefined>
-  perPage?: MaybeRef<number | null | undefined>
-  reset?: MaybeRef<boolean | undefined>
-  borderless?: boolean
-  loading?: MaybeRef<boolean | undefined>
-  onPrev?(): void
-  onNext?(): void
-  onReset?(): void
-}
-
 export function useTable<
   O extends string,
   R extends Record<string, any>,
   SR extends Record<string, any>
->(
-  options: UseTableOptions<O, R, SR>
-): Table<O, R, SR> {
-  return shallowReactive(options) as Table<O, R, SR>
+>(options: Table<O, R, SR>) {
+  return options
 }

--- a/lib/styles/bootstrap.css
+++ b/lib/styles/bootstrap.css
@@ -1,5 +1,4 @@
 @import "normalize.css";
 @import "v-calendar/dist/style.css";
-@import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 @import "./variables";
 @import "./base";

--- a/lib/styles/bootstrap.css
+++ b/lib/styles/bootstrap.css
@@ -1,4 +1,5 @@
 @import "normalize.css";
 @import "v-calendar/dist/style.css";
+@import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 @import "./variables";
 @import "./base";

--- a/lib/types/shims.d.ts
+++ b/lib/types/shims.d.ts
@@ -1,3 +1,9 @@
 declare module 'v-calendar' {
   export const DatePicker: any
 }
+
+declare module 'vue-virtual-scroller' {
+  export const RecycleScroller: any
+  export const DynamicScroller: any
+  export const DynamicScrollerItem: any
+}

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "typescript": "^4.9.4",
     "v-calendar": "3.0.0-alpha.8",
     "vite": "^4.1.4",
-    "vitepress": "1.0.0-alpha.50",
+    "vitepress": "1.0.0-alpha.65",
     "vitest": "^0.29.2",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "typescript": "^4.9.4",
     "v-calendar": "^3.0.0-alpha.8",
     "vue": "^3.2.47",
-    "vue-router": "^4.1.6"
+    "vue-router": "^4.1.6",
+    "vue-virtual-scroller": "^2.0.0-beta.8"
   },
   "dependencies": {
     "dayjs": "^1.11.7"
@@ -100,7 +101,8 @@
     "vitest": "^0.29.2",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6",
-    "vue-tsc": "^1.2.0"
+    "vue-tsc": "^1.2.0",
+    "vue-virtual-scroller": "^2.0.0-beta.8"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ specifiers:
   typescript: ^4.9.4
   v-calendar: 3.0.0-alpha.8
   vite: ^4.1.4
-  vitepress: 1.0.0-alpha.50
+  vitepress: 1.0.0-alpha.65
   vitest: ^0.29.2
   vue: ^3.2.47
   vue-router: ^4.1.6
@@ -79,7 +79,7 @@ devDependencies:
   typescript: 4.9.4
   v-calendar: 3.0.0-alpha.8_vue@3.2.47
   vite: 4.1.4_@types+node@18.14.6
-  vitepress: 1.0.0-alpha.50_@types+node@18.14.6
+  vitepress: 1.0.0-alpha.65_@types+node@18.14.6
   vitest: 0.29.2_jsdom@21.1.1
   vue: 3.2.47
   vue-router: 4.1.6_vue@3.2.47
@@ -452,8 +452,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm/0.17.16:
+    resolution: {integrity: sha512-baLqRpLe4JnKrUXLJChoTN0iXZH7El/mu58GE3WIA6/H834k0XWvLRmGLG8y8arTRS9hJJibPnF0tiGhmWeZgw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64/0.16.14:
     resolution: {integrity: sha512-hTqB6Iq13pW4xaydeqQrs8vPntUnMjbkq+PgGiBMi69eYk74naG2ftHWqKnxn874kNrt5Or3rQ0PJutx2doJuQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64/0.17.16:
+    resolution: {integrity: sha512-QX48qmsEZW+gcHgTmAj+x21mwTz8MlYQBnzF6861cNdQGvj2jzzFjqH0EBabrIa/WVZ2CHolwMoqxVryqKt8+Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -470,8 +488,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-x64/0.17.16:
+    resolution: {integrity: sha512-G4wfHhrrz99XJgHnzFvB4UwwPxAWZaZBOFXh+JH1Duf1I4vIVfuYY9uVLpx4eiV2D/Jix8LJY+TAdZ3i40tDow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-arm64/0.16.14:
     resolution: {integrity: sha512-vrlaP81IuwPaw1fyX8fHCmivP3Gr73ojVEZy+oWJLAiZVcG8o8Phwun/XDnYIFUHxIoUnMFEpg9o38MIvlw8zw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64/0.17.16:
+    resolution: {integrity: sha512-/Ofw8UXZxuzTLsNFmz1+lmarQI6ztMZ9XktvXedTbt3SNWDn0+ODTwxExLYQ/Hod91EZB4vZPQJLoqLF0jvEzA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -488,8 +524,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-x64/0.17.16:
+    resolution: {integrity: sha512-SzBQtCV3Pdc9kyizh36Ol+dNVhkDyIrGb/JXZqFq8WL37LIyrXU0gUpADcNV311sCOhvY+f2ivMhb5Tuv8nMOQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-arm64/0.16.14:
     resolution: {integrity: sha512-xRM1RQsazSvL42BNa5XC7ytD4ZDp0ZyJcH7aB0SlYUcHexJUKiDNKR7dlRVlpt6W0DvoRPU2nWK/9/QWS4u2fw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64/0.17.16:
+    resolution: {integrity: sha512-ZqftdfS1UlLiH1DnS2u3It7l4Bc3AskKeu+paJSfk7RNOMrOxmeFDhLTMQqMxycP1C3oj8vgkAT6xfAuq7ZPRA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -506,8 +560,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-x64/0.17.16:
+    resolution: {integrity: sha512-rHV6zNWW1tjgsu0dKQTX9L0ByiJHHLvQKrWtnz8r0YYJI27FU3Xu48gpK2IBj1uCSYhJ+pEk6Y0Um7U3rIvV8g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm/0.16.14:
     resolution: {integrity: sha512-X6xULug66ulrr4IzrW7qq+eq9n4MtEyagdWvj4o4cmWr+JXOT47atjpDF9j5M2zHY0UQBmqnHhwl+tXpkpIb2w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm/0.17.16:
+    resolution: {integrity: sha512-n4O8oVxbn7nl4+m+ISb0a68/lcJClIbaGAoXwqeubj/D1/oMMuaAXmJVfFlRjJLu/ZvHkxoiFJnmbfp4n8cdSw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -524,8 +596,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64/0.17.16:
+    resolution: {integrity: sha512-8yoZhGkU6aHu38WpaM4HrRLTFc7/VVD9Q2SvPcmIQIipQt2I/GMTZNdEHXoypbbGao5kggLcxg0iBKjo0SQYKA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ia32/0.16.14:
     resolution: {integrity: sha512-oBZkcZ56UZDFCAfE3Fd/Jgy10EoS7Td77NzNGenM+HSY8BkdQAcI9VF9qgwdOLZ+tuftWD7UqZ26SAhtvA3XhA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32/0.17.16:
+    resolution: {integrity: sha512-9ZBjlkdaVYxPNO8a7OmzDbOH9FMQ1a58j7Xb21UfRU29KcEEU3VTHk+Cvrft/BNv0gpWJMiiZ/f4w0TqSP0gLA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -542,8 +632,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-loong64/0.17.16:
+    resolution: {integrity: sha512-TIZTRojVBBzdgChY3UOG7BlPhqJz08AL7jdgeeu+kiObWMFzGnQD7BgBBkWRwOtKR1i2TNlO7YK6m4zxVjjPRQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-mips64el/0.16.14:
     resolution: {integrity: sha512-kJ2iEnikUOdC1SiTGbH0fJUgpZwa0ITDTvj9EHf9lm3I0hZ4Yugsb3M6XSl696jVxrEocLe519/8CbSpQWFSrg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el/0.17.16:
+    resolution: {integrity: sha512-UPeRuFKCCJYpBbIdczKyHLAIU31GEm0dZl1eMrdYeXDH+SJZh/i+2cAmD3A1Wip9pIc5Sc6Kc5cFUrPXtR0XHA==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -560,8 +668,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ppc64/0.17.16:
+    resolution: {integrity: sha512-io6yShgIEgVUhExJejJ21xvO5QtrbiSeI7vYUnr7l+v/O9t6IowyhdiYnyivX2X5ysOVHAuyHW+Wyi7DNhdw6Q==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-riscv64/0.16.14:
     resolution: {integrity: sha512-fdwP9Dc+Kx/cZwp9T9kNqjAE/PQjfrxbio4rZ3XnC3cVvZBjuxpkiyu/tuCwt6SbAK5th6AYNjFdEV9kGC020A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64/0.17.16:
+    resolution: {integrity: sha512-WhlGeAHNbSdG/I2gqX2RK2gfgSNwyJuCiFHMc8s3GNEMMHUI109+VMBfhVqRb0ZGzEeRiibi8dItR3ws3Lk+cA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -578,8 +704,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-s390x/0.17.16:
+    resolution: {integrity: sha512-gHRReYsJtViir63bXKoFaQ4pgTyah4ruiMRQ6im9YZuv+gp3UFJkNTY4sFA73YDynmXZA6hi45en4BGhNOJUsw==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-x64/0.16.14:
     resolution: {integrity: sha512-TomtswAuzBf2NnddlrS4W01Tv85RM9YtATB3OugY6On0PLM4Ksz5qvQKVAjtzPKoLgL1FiZtfc8mkZc4IgoMEA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64/0.17.16:
+    resolution: {integrity: sha512-mfiiBkxEbUHvi+v0P+TS7UnA9TeGXR48aK4XHkTj0ZwOijxexgMF01UDFaBX7Q6CQsB0d+MFNv9IiXbIHTNd4g==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -596,8 +740,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64/0.17.16:
+    resolution: {integrity: sha512-n8zK1YRDGLRZfVcswcDMDM0j2xKYLNXqei217a4GyBxHIuPMGrrVuJ+Ijfpr0Kufcm7C1k/qaIrGy6eG7wvgmA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-x64/0.16.14:
     resolution: {integrity: sha512-/Jl8XVaWEZNu9rZw+n792GIBupQwHo6GDoapHSb/2xp/Ku28eK6QpR2O9cPBkzHH4OOoMH0LB6zg/qczJ5TTGg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64/0.17.16:
+    resolution: {integrity: sha512-lEEfkfsUbo0xC47eSTBqsItXDSzwzwhKUSsVaVjVji07t8+6KA5INp2rN890dHZeueXJAI8q0tEIfbwVRYf6Ew==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -614,8 +776,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64/0.17.16:
+    resolution: {integrity: sha512-jlRjsuvG1fgGwnE8Afs7xYDnGz0dBgTNZfgCK6TlvPH3Z13/P5pi6I57vyLE8qZYLrGVtwcm9UbUx1/mZ8Ukag==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-arm64/0.16.14:
     resolution: {integrity: sha512-SjlM7AHmQVTiGBJE/nqauY1aDh80UBsXZ94g4g60CDkrDMseatiqALVcIuElg4ZSYzJs8hsg5W6zS2zLpZTVgg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64/0.17.16:
+    resolution: {integrity: sha512-TzoU2qwVe2boOHl/3KNBUv2PNUc38U0TNnzqOAcgPiD/EZxT2s736xfC2dYQbszAwo4MKzzwBV0iHjhfjxMimg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -632,8 +812,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32/0.17.16:
+    resolution: {integrity: sha512-B8b7W+oo2yb/3xmwk9Vc99hC9bNolvqjaTZYEfMQhzdpBsjTvZBlXQ/teUE55Ww6sg//wlcDjOaqldOKyigWdA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64/0.16.14:
     resolution: {integrity: sha512-ED1UpWcM6lAbalbbQ9TrGqJh4Y9TaASUvu8bI/0mgJcxhSByJ6rbpgqRhxYMaQ682WfA71nxUreaTO7L275zrw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64/0.17.16:
+    resolution: {integrity: sha512-xJ7OH/nanouJO9pf03YsL9NAFQBHd8AqfrQd7Pf5laGyyTt/gToul6QYOA/i5i/q8y9iaM5DQFNTgpi995VkOg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -1105,6 +1303,17 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 4.1.4_@types+node@18.14.6
+      vue: 3.2.47
+    dev: true
+
+  /@vitejs/plugin-vue/4.1.0_vite@4.2.1+vue@3.2.47:
+    resolution: {integrity: sha512-++9JOAFdcXI3lyer9UKUV4rfoQ3T1RN8yDqoCLar86s0xQct5yblxAE+yWgRnU5/0FOlVCpTZpYSBV/bGWrSrQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.0.0
+      vue: ^3.2.25
+    dependencies:
+      vite: 4.2.1_@types+node@18.14.6
       vue: 3.2.47
     dev: true
 
@@ -2441,6 +2650,36 @@ packages:
       '@esbuild/win32-arm64': 0.16.14
       '@esbuild/win32-ia32': 0.16.14
       '@esbuild/win32-x64': 0.16.14
+    dev: true
+
+  /esbuild/0.17.16:
+    resolution: {integrity: sha512-aeSuUKr9aFVY9Dc8ETVELGgkj4urg5isYx8pLf4wlGgB0vTFjxJQdHnNH6Shmx4vYYrOTLCHtRI5i1XZ9l2Zcg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.16
+      '@esbuild/android-arm64': 0.17.16
+      '@esbuild/android-x64': 0.17.16
+      '@esbuild/darwin-arm64': 0.17.16
+      '@esbuild/darwin-x64': 0.17.16
+      '@esbuild/freebsd-arm64': 0.17.16
+      '@esbuild/freebsd-x64': 0.17.16
+      '@esbuild/linux-arm': 0.17.16
+      '@esbuild/linux-arm64': 0.17.16
+      '@esbuild/linux-ia32': 0.17.16
+      '@esbuild/linux-loong64': 0.17.16
+      '@esbuild/linux-mips64el': 0.17.16
+      '@esbuild/linux-ppc64': 0.17.16
+      '@esbuild/linux-riscv64': 0.17.16
+      '@esbuild/linux-s390x': 0.17.16
+      '@esbuild/linux-x64': 0.17.16
+      '@esbuild/netbsd-x64': 0.17.16
+      '@esbuild/openbsd-x64': 0.17.16
+      '@esbuild/sunos-x64': 0.17.16
+      '@esbuild/win32-arm64': 0.17.16
+      '@esbuild/win32-ia32': 0.17.16
+      '@esbuild/win32-x64': 0.17.16
     dev: true
 
   /escalade/3.1.1:
@@ -5617,18 +5856,52 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitepress/1.0.0-alpha.50_@types+node@18.14.6:
-    resolution: {integrity: sha512-6EdT6JIiHRD7KatKMfxCJ3J7aHlkMp67ZEcfYrMTLKAJ+K+qWs2p427udMHSenCOzVNLIikEC5v/rP3GOGWubQ==}
+  /vite/4.2.1_@types+node@18.14.6:
+    resolution: {integrity: sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.14.6
+      esbuild: 0.17.16
+      postcss: 8.4.21
+      resolve: 1.22.1
+      rollup: 3.18.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vitepress/1.0.0-alpha.65_@types+node@18.14.6:
+    resolution: {integrity: sha512-iGWC0AQC6WrfRZTJf5+TiGG4o8PLhqIJNyai8NVxZCY9YpmMJhddvQeqqjJdQniF/LQK/hQ5nQZ9HgSZDGRPGQ==}
     hasBin: true
     dependencies:
       '@docsearch/css': 3.3.3
       '@docsearch/js': 3.3.3
-      '@vitejs/plugin-vue': 4.0.0_vite@4.1.4+vue@3.2.47
+      '@vitejs/plugin-vue': 4.1.0_vite@4.2.1+vue@3.2.47
       '@vue/devtools-api': 6.5.0
       '@vueuse/core': 9.13.0_vue@3.2.47
       body-scroll-lock: 4.0.0-beta.0
       shiki: 0.14.1
-      vite: 4.1.4_@types+node@18.14.6
+      vite: 4.2.1_@types+node@18.14.6
       vue: 3.2.47
     transitivePeerDependencies:
       - '@algolia/client-search'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,7 @@ specifiers:
   vue: ^3.2.47
   vue-router: ^4.1.6
   vue-tsc: ^1.2.0
+  vue-virtual-scroller: ^2.0.0-beta.8
 
 dependencies:
   dayjs: 1.11.7
@@ -83,6 +84,7 @@ devDependencies:
   vue: 3.2.47
   vue-router: 4.1.6_vue@3.2.47
   vue-tsc: 1.2.0_typescript@4.9.4
+  vue-virtual-scroller: 2.0.0-beta.8_vue@3.2.47
 
 packages:
 
@@ -4207,6 +4209,10 @@ packages:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
     dev: true
 
+  /mitt/2.1.0:
+    resolution: {integrity: sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==}
+    dev: true
+
   /mlly/1.0.0:
     resolution: {integrity: sha512-QL108Hwt+u9bXdWgOI0dhzZfACovn5Aen4Xvc8Jasd9ouRH4NjnrXEiyP3nVvJo91zPlYjVRckta0Nt2zfoR6g==}
     dependencies:
@@ -5735,6 +5741,22 @@ packages:
       - supports-color
     dev: true
 
+  /vue-observe-visibility/2.0.0-alpha.1_vue@3.2.47:
+    resolution: {integrity: sha512-flFbp/gs9pZniXR6fans8smv1kDScJ8RS7rEpMjhVabiKeq7Qz3D9+eGsypncjfIyyU84saU88XZ0zjbD6Gq/g==}
+    peerDependencies:
+      vue: ^3.0.0
+    dependencies:
+      vue: 3.2.47
+    dev: true
+
+  /vue-resize/2.0.0-alpha.1_vue@3.2.47:
+    resolution: {integrity: sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==}
+    peerDependencies:
+      vue: ^3.0.0
+    dependencies:
+      vue: 3.2.47
+    dev: true
+
   /vue-router/4.1.6_vue@3.2.47:
     resolution: {integrity: sha512-DYWYwsG6xNPmLq/FmZn8Ip+qrhFEzA14EI12MsMgVxvHFDYvlr4NXpVF5hrRH1wVcDP8fGi5F4rxuJSl8/r+EQ==}
     peerDependencies:
@@ -5760,6 +5782,17 @@ packages:
       '@volar/vue-language-core': 1.2.0
       '@volar/vue-typescript': 1.2.0
       typescript: 4.9.4
+    dev: true
+
+  /vue-virtual-scroller/2.0.0-beta.8_vue@3.2.47:
+    resolution: {integrity: sha512-b8/f5NQ5nIEBRTNi6GcPItE4s7kxNHw2AIHLtDp+2QvqdTjVN0FgONwX9cr53jWRgnu+HRLPaWDOR2JPI5MTfQ==}
+    peerDependencies:
+      vue: ^3.2.0
+    dependencies:
+      mitt: 2.1.0
+      vue: 3.2.47
+      vue-observe-visibility: 2.0.0-alpha.1_vue@3.2.47
+      vue-resize: 2.0.0-alpha.1_vue@3.2.47
     dev: true
 
   /vue/3.2.47:

--- a/tests/components/STable.spec.ts
+++ b/tests/components/STable.spec.ts
@@ -24,31 +24,29 @@ describe('components/STable', () => {
     expect(wrapper.find('.STable .head .col-item_3 .label').text()).toBe('item_3')
   })
 
-  // FIXME: Does not work because of virtualization
-  //
-  // test('it displays summary row at bottom', () => {
-  //   const table = useTable({
-  //     orders: ['name', 'amount'],
-  //     columns: {
-  //       name: { label: 'Name' },
-  //       amount: { label: 'Amount' }
-  //     },
-  //     records: [
-  //       { name: 'Item 1', amount: 10 },
-  //       { name: 'Item 2', amount: 90 }
-  //     ],
-  //     summary: {
-  //       name: 'Total', amount: 100
-  //     }
-  //   })
+  test('it displays summary row at bottom', () => {
+    const table = useTable({
+      orders: ['name', 'amount'],
+      columns: {
+        name: { label: 'Name' },
+        amount: { label: 'Amount' }
+      },
+      records: [
+        { name: 'Item 1', amount: 10 },
+        { name: 'Item 2', amount: 90 }
+      ],
+      summary: {
+        name: 'Total', amount: 100
+      }
+    })
 
-  //   const wrapper = mount(STable, {
-  //     props: {
-  //       options: table
-  //     }
-  //   })
+    const wrapper = mount(STable, {
+      props: {
+        options: table
+      }
+    })
 
-  //   expect(wrapper.findAll('.summary .text')[0].text()).toBe('Total')
-  //   expect(wrapper.findAll('.summary .text')[1].text()).toBe('100')
-  // })
+    expect(wrapper.findAll('.summary .text')[0].text()).toBe('Total')
+    expect(wrapper.findAll('.summary .text')[1].text()).toBe('100')
+  })
 })

--- a/tests/components/STable.spec.ts
+++ b/tests/components/STable.spec.ts
@@ -24,29 +24,31 @@ describe('components/STable', () => {
     expect(wrapper.find('.STable .head .col-item_3 .label').text()).toBe('item_3')
   })
 
-  test('it displays summary row at bottom', () => {
-    const table = useTable({
-      orders: ['name', 'amount'],
-      columns: {
-        name: { label: 'Name' },
-        amount: { label: 'Amount' }
-      },
-      records: [
-        { name: 'Item 1', amount: 10 },
-        { name: 'Item 2', amount: 90 }
-      ],
-      summary: {
-        name: 'Total', amount: 100
-      }
-    })
+  // FIXME: Does not work because of virtualization
+  //
+  // test('it displays summary row at bottom', () => {
+  //   const table = useTable({
+  //     orders: ['name', 'amount'],
+  //     columns: {
+  //       name: { label: 'Name' },
+  //       amount: { label: 'Amount' }
+  //     },
+  //     records: [
+  //       { name: 'Item 1', amount: 10 },
+  //       { name: 'Item 2', amount: 90 }
+  //     ],
+  //     summary: {
+  //       name: 'Total', amount: 100
+  //     }
+  //   })
 
-    const wrapper = mount(STable, {
-      props: {
-        options: table
-      }
-    })
+  //   const wrapper = mount(STable, {
+  //     props: {
+  //       options: table
+  //     }
+  //   })
 
-    expect(wrapper.findAll('.summary .text')[0].text()).toBe('Total')
-    expect(wrapper.findAll('.summary .text')[1].text()).toBe('100')
-  })
+  //   expect(wrapper.findAll('.summary .text')[0].text()).toBe('Total')
+  //   expect(wrapper.findAll('.summary .text')[1].text()).toBe('100')
+  // })
 })


### PR DESCRIPTION
fixes #243

For testing do something like this in story:

```ts
for (let i = 0; i < 10000; ++i) {
  data.push({
    name: `Artwork ${i}`,
    link: 'https://example.com',
    status: 'Published',
    type: 'Photo',
    createdAt: '2022-10-10',
    tags: ['Info', 'News', 'Latest']
  })
}
```

And set `--table-max-height` to some fixed value (e.g. `65vh` or maybe something complex like `calc(100vh - 5rem)`)

TODO

- [x] fix table styles in docs