### PR TITLE
refactor: use `app.component` instead of `mixin` for global component registration

### DIFF
--- a/lib/mixins/Card.ts
+++ b/lib/mixins/Card.ts
@@ -12,19 +12,31 @@ import SCardHeaderActions from '../components/SCardHeaderActions.vue'
 import SCardHeaderTitle from '../components/SCardHeaderTitle.vue'
 
 export function mixin(app: App): void {
-  app.mixin({
-    components: {
-      SCard,
-      SCardBlock,
-      SCardFooter,
-      SCardFooterAction,
-      SCardFooterActions,
-      SCardHeader,
-      SCardHeaderAction,
-      SCardHeaderActionClose,
-      SCardHeaderActionCollapse,
-      SCardHeaderActions,
-      SCardHeaderTitle
-    }
-  })
+  app.component('SCard', SCard)
+  app.component('SCardBlock', SCardBlock)
+  app.component('SCardFooter', SCardFooter)
+  app.component('SCardFooterAction', SCardFooterAction)
+  app.component('SCardFooterActions', SCardFooterActions)
+  app.component('SCardHeader', SCardHeader)
+  app.component('SCardHeaderAction', SCardHeaderAction)
+  app.component('SCardHeaderActionClose', SCardHeaderActionClose)
+  app.component('SCardHeaderActionCollapse', SCardHeaderActionCollapse)
+  app.component('SCardHeaderActions', SCardHeaderActions)
+  app.component('SCardHeaderTitle', SCardHeaderTitle)
+}
+
+declare module 'vue' {
+  export interface GlobalComponents {
+    SCard: typeof SCard
+    SCardBlock: typeof SCardBlock
+    SCardFooter: typeof SCardFooter
+    SCardFooterAction: typeof SCardFooterAction
+    SCardFooterActions: typeof SCardFooterActions
+    SCardHeader: typeof SCardHeader
+    SCardHeaderAction: typeof SCardHeaderAction
+    SCardHeaderActionClose: typeof SCardHeaderActionClose
+    SCardHeaderActionCollapse: typeof SCardHeaderActionCollapse
+    SCardHeaderActions: typeof SCardHeaderActions
+    SCardHeaderTitle: typeof SCardHeaderTitle
+  }
 }

--- a/lib/mixins/Grid.ts
+++ b/lib/mixins/Grid.ts
@@ -3,10 +3,13 @@ import SGrid from '../components/SGrid.vue'
 import SGridItem from '../components/SGridItem.vue'
 
 export function mixin(app: App): void {
-  app.mixin({
-    components: {
-      SGrid,
-      SGridItem
-    }
-  })
+  app.component('SGrid', SGrid)
+  app.component('SGridItem', SGridItem)
+}
+
+declare module 'vue' {
+  export interface GlobalComponents {
+    SGrid: typeof SGrid
+    SGridItem: typeof SGridItem
+  }
 }

--- a/lib/mixins/Head.ts
+++ b/lib/mixins/Head.ts
@@ -4,11 +4,15 @@ import SHeadLead from '../components/SHeadLead.vue'
 import SHeadTitle from '../components/SHeadTitle.vue'
 
 export function mixin(app: App): void {
-  app.mixin({
-    components: {
-      SHead,
-      SHeadLead,
-      SHeadTitle
-    }
-  })
+  app.component('SHead', SHead)
+  app.component('SHeadLead', SHeadLead)
+  app.component('SHeadTitle', SHeadTitle)
+}
+
+declare module 'vue' {
+  export interface GlobalComponents {
+    SHead: typeof SHead
+    SHeadLead: typeof SHeadLead
+    SHeadTitle: typeof SHeadTitle
+  }
 }

--- a/lib/mixins/Sheet.ts
+++ b/lib/mixins/Sheet.ts
@@ -8,15 +8,23 @@ import SSheetMedium from '../components/SSheetMedium.vue'
 import SSheetTitle from '../components/SSheetTitle.vue'
 
 export function mixin(app: App): void {
-  app.mixin({
-    components: {
-      SSheet,
-      SSheetTitle,
-      SSheetMedium,
-      SSheetForm,
-      SSheetFooter,
-      SSheetFooterActions,
-      SSheetFooterAction
-    }
-  })
+  app.component('SSheet', SSheet)
+  app.component('SSheetFooter', SSheetFooter)
+  app.component('SSheetFooterAction', SSheetFooterAction)
+  app.component('SSheetFooterActions', SSheetFooterActions)
+  app.component('SSheetForm', SSheetForm)
+  app.component('SSheetMedium', SSheetMedium)
+  app.component('SSheetTitle', SSheetTitle)
+}
+
+declare module 'vue' {
+  export interface GlobalComponents {
+    SSheet: typeof SSheet
+    SSheetFooter: typeof SSheetFooter
+    SSheetFooterAction: typeof SSheetFooterAction
+    SSheetFooterActions: typeof SSheetFooterActions
+    SSheetForm: typeof SSheetForm
+    SSheetMedium: typeof SSheetMedium
+    SSheetTitle: typeof SSheetTitle
+  }
 }


### PR DESCRIPTION
Guess we're moving away from mixins 😎 