### PR TITLE
test(STable): stub IntersectionObserver

### DIFF
--- a/tests/components/STable.spec.ts
+++ b/tests/components/STable.spec.ts
@@ -2,6 +2,11 @@ import { mount } from '@vue/test-utils'
 import STable from 'sefirot/components/STable.vue'
 import { useTable } from 'sefirot/composables/Table'
 
+vi.stubGlobal('IntersectionObserver', vi.fn(() => ({
+  disconnect: vi.fn(),
+  observe: vi.fn()
+})))
+
 describe('components/STable', () => {
   test('it displays columns in order', () => {
     const table = useTable({


### PR DESCRIPTION
Suppress warning (and stub as good practice) from [`vue-observe-visibility`](https://github.com/Akryum/vue-observe-visibility/blob/5aa7c4bf5c661ca47f4832c9609683050fd58fe8/src/directives/observe-visibility.js#L87) (dependency of `vue-virtual-scroller`)