### PR TITLE
fix(dropdown): radio button overflows on search input (#300)

### DIFF
--- a/lib/components/SDropdownSectionFilter.vue
+++ b/lib/components/SDropdownSectionFilter.vue
@@ -103,6 +103,7 @@ function handleClick(option: DropdownSectionFilterOption, value: string | number
 .search {
   position: sticky;
   top: 0;
+  z-index: 10;
   border-bottom: 1px solid var(--c-gutter);
   padding: 8px;
   background-color: var(--c-bg-elv-up);


### PR DESCRIPTION
- close #300 

This was only happening for radio button due to it having `position: relative` but not for checkboxes which have `position: static`. Added `z-index` on search input so that it always gets shown above the filter items.