### PR TITLE
fix(tooltip): positioning breaking on some edge cases

### DIFF
--- a/lib/composables/Tooltip.ts
+++ b/lib/composables/Tooltip.ts
@@ -67,9 +67,9 @@ export function useTooltip(
     const contentRightX = contentRect.x + contentRect.width
     const tipRightX = tipRect.x + tipRect.width
 
-    if (tipRect.x < 0) {
+    if (tipRect.x < SCREEN_PADDING) {
       adjustLeftPosition(contentRect.x)
-    } else if (tipRightX > window.outerWidth) {
+    } else if (tipRightX > (document.body.clientWidth - SCREEN_PADDING)) {
       adjustRightPosition(contentRightX)
     }
 
@@ -85,7 +85,7 @@ export function useTooltip(
   function adjustRightPosition(contentRightX: number): void {
     tip.value!.style.left = 'auto'
     tip.value!.style.right = '0'
-    setTransform((window.outerWidth - contentRightX) - SCREEN_PADDING)
+    setTransform((document.body.clientWidth - contentRightX) - SCREEN_PADDING)
   }
 
   function resetPosition(): void {

--- a/lib/composables/Tooltip.ts
+++ b/lib/composables/Tooltip.ts
@@ -8,8 +8,6 @@ export interface Tooltip {
 
 export type Position = 'top' | 'right' | 'bottom' | 'left'
 
-const SCREEN_PADDING = 16
-
 const globalHide = ref<() => void>()
 
 /**
@@ -61,31 +59,32 @@ export function useTooltip(
     // Temporally show tip to get its size.
     tip.value!.style.display = 'block'
 
+    const screenPadding = document.body.clientWidth >= 512 ? 24 : 8
     const contentRect = content.value!.getBoundingClientRect()
     const tipRect = tip.value!.getBoundingClientRect()
 
     const contentRightX = contentRect.x + contentRect.width
     const tipRightX = tipRect.x + tipRect.width
 
-    if (tipRect.x < SCREEN_PADDING) {
-      adjustLeftPosition(contentRect.x)
-    } else if (tipRightX > (document.body.clientWidth - SCREEN_PADDING)) {
-      adjustRightPosition(contentRightX)
+    if (tipRect.x < screenPadding) {
+      adjustLeftPosition(screenPadding, contentRect.x)
+    } else if (tipRightX > (document.body.clientWidth - screenPadding)) {
+      adjustRightPosition(screenPadding, contentRightX)
     }
 
     tip.value!.style.display = 'none'
   }
 
-  function adjustLeftPosition(contentRectX: number): void {
+  function adjustLeftPosition(screenPadding: number, contentRectX: number): void {
     tip.value!.style.left = '0'
     tip.value!.style.right = 'auto'
-    setTransform(-contentRectX + SCREEN_PADDING)
+    setTransform(-contentRectX + screenPadding)
   }
 
-  function adjustRightPosition(contentRightX: number): void {
+  function adjustRightPosition(screenPadding: number, contentRightX: number): void {
     tip.value!.style.left = 'auto'
     tip.value!.style.right = '0'
-    setTransform((document.body.clientWidth - contentRightX) - SCREEN_PADDING)
+    setTransform((document.body.clientWidth - contentRightX) - screenPadding)
   }
 
   function resetPosition(): void {


### PR DESCRIPTION
When the tooltip overflows window width, seems like it isn't considering scroll bar width and causing windows to display temporally horizontal scroll bar.

![image](https://github.com/globalbrain/sefirot/assets/3753672/02912df7-e06f-4658-b95b-b797d1840179)

With this, fix I've changed `windoe.outerWidth` to `document.body.clientWidth` to remove scroll bar width.

Also including `SCREEN_PADDING` (16px) when checking the tip position. When positioning tooltip we set 16px padding from the edge of the window. So, the tooltip must not exceed this 16px padding area. Which means the edge of the window should be `document.body.clientWidth - SCREEN_PADDING`.

I don't have windows so I can't directly confirm this but I'm asking to our team member for confirmation.