### PR TITLE
feat(card): add special support when used within modal (#281)

### DIFF
--- a/lib/components/SCard.vue
+++ b/lib/components/SCard.vue
@@ -33,7 +33,7 @@ const { isCollapsed } = provideCardState()
 .SModal > .SCard {
   margin: 12px 12px 128px;
   box-shadow: var(--shadow-depth-3);
-  transition: opacity 0.5s, transform 0.5s;
+  transition: opacity 0.25s, transform 0.25s;
 
   @media (min-width: 512px) {
     margin: 24px 24px 128px;

--- a/lib/components/SCard.vue
+++ b/lib/components/SCard.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
 import { provideCardState } from '../composables/Card'
 
+export type Size = 'small' | 'medium'
+
+defineProps<{
+  size?: Size
+}>()
+
 const { isCollapsed } = provideCardState()
 </script>
 
 <template>
-  <div class="SCard" :class="{ collapsed: isCollapsed }">
+  <div class="SCard" :class="[size, { collapsed: isCollapsed }]">
     <slot />
   </div>
 </template>
@@ -22,5 +28,43 @@ const { isCollapsed } = provideCardState()
 .SCard.collapsed {
   height: 48px;
   overflow: hidden;
+}
+
+.SModal > .SCard {
+  margin: 12px 12px 128px;
+  box-shadow: var(--shadow-depth-3);
+  transition: opacity 0.5s, transform 0.5s;
+
+  @media (min-width: 512px) {
+    margin: 24px 24px 128px;
+  }
+
+  @media (min-width: 768px) {
+    margin: 48px 48px 128px;
+  }
+
+  &.small {
+    @media (min-width: 560px) {
+      margin: 24px auto 128px;
+      max-width: 512px;
+    }
+
+    @media (min-width: 768px) {
+      margin: 48px auto 128px;
+    }
+  }
+
+  &.medium {
+    @media (min-width: 864px) {
+      margin: 48px auto 128px;
+      max-width: 768px;
+    }
+  }
+}
+
+.SModal.fade-enter-from > .SCard,
+.SModal.fade-leave-to > .SCard {
+  opacity: 0;
+  transform: translateY(8px);
 }
 </style>

--- a/lib/components/SModal.vue
+++ b/lib/components/SModal.vue
@@ -46,7 +46,7 @@ function onClick(e: MouseEvent) {
   left: 0;
   z-index: var(--z-index-backdrop);
   background-color: rgba(0, 0, 0, .8);
-  transition: opacity 0.5s;
+  transition: opacity 0.25s;
   overflow: hidden;
   overflow-y: auto;
 }

--- a/lib/components/SModal.vue
+++ b/lib/components/SModal.vue
@@ -29,11 +29,11 @@ function onClick(e: MouseEvent) {
 
 <template>
   <Teleport to="#sefirot-modals">
-    <transition name="fade">
+    <Transition name="fade">
       <div v-if="open" class="SModal" ref="el" @mousedown="onClick">
         <slot />
       </div>
-    </transition>
+    </Transition>
   </Teleport>
 </template>
 
@@ -46,7 +46,7 @@ function onClick(e: MouseEvent) {
   left: 0;
   z-index: var(--z-index-backdrop);
   background-color: rgba(0, 0, 0, .8);
-  transition: opacity 0.25s;
+  transition: opacity 0.5s;
   overflow: hidden;
   overflow-y: auto;
 }

--- a/lib/styles/variables.css
+++ b/lib/styles/variables.css
@@ -183,7 +183,7 @@
   --c-divider-1: var(--c-divider-light-1);
   --c-divider-2: var(--c-divider-light-2);
 
-  --c-gutter: var(--c-divider-light-2);
+  --c-gutter: #e8e8e8;
 
   --c-neutral-1: var(--c-neutral-light-1);
   --c-neutral-2: var(--c-neutral-light-2);

--- a/stories/components/SCard.02_Within_Modal.story.vue
+++ b/stories/components/SCard.02_Within_Modal.story.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import SButton from 'sefirot/components/SButton.vue'
+import SCard from 'sefirot/components/SCard.vue'
+import SCardBlock from 'sefirot/components/SCardBlock.vue'
+import SCardFooter from 'sefirot/components/SCardFooter.vue'
+import SCardFooterAction from 'sefirot/components/SCardFooterAction.vue'
+import SCardFooterActions from 'sefirot/components/SCardFooterActions.vue'
+import SCardHeader from 'sefirot/components/SCardHeader.vue'
+import SCardHeaderActionClose from 'sefirot/components/SCardHeaderActionClose.vue'
+import SCardHeaderActions from 'sefirot/components/SCardHeaderActions.vue'
+import SCardHeaderTitle from 'sefirot/components/SCardHeaderTitle.vue'
+import SModal from 'sefirot/components/SModal.vue'
+import { ref } from 'vue'
+
+const title = 'Components / SCard / 02. Within Modal'
+const docs = '/components/card'
+
+const open = ref(false)
+</script>
+
+<template>
+  <Story :title="title" source="Not available" auto-props-disabled>
+    <div id="sefirot-modals" />
+
+    <Board :title="title" :docs="docs">
+      <SButton mode="info" label="Open dialog" @click="open = true" />
+
+      <SModal :open="open" @close="open = false">
+        <SCard size="small">
+          <SCardHeader>
+            <SCardHeaderTitle>Header title</SCardHeaderTitle>
+            <SCardHeaderActions>
+              <SCardHeaderActionClose @click="open = false" />
+            </SCardHeaderActions>
+          </SCardHeader>
+
+          <SCardBlock space="compact">
+            <p class="text-14">
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+              tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+              quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+              consequat.
+            </p>
+          </SCardBlock>
+
+          <SCardFooter>
+            <SCardFooterActions>
+              <SCardFooterAction mode="mute" label="Cancel" @click="open = false" />
+              <SCardFooterAction mode="info" label="Submit" @click="open = false" />
+            </SCardFooterActions>
+          </SCardFooter>
+        </SCard>
+      </SModal>
+    </Board>
+  </Story>
+</template>


### PR DESCRIPTION
- close #281

I went with the Idea 1 approach. I think this is much easier to consume and also, easier to add transition and box shadow.

[See it in action at histoire](https://deploy-preview-282--sefirot-story.netlify.app/story/stories-components-scard-02-within-modal-story-vue?variantId=_default).

The code would look like this.

```html
<SModal :open="isOpen">
  <SCard size="small">
    ...
  </SCard>
</SModal>
```

<img width="1392" alt="Screenshot 2023-05-23 at 13 45 22" src="https://github.com/globalbrain/sefirot/assets/3753672/89859fb4-7efc-4c8e-a136-c577a9c510f7">
