### PR TITLE
feat(table): add `menu` option (#249)

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -251,6 +251,48 @@ const options = useTable({
 })
 ```
 
+## Header menu
+
+You may define `menu` option to display a menu button on the table header. The menu is dropdown options that can display any kind of dropdown items.
+
+This is useful when you would like to add filter options that does not make sense adding it to the column options.
+
+```ts
+const options = useTable({
+  menu: [
+    {
+      label: 'Option A',
+      dropdown: {
+        type: 'menu',
+        options: [
+          { label: 'Option 1', onClick: () => {} },
+          { label: 'Option 2', onClick: () => {} },
+          { label: 'Option 3', onClick: () => {} }
+        ]
+      }
+    }
+  ]
+})
+```
+
+You may also pass `state` option to change how the menu button looks like. The `state` option can be one of `inactive`, `active`, and `indicate`.
+
+- `inactive` – The default state. The menu button fill look slightly muted.
+- `active` – The menu button label text will appear with `--c-text-1` color.
+- `indicate` – Adds blue dot indicator on the menu button. Use this to indicate user that the menu is now different than its default state (e.g. user has selected some option).
+
+```ts
+const options = useTable({
+  menu: [
+    {
+      label: 'Option A',
+      state: 'indicate',
+      dropdown: { ... }
+    }
+  ]
+})
+```
+
 ## Pagination
 
 By passing in `total`, `page`, and `perPage` option, the table footer gets displayed with pagination. You can listen to "Prev" and "Next" button click callback via `onPrev` and `onNext` option. Note that if both `onPrev` or `onNext` is not defined, it will not show the "Prev" and "Next" buttons.

--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -60,7 +60,11 @@ const showHeader = computed(() => {
     return header
   }
 
-  return unref(props.options.total) != null || !!unref(props.options.reset)
+  return (
+    unref(props.options.total) != null
+    || !!unref(props.options.reset)
+    || !!unref(props.options.menu)
+  )
 })
 
 const showFooter = computed(() => {
@@ -216,6 +220,7 @@ function getCell(key: string, index: number) {
         v-if="showHeader"
         :total="unref(options.total)"
         :reset="unref(options.reset)"
+        :menu="unref(options.menu)"
         :borderless="unref(options.borderless)"
         :on-reset="options.onReset"
       />

--- a/lib/components/STableHeader.vue
+++ b/lib/components/STableHeader.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
+import { type TableMenu } from '../composables/Table'
 import { format } from '../support/Num'
 import { isNullish } from '../support/Utils'
+import STableHeaderMenu from './STableHeaderMenu.vue'
 
 defineProps<{
   total?: number | null
   reset?: boolean
+  menu?: TableMenu[] | TableMenu[][]
   borderless?: boolean
   onReset?(): void
 }>()
@@ -13,14 +16,18 @@ defineProps<{
 <template>
   <div class="STableHeader" :class="{ borderless }">
     <div class="container">
-      <p v-if="!isNullish(total)" class="total">
-        {{ format(total) }} {{ (total) > 1 ? 'records' : 'record' }}
-      </p>
-
-      <div v-if="reset" class="reset">
-        <button class="button" @click="onReset">
-          Reset filters
-        </button>
+      <div class="stat">
+        <p v-if="!isNullish(total)" class="total">
+          {{ format(total) }} {{ (total) > 1 ? 'records' : 'record' }}
+        </p>
+        <div v-if="reset" class="reset">
+          <button class="button" @click="onReset">
+            Reset filters
+          </button>
+        </div>
+      </div>
+      <div v-if="menu && menu.length" class="menu">
+        <STableHeaderMenu :menu="menu" />
       </div>
     </div>
   </div>
@@ -36,13 +43,18 @@ defineProps<{
 
 .container {
   display: flex;
-  padding: 0 16px;
   min-height: 48px;
+}
+
+.stat {
+  display: flex;
+  flex-grow: 1;
+  padding: 0 16px;
 }
 
 .total {
   margin: 0;
-  padding: 13px 0 11px;
+  padding: 12px 0;
   line-height: 24px;
   font-size: 12px;
   font-weight: 500;
@@ -68,7 +80,7 @@ defineProps<{
 }
 
 .button {
-  padding: 13px 0 11px;
+  padding: 12px 0;
   line-height: 24px;
   font-size: 12px;
   font-weight: 500;
@@ -78,5 +90,10 @@ defineProps<{
   &:hover {
     color: var(--c-info-text-dark);
   }
+}
+
+.menu {
+  flex-shrink: 0;
+  padding-right: 8px;
 }
 </style>

--- a/lib/components/STableHeaderMenu.vue
+++ b/lib/components/STableHeaderMenu.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { type TableMenu } from '../composables/Table'
+import { isArray } from '../support/Utils'
+import STableHeaderMenuItem from './STableHeaderMenuItem.vue'
+
+const props = defineProps<{
+  menu: TableMenu[] | TableMenu[][]
+}>()
+
+const normalizedMenu = computed(() => {
+  return isArray(props.menu[0])
+    ? props.menu as TableMenu[][]
+    : [props.menu] as TableMenu[][]
+})
+</script>
+
+<template>
+  <div class="STableHeaderMenu">
+    <div v-for="items, index in normalizedMenu" :key="index" class="group">
+      <div v-if="index > 0" class="divider" />
+      <div v-for="item in items" :key="item.label" class="item">
+        <STableHeaderMenuItem
+          :label="item.label"
+          :state="item.state"
+          :dropdown="item.dropdown"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.STableHeaderMenu {
+  display: flex;
+  align-items: center;
+  height: 48px;
+}
+
+.group {
+  display: flex;
+  align-items: center;
+  height: 48px;
+}
+
+.divider {
+  margin: 0 8px;
+  width: 1px;
+  height: 16px;
+  background-color: var(--c-divider-2);
+}
+</style>

--- a/lib/components/STableHeaderMenuItem.vue
+++ b/lib/components/STableHeaderMenuItem.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import IconCaretDown from '@iconify-icons/ph/caret-down-bold'
+import { type DropdownSection } from '../composables/Dropdown'
+import { useFlyout } from '../composables/Flyout'
+import SDropdown from './SDropdown.vue'
+import SIcon from './SIcon.vue'
+
+defineProps<{
+  label: string
+  state?: 'inactive' | 'active' | 'indicate'
+  dropdown: DropdownSection[]
+}>()
+
+const { container, isOpen, toggle } = useFlyout()
+</script>
+
+<template>
+  <div class="STableHeaderMenuItem" ref="container">
+    <button class="button" :class="[state]" @click="toggle">
+      <span class="label">{{ label }}</span>
+      <span v-if="state !== 'indicate'" class="caret">
+        <SIcon class="caret-svg" :icon="IconCaretDown" />
+      </span>
+      <span v-else class="indicator">
+        <span class="indicator-dot" />
+      </span>
+    </button>
+    <Transition name="fade">
+      <div v-if="isOpen" class="dialog">
+        <SDropdown :sections="dropdown" />
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.STableHeaderMenuItem {
+  position: relative;
+}
+
+.button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 6px;
+  padding: 6px 7px 6px 9px;
+  transition: background-color 0.25s;
+
+  &:hover {
+    background-color: var(--c-mute);
+  }
+}
+
+.label {
+  font-size: 12px;
+  color: var(--c-text-2);
+  transition: color 0.25s;
+
+  .button:hover & {
+    color: var(--c-text-1);
+  }
+
+  .button.active &,
+  .button.indicate & {
+    color: var(--c-text-1);
+  }
+}
+
+.caret-svg {
+  width: 12px;
+  height: 12px;
+  color: var(--c-text-2);
+  transition: color 0.25s;
+
+  .button:hover & {
+    color: var(--c-text-1);
+  }
+}
+
+.indicator {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 12px;
+  height: 12px;
+}
+
+.indicator-dot {
+  display: block;
+  border-radius: 6px;
+  width: 6px;
+  height: 6px;
+  background-color: var(--c-info-text);
+}
+
+.dialog {
+  position: absolute;
+  top: 32px;
+  right: 0;
+  z-index: var(--z-index-dropdown);
+  transition: opacity 0.25s, transform 0.25s;
+}
+
+.dialog.fade-enter-from,
+.dialog.fade-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+</style>

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -10,6 +10,7 @@ export interface Table<
 > {
   orders: MaybeRef<O[]>
   columns: MaybeRef<TableColumns<O, R, SR>>
+  menu?: MaybeRef<TableMenu[] | TableMenu[][]>
   records?: MaybeRef<R[] | null | undefined>
   header?: MaybeRef<boolean | undefined>
   footer?: MaybeRef<boolean | undefined>
@@ -149,6 +150,12 @@ export interface TableCellState extends TableCellBase {
   type: 'state'
   label: string
   mode?: 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
+}
+
+export interface TableMenu {
+  label: string
+  state?: 'inactive' | 'active' | 'indicate'
+  dropdown: DropdownSection[]
 }
 
 export function useTable<

--- a/tests/components/STable.spec.ts
+++ b/tests/components/STable.spec.ts
@@ -8,50 +8,175 @@ vi.stubGlobal('IntersectionObserver', vi.fn(() => ({
 })))
 
 describe('components/STable', () => {
-  test('it displays columns in order', () => {
-    const table = useTable({
-      orders: ['item_1', 'item_2', 'item_3'],
-      columns: {
-        item_1: { label: 'item_1' },
-        item_2: { label: 'item_2' },
-        item_3: { label: 'item_3' }
-      }
-    })
+  describe('basics', () => {
+    test('it displays columns in order', () => {
+      const table = useTable({
+        orders: ['item_1', 'item_2', 'item_3'],
+        columns: {
+          item_1: { label: 'item_1' },
+          item_2: { label: 'item_2' },
+          item_3: { label: 'item_3' }
+        }
+      })
 
-    const wrapper = mount(STable, {
-      props: {
-        options: table
-      }
-    })
+      const wrapper = mount(STable, {
+        props: {
+          options: table
+        }
+      })
 
-    expect(wrapper.find('.STable .head .col-item_1 .label').text()).toBe('item_1')
-    expect(wrapper.find('.STable .head .col-item_2 .label').text()).toBe('item_2')
-    expect(wrapper.find('.STable .head .col-item_3 .label').text()).toBe('item_3')
+      expect(wrapper.find('.STable .head .col-item_1 .label').text()).toBe('item_1')
+      expect(wrapper.find('.STable .head .col-item_2 .label').text()).toBe('item_2')
+      expect(wrapper.find('.STable .head .col-item_3 .label').text()).toBe('item_3')
+    })
   })
 
-  test('it displays summary row at bottom', () => {
-    const table = useTable({
-      orders: ['name', 'amount'],
-      columns: {
-        name: { label: 'Name' },
-        amount: { label: 'Amount' }
-      },
-      records: [
-        { name: 'Item 1', amount: 10 },
-        { name: 'Item 2', amount: 90 }
-      ],
-      summary: {
-        name: 'Total', amount: 100
-      }
+  describe('menu', () => {
+    test('menu items is displayed in the header when `:menu` is set', () => {
+      const table = useTable({
+        orders: ['name'],
+        columns: {
+          name: { label: 'Name' }
+        },
+        menu: [
+          {
+            label: 'Option A',
+            dropdown: [{
+              type: 'menu',
+              options: [{ label: 'Option A1', onClick: () => {} }]
+            }]
+          }
+        ],
+        records: []
+      })
+
+      const wrapper = mount(STable, {
+        props: {
+          options: table
+        }
+      })
+
+      expect(wrapper.find('.STableHeaderMenuItem .label').text()).toBe('Option A')
     })
 
-    const wrapper = mount(STable, {
-      props: {
-        options: table
-      }
+    test('displays divider when multiple group of menus are passed', async () => {
+      const table = useTable({
+        orders: ['name'],
+        columns: {
+          name: { label: 'Name' }
+        },
+        menu: [
+          [{
+            label: 'Option A',
+            dropdown: [{
+              type: 'menu',
+              options: [{ label: 'Option A1', onClick: () => {} }]
+            }]
+          }],
+          [{
+            label: 'Option B',
+            dropdown: [{
+              type: 'menu',
+              options: [{ label: 'Option B1', onClick: () => {} }]
+            }]
+          }]
+        ],
+        records: []
+      })
+
+      const wrapper = mount(STable, {
+        props: {
+          options: table
+        }
+      })
+
+      expect(wrapper.find('.STableHeaderMenu .divider').exists()).toBe(true)
     })
 
-    expect(wrapper.findAll('.summary .text')[0].text()).toBe('Total')
-    expect(wrapper.findAll('.summary .text')[1].text()).toBe('100')
+    test('display indicator icon when the state is set to `indicate`', () => {
+      const table = useTable({
+        orders: ['name'],
+        columns: {
+          name: { label: 'Name' }
+        },
+        menu: [
+          {
+            label: 'Option A',
+            state: 'indicate',
+            dropdown: [{
+              type: 'menu',
+              options: [{ label: 'Option A1', onClick: () => {} }]
+            }]
+          }
+        ],
+        records: []
+      })
+
+      const wrapper = mount(STable, {
+        props: {
+          options: table
+        }
+      })
+
+      expect(wrapper.find('.STableHeaderMenuItem .indicator').exists()).toBe(true)
+      expect(wrapper.find('.STableHeaderMenuItem .caret').exists()).toBe(false)
+    })
+
+    test('opens dropdown dialog when clicking the menu item', async () => {
+      const table = useTable({
+        orders: ['name'],
+        columns: {
+          name: { label: 'Name' }
+        },
+        menu: [
+          {
+            label: 'Option A',
+            dropdown: [{
+              type: 'menu',
+              options: [{ label: 'Option A1', onClick: () => {} }]
+            }]
+          }
+        ],
+        records: []
+      })
+
+      const wrapper = mount(STable, {
+        props: {
+          options: table
+        }
+      })
+
+      expect(wrapper.find('.STableHeaderMenuItem .dialog').exists()).toBe(false)
+      await wrapper.find('.STableHeaderMenuItem .button').trigger('click')
+      expect(wrapper.find('.STableHeaderMenuItem .dialog').exists()).toBe(true)
+    })
+  })
+
+  describe('summary', () => {
+    test('it displays summary row at bottom', () => {
+      const table = useTable({
+        orders: ['name', 'amount'],
+        columns: {
+          name: { label: 'Name' },
+          amount: { label: 'Amount' }
+        },
+        records: [
+          { name: 'Item 1', amount: 10 },
+          { name: 'Item 2', amount: 90 }
+        ],
+        summary: {
+          name: 'Total', amount: 100
+        }
+      })
+
+      const wrapper = mount(STable, {
+        props: {
+          options: table
+        }
+      })
+
+      expect(wrapper.findAll('.summary .text')[0].text()).toBe('Total')
+      expect(wrapper.findAll('.summary .text')[1].text()).toBe('100')
+    })
   })
 })


### PR DESCRIPTION
- close #249

Adds `menu` option to the table.

```ts
const options = useTable({
  menu: [
    {
      label: 'Option A',
      dropdown: {
        type: 'menu',
        options: [
          { label: 'Option 1', onClick: () => {} },
          { label: 'Option 2', onClick: () => {} },
          { label: 'Option 3', onClick: () => {} }
        ]
      }
    }
  ]
})
```

User can pass in multiple options. And also, by passing in multiple nested array, it groups the menu with divider like shown in the screenshot.

```ts
const options = useTable({
  menu: [
    [
      { label: 'Option A', dropdown: { ... } },
      { label: 'Option B', dropdown: { ... } }
    ],
    [
      { label: 'Option A', dropdown: { ... } }
    ]
  ]
})
```

User can use `state` option to control how the menu button would appear.

- `inactive` – The default state. The menu button fill look slightly muted.
- `active` – The menu button label text will appear with `--c-text-1` color.
- `indicate` – Adds blue dot indicator on the menu button. Use this to indicate user that the menu is now different than its default state (e.g. user has selected some option).

```ts
const options = useTable({
  menu: [
    {
      label: 'Option A',
      state: 'indicate',
      dropdown: { ... }
    }
  ]
})
```

<img width="1392" alt="Screenshot 2023-05-29 at 13 57 03" src="https://github.com/globalbrain/sefirot/assets/3753672/ad6e0cf7-5c24-4a47-8b39-56b3b8d19837">
