### PR TITLE
fix(table): `0` value not displayed on number type cell

### DIFF
--- a/lib/components/STableCellNumber.vue
+++ b/lib/components/STableCellNumber.vue
@@ -32,7 +32,7 @@ const classes = computed(() => [
 <template>
   <div class="STableCellNumber" :class="classes">
     <SLink
-      v-if="_value"
+      v-if="_value != null"
       class="container"
       :href="link"
       :role="onClick ? 'button' : null"

--- a/tests/components/STable.spec.ts
+++ b/tests/components/STable.spec.ts
@@ -152,6 +152,33 @@ describe('components/STable', () => {
     })
   })
 
+  describe('cell number', () => {
+    test('it displays `0` value', () => {
+      const table = useTable({
+        orders: ['num'],
+        columns: {
+          num: {
+            label: 'Name',
+            cell: {
+              type: 'number'
+            }
+          }
+        },
+        records: [
+          { num: 0 }
+        ]
+      })
+
+      const wrapper = mount(STable, {
+        props: {
+          options: table
+        }
+      })
+
+      expect(wrapper.find('.STableCellNumber .value').text()).toBe('0')
+    })
+  })
+
   describe('summary', () => {
     test('it displays summary row at bottom', () => {
       const table = useTable({


### PR DESCRIPTION
It was doing falthy check on `v-if` so `0` value on number type cell wasn't displaying any value. Number cell should display any value other than `null` and `undefined`.