### PR TITLE
test(SState): missing required prop

### DIFF
--- a/tests/components/SState.spec.ts
+++ b/tests/components/SState.spec.ts
@@ -3,7 +3,11 @@ import SState from 'sefirot/components/SState.vue'
 
 describe('components/SState', () => {
   test('tag is set to `span` by default', () => {
-    const wrapper = mount(SState)
+    const wrapper = mount(SState, {
+      props: {
+        label: 'Label'
+      }
+    })
 
     expect(wrapper.find('.SState').element.tagName).toBe('SPAN')
   })
@@ -11,7 +15,8 @@ describe('components/SState', () => {
   test('`:as` sets html tag', () => {
     const wrapper = mount(SState, {
       props: {
-        as: 'div'
+        as: 'div',
+        label: 'Label'
       }
     })
 


### PR DESCRIPTION
Removes multiple warnings, for example:

```
stderr | tests/components/SState.spec.ts > components/SState > tag is set to `span` by default
[Vue warn]: Missing required prop: "label" 
  at <SState ref="VTU_COMPONENT" > 
  at <VTUROOT>
```