### PR TITLE
fix(table): No background color is applied when pills is empty array

### DIFF
--- a/lib/components/STableCellPills.vue
+++ b/lib/components/STableCellPills.vue
@@ -33,6 +33,7 @@ const items = computed(() => props.pills(props.value, props.record))
 .STableCellPills {
   display: flex;
   padding: 0 14px;
+  min-height: 40px;
 
   :deep(.STableCellPill) {
     padding-right: 2px;


### PR DESCRIPTION
This PR fixes that the background color of the `PillsCell` is different from other cells when the pills' value is empty array.
This is because the cell height is 0 when the pills are empty.