### PR TITLE
feat(desc): add `SDesc` component

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,7 @@ function sidebar(): DefaultTheme.SidebarItem[] {
         { text: 'SButtonGroup', link: '/components/button-group' },
         { text: 'SCard', link: '/components/card' },
         { text: 'SContent', link: '/components/content' },
+        { text: 'SDesc', link: '/components/desc' },
         { text: 'SFragment', link: '/components/fragment' },
         { text: 'SGrid', link: '/components/grid' },
         { text: 'SHead', link: '/components/head' },

--- a/docs/components/desc.md
+++ b/docs/components/desc.md
@@ -364,9 +364,9 @@ type Mode =
 
 ## Empty state
 
-All value components accepts empty value as `null` and `undefined`. When the value is not present, the `<SDescEmpty>` component are displayed.
+All components that support `:value` can accept empty values, which are represented as `null` or `undefined`. When `:value` is not present or is empty, the `<SDescEmpty>` component is displayed.
 
-Although probably not very useful, you could directly use `<SDescEmpty>` component to display empty value.
+Although it may not be very useful, you have the option to directly use `<SDescEmpty>` to display empty values.
 
 ```vue-html
 <SDesc cols="2" gap="24">

--- a/docs/components/desc.md
+++ b/docs/components/desc.md
@@ -1,0 +1,378 @@
+<script setup lang="ts">
+import SDesc from 'sefirot/components/SDesc.vue'
+import SDescItem from 'sefirot/components/SDescItem.vue'
+import SDescLabel from 'sefirot/components/SDescLabel.vue'
+import SDescLink from 'sefirot/components/SDescLink.vue'
+import SDescPill from 'sefirot/components/SDescPill.vue'
+import SDescState from 'sefirot/components/SDescState.vue'
+import SDescText from 'sefirot/components/SDescText.vue'
+</script>
+
+# SDesc
+
+`<SDesc>` is a component for creating "Description List". It's a list of key-value pairs, usually used to display a list of data.
+
+<Showcase
+  path="/components/SDesc.vue"
+  story="/stories-components-sdesc-01-playground-story-vue"
+>
+  <div>
+    <SDesc cols="2" gap="24">
+      <SDescItem span="1">
+        <SDescLabel>Full name</SDescLabel>
+        <SDescText>Margot Foster</SDescText>
+      </SDescItem>
+      <SDescItem span="1">
+        <SDescLabel>Website</SDescLabel>
+        <SDescLink>https://example.com</SDescLink>
+      </SDescItem>
+      <SDescItem span="1">
+        <SDescLabel>Application for</SDescLabel>
+        <SDescPill :pill="{ label: 'Frontend Developer' }" />
+      </SDescItem>
+      <SDescItem span="1">
+        <SDescLabel>Interview status</SDescLabel>
+        <SDescState :state="{ mode: 'info', label: 'In progress' }" />
+      </SDescItem>
+      <SDescItem span="2">
+        <SDescLabel>About</SDescLabel>
+        <SDescText>Fugiat ipsum ipsum deserunt culpa aute sint do nostrud anim incididunt cillum culpa consequat. Excepteur <a href="https://hello.com">qui ipsum aliquip consequat</a> sint. Sit id mollit nulla mollit nostrud in ea officia proident. Irure nostrud pariatur mollit ad adipisicing reprehenderit deserunt qui eu.</SDescText>
+      </SDescItem>
+    </SDesc>
+  </div>
+</Showcase>
+
+## Usage
+
+The `<SDesc>` has various child components that you can use to build your description list. Here is a basic example of how to use the `<SDesc>` component.
+
+```vue
+<script setup lang="ts">
+import SDesc from 'sefirot/components/SDesc.vue'
+import SDescItem from 'sefirot/components/SDescItem.vue'
+import SDescLabel from 'sefirot/components/SDescLabel.vue'
+import SDescText from 'sefirot/components/SDescText.vue'
+</script>
+
+<template>
+  <SDesc cols="2" gap="24">
+    <SDescItem span="1">
+      <SDescLabel>Full name</SDescLabel>
+      <SDescText>Margot Foster</SDescText>
+    </SDescItem>
+    <SDescItem span="1">
+      <SDescLabel>Website</SDescLabel>
+      <SDescLink>https://example.com</SDescLink>
+    </SDescItem>
+    <SDescItem span="2">
+      <SDescLabel>About</SDescLabel>
+      <SDescText>Fugiat ipsum ipsum deserunt culpa aute sint do nostrud anim incididunt cillum culpa consequat. Excepteur <a href="https://hello.com">qui ipsum aliquip consequat</a> sint. Sit id mollit nulla mollit nostrud in ea officia proident. Irure nostrud pariatur mollit ad adipisicing reprehenderit deserunt qui eu.</SDescText>
+    </SDescItem>
+  </SDesc>
+</template>
+```
+
+## Layout
+
+At the top level, use `<SDesc>` and `<SDescItem>` to define the layout. `<SDesc>` and `<SDescItem>` extends `<SGrid>` and `<SGridItem>` respectively, so you can use all the props that `<SGrid>` and `<SGridItem>` provides. Refer to [SGrid documentation](./grid) for more details including how to handle responsive design.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    ...
+  </SDescItem>
+  <SDescItem span="1">
+    ...
+  </SDescItem>
+</SDesc>
+```
+
+## Label
+
+Place labels with `<SDescLabel>` followed by value components such as `<SDescText>` or `<SDescLink>` under `<SDescItem>`.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel>Full name</SDescLabel>
+    <SDescText>Margot Foster</SDescText>
+  </SDescItem>
+  <SDescItem span="1">
+    <SDescItem span="1">
+      <SDescLabel>Website</SDescLabel>
+      <SDescLink>https://example.com</SDescLink>
+    </SDescItem>
+  </SDescItem>
+</SDesc>
+```
+
+You may also pass value through `:value` prop instead of the default slot to `<SDescLabel>`. When you define both `:value` prop and default slot, the slot value will take precedence.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Full name" />
+    ...
+  </SDescItem>
+</SDesc>
+```
+
+## Text value
+
+Use `<SDescText>` to display text value. Note that this component is the most generic one to display a value. Explore other specialized components like `<SDescNumber>` or `<SDescDay>` before resorting to `<SDescText>`. These dedicated components are tailored to display specific types of values, ensuring a more accurate and appropriate representation.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel>Name</SDescLabel>
+    <SDescText>John Doe</SDescText>
+  </SDescItem>
+</SDesc>
+```
+
+You may also use `:value` prop instead of the default slot. When you define both `:value` prop and default slot, the slot value will take precedence.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Name" />
+    <SDescText value="John Doe" />
+  </SDescItem>
+</SDesc>
+```
+
+The `<SDescText>` has builtin styling support for links. You may make part of the text a link without having to add additional CSS your self.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel>About</SDescLabel>
+    <SDescText>
+      For more details<SLink href="...">refer to this link</SLink>.
+    </SDescText>
+  </SDescItem>
+</SDesc>
+```
+
+When displaying long text, there might be a case where you want to trim the texts into certain length. You can do so by passing `:line-clamp` prop. The value is the number of lines you want to display.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel>About</SDescLabel>
+    <SDescText line-clamp="3">
+      Long text...
+    </SDescText>
+  </SDescItem>
+</SDesc>
+```
+
+You may also use `:pre-wrap` prop to preserve users line breaks in the text. This is especially helpful when the content comes from user inputs, such as through a `<textarea>` element. With this feature, the original formatting provided by users will be retained, making the displayed text consistent with their input.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel>About</SDescLabel>
+    <SDescText pre-wrap>
+      Text with line breaks...
+    </SDescText>
+  </SDescItem>
+</SDesc>
+```
+
+## Number value
+
+Use `<SDescNumber>` component, which is a specialized version of `<SDescText>` that is tailored to display numbers. It provides additional styling and formatting options that are not available in `<SDescText>`.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel>Age</SDescLabel>
+    <SDescNumber>37</SDescText>
+  </SDescItem>
+</SDesc>
+```
+
+You may also use `:value` prop instead of the default slot. When you define both `:value` prop and default slot, the slot value will take precedence.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Age" />
+    <SDescText :value="37" />
+  </SDescItem>
+</SDesc>
+```
+
+The `<SDescNumber>` supports `:separator` prop add thousand separators to the number.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Amount" />
+    <!-- Displays "123,456" -->
+    <SDescText :value="123456" separator />
+  </SDescItem>
+</SDesc>
+```
+
+## Link value
+
+If the whole value should be a link, use `<SDescLink>` component. The displayed value is similar to how `<SDescText>` displays links. However, `<SDescLink>` will always trim the value in single line.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel>Website</SDescLabel>
+    <SDescLink>https://example.com</SDescLink>
+  </SDescItem>
+</SDesc>
+```
+
+You may also use `:value` prop instead of the default slot. When you define both `:value` prop and default slot, the slot value will take precedence.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Website" />
+    <SDescText value="https://example.com" />
+  </SDescItem>
+</SDesc>
+```
+
+You may pass in `:href` prop to specify the link destination. Use this to make link value and link destination different.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Website" />
+    <SDescText
+      value="Official Website"
+      href="https://example.com"
+    />
+  </SDescItem>
+</SDesc>
+```
+
+## Date value
+
+When displaying a date, use `<SDescDay>` component. This component adds slightly different styling specialized for dates, and also provides additional formatting options.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel>Birthday</SDescLabel>
+    <SDescDay>1985-10-10</SDescLink>
+  </SDescItem>
+</SDesc>
+```
+
+You may also pass in the value as [`Day`](../support/day) object with optional `:format` prop. The `:format` prop supports [formatting syntax of Day.js](https://day.js.org/docs/en/display/format) with the default being `YYYY-MM-DD HH:mm:ss`.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Birthday" />
+    <SDescDay :value="day" format="MM-DD-YYYY" />
+  </SDescItem>
+</SDesc>
+```
+
+## Pill value
+
+You may use `<SDescPill>` component to display a value using [`<SPill>`](./pill) component. The size of the pill will be automatically adjusted to fit the description list item.
+
+```ts
+interface Props {
+  pill?: Pill | Pill[] | null
+}
+
+interface Pill {
+  mode?: Mode
+  label: string
+}
+
+type Mode =
+  | 'neutral'
+  | 'mute'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+```
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Type" />
+    <SDescPill :pill="{
+      mode: 'info',
+      label: 'Photo'
+    }" />
+  </SDescItem>
+</SDesc>
+```
+
+You may also pass in mutiple pills as an array.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Categories" />
+    <SDescPill :pill="[
+      { mode: 'info', label: 'Book' },
+      { mode: 'info', label: 'Si-Fi' },
+    ]" />
+  </SDescItem>
+</SDesc>
+```
+
+## State value
+
+Use `<SDescState>` component to display a value using [`<SState>`](./state) component. The size of the pill will be automatically adjusted to fit the description list item.
+
+```ts
+interface Props {
+  pill?: State | null
+}
+
+interface State {
+  mode?: Mode
+  label: string
+}
+
+type Mode =
+  | 'neutral'
+  | 'mute'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+```
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Status" />
+    <SDescState :state="{
+      mode: 'success',
+      label: 'Complete'
+    }" />
+  </SDescItem>
+</SDesc>
+```
+
+## Empty state
+
+All value components accepts empty value as `null` and `undefined`. When the value is not present, the `<SDescEmpty>` component are displayed.
+
+Although probably not very useful, you could directly use `<SDescEmpty>` component to display empty value.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel>...</SDescLabel>
+    <SDescEmpty />
+  </SDescItem>
+</SDesc>
+```

--- a/docs/components/desc.md
+++ b/docs/components/desc.md
@@ -10,7 +10,7 @@ import SDescText from 'sefirot/components/SDescText.vue'
 
 # SDesc
 
-`<SDesc>` is a component for creating "Description List". It's a list of key-value pairs, usually used to display a list of data.
+`<SDesc>` is a component for creating "Description List". It is a list of key-value pairs, usually used to display a list of data.
 
 <Showcase
   path="/components/SDesc.vue"
@@ -44,7 +44,7 @@ import SDescText from 'sefirot/components/SDescText.vue'
 
 ## Usage
 
-The `<SDesc>` has various child components that you can use to build your description list. Here is a basic example of how to use the `<SDesc>` component.
+The `<SDesc>` has various child components that you can use to build your description list. Here is a basic example of how to use the `<SDesc>`.
 
 ```vue
 <script setup lang="ts">
@@ -106,7 +106,7 @@ Place labels with `<SDescLabel>` followed by value components such as `<SDescTex
 </SDesc>
 ```
 
-You may also pass value through `:value` prop instead of the default slot to `<SDescLabel>`. When you define both `:value` prop and default slot, the slot value will take precedence.
+You may also pass value through `:value` instead of the default slot to `<SDescLabel>`. When you define both `:value` and default slot, the slot value will take precedence.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -130,7 +130,7 @@ Use `<SDescText>` to display text value. Note that this component is the most ge
 </SDesc>
 ```
 
-You may also use `:value` prop instead of the default slot. When you define both `:value` prop and default slot, the slot value will take precedence.
+You may also use `:value` instead of the default slot. When you define both `:value` and default slot, the slot value will take precedence.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -154,7 +154,7 @@ The `<SDescText>` has builtin styling support for links. You may make part of th
 </SDesc>
 ```
 
-When displaying long text, there might be a case where you want to trim the texts into certain length. You can do so by passing `:line-clamp` prop. The value is the number of lines you want to display.
+When displaying long text, there might be a case where you want to trim the texts into certain length. You can do so by defining `:line-clamp`. The value is the number of lines you want to display.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -167,7 +167,7 @@ When displaying long text, there might be a case where you want to trim the text
 </SDesc>
 ```
 
-You may also use `:pre-wrap` prop to preserve users line breaks in the text. This is especially helpful when the content comes from user inputs, such as through a `<textarea>` element. With this feature, the original formatting provided by users will be retained, making the displayed text consistent with their input.
+You may also use `:pre-wrap` to preserve line breaks in the text. This is especially helpful when the content comes from user inputs, such as through a `<textarea>` element. With this feature, the original formatting provided by users will be retained, making the displayed text consistent with their input.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -182,7 +182,7 @@ You may also use `:pre-wrap` prop to preserve users line breaks in the text. Thi
 
 ## Number value
 
-Use `<SDescNumber>` component, which is a specialized version of `<SDescText>` that is tailored to display numbers. It provides additional styling and formatting options that are not available in `<SDescText>`.
+Use `<SDescNumber>` which is a specialized version of `<SDescText>` that is tailored to display numbers. It provides additional styling and formatting options that are not available in `<SDescText>`.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -193,7 +193,7 @@ Use `<SDescNumber>` component, which is a specialized version of `<SDescText>` t
 </SDesc>
 ```
 
-You may also use `:value` prop instead of the default slot. When you define both `:value` prop and default slot, the slot value will take precedence.
+You may also use `:value` instead of the default slot. When you define both `:value` and default slot, the slot value will take precedence.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -204,7 +204,7 @@ You may also use `:value` prop instead of the default slot. When you define both
 </SDesc>
 ```
 
-The `<SDescNumber>` supports `:separator` prop add thousand separators to the number.
+The `<SDescNumber>` supports `:separator` that adds thousand separators to the number.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -218,7 +218,7 @@ The `<SDescNumber>` supports `:separator` prop add thousand separators to the nu
 
 ## Link value
 
-If the whole value should be a link, use `<SDescLink>` component. The displayed value is similar to how `<SDescText>` displays links. However, `<SDescLink>` will always trim the value in single line.
+If the whole value should be a link, use `<SDescLink>`. The displayed value is similar to how `<SDescText>` displays links. However, `<SDescLink>` will always trim the value in single line.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -229,7 +229,7 @@ If the whole value should be a link, use `<SDescLink>` component. The displayed 
 </SDesc>
 ```
 
-You may also use `:value` prop instead of the default slot. When you define both `:value` prop and default slot, the slot value will take precedence.
+You may also use `:value` instead of the default slot. When you define both `:value` and default slot, the slot value will take precedence.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -240,7 +240,7 @@ You may also use `:value` prop instead of the default slot. When you define both
 </SDesc>
 ```
 
-You may pass in `:href` prop to specify the link destination. Use this to make link value and link destination different.
+You may pass in `:href` to specify the link destination. Use this to make link value and link destination different.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -256,7 +256,7 @@ You may pass in `:href` prop to specify the link destination. Use this to make l
 
 ## Date value
 
-When displaying a date, use `<SDescDay>` component. This component adds slightly different styling specialized for dates, and also provides additional formatting options.
+When displaying a date, use `<SDescDay>`. This component adds slightly different styling specialized for dates, and also provides additional formatting options.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -267,7 +267,7 @@ When displaying a date, use `<SDescDay>` component. This component adds slightly
 </SDesc>
 ```
 
-You may also pass in the value as [`Day`](../support/day) object with optional `:format` prop. The `:format` prop supports [formatting syntax of Day.js](https://day.js.org/docs/en/display/format) with the default being `YYYY-MM-DD HH:mm:ss`.
+You may also pass in the value as [`Day`](../support/day) object with optional `:format`. The `:format` supports [formatting syntax of Day.js](https://day.js.org/docs/en/display/format) with the default being `YYYY-MM-DD HH:mm:ss`.
 
 ```vue-html
 <SDesc cols="2" gap="24">
@@ -280,7 +280,7 @@ You may also pass in the value as [`Day`](../support/day) object with optional `
 
 ## Pill value
 
-You may use `<SDescPill>` component to display a value using [`<SPill>`](./pill) component. The size of the pill will be automatically adjusted to fit the description list item.
+You may use `<SDescPill>` to display a value using [`<SPill>`](./pill). The size of the pill will be automatically adjusted to fit the description list item.
 
 ```ts
 interface Props {
@@ -329,7 +329,7 @@ You may also pass in mutiple pills as an array.
 
 ## State value
 
-Use `<SDescState>` component to display a value using [`<SState>`](./state) component. The size of the pill will be automatically adjusted to fit the description list item.
+Use `<SDescState>` component to display a value using [`<SState>`](./state). The size of the pill will be automatically adjusted to fit the description list item.
 
 ```ts
 interface Props {
@@ -364,7 +364,7 @@ type Mode =
 
 ## Empty state
 
-All components that support `:value` can accept empty values, which are represented as `null` or `undefined`. When `:value` is not present or is empty, the `<SDescEmpty>` component is displayed.
+All components that support `:value` can accept empty values, which are represented as `null` or `undefined`. When `:value` is not present or is empty, the `<SDescEmpty>` is displayed.
 
 Although it may not be very useful, you have the option to directly use `<SDescEmpty>` to display empty values.
 

--- a/docs/components/desc.md
+++ b/docs/components/desc.md
@@ -148,7 +148,7 @@ The `<SDescText>` has builtin styling support for links. You may make part of th
   <SDescItem span="1">
     <SDescLabel>About</SDescLabel>
     <SDescText>
-      For more details<SLink href="...">refer to this link</SLink>.
+      For more details <SLink href="...">refer to this link</SLink>.
     </SDescText>
   </SDescItem>
 </SDesc>

--- a/lib/components/SDesc.vue
+++ b/lib/components/SDesc.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import SGrid from './SGrid.vue'
+
+defineProps<{
+  cols?: string | number
+  gap?: string | number
+}>()
+</script>
+
+<template>
+  <SGrid class="SDesc" :cols="cols" :gap="gap">
+    <slot />
+  </SGrid>
+</template>

--- a/lib/components/SDescDay.vue
+++ b/lib/components/SDescDay.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed, useSlots } from 'vue'
+import { type Day } from '../support/Day'
+import SDescEmpty from './SDescEmpty.vue'
+
+const props = defineProps<{
+  value?: Day | null
+  format?: string
+}>()
+
+const slots = useSlots()
+
+const _value = computed(() => {
+  const slotValue = slots.default?.()[0].children
+
+  if (typeof slotValue === 'string') {
+    return slotValue
+  }
+
+  if (props.value) {
+    return props.value.format(props.format ?? 'YYYY-MM-DD HH:mm:ss')
+  }
+
+  return null
+})
+</script>
+
+<template>
+  <div v-if="_value" class="SDescDay">
+    <div class="value">
+      {{ _value }}
+    </div>
+  </div>
+  <SDescEmpty v-else />
+</template>
+
+<style scoped lang="postcss">
+.SDescDay {
+  border-bottom: 1px dashed var(--c-divider-1);
+  padding-bottom: 7px;
+}
+
+.value {
+  line-height: 24px;
+  font-size: 14px;
+  font-weight: 400;
+  font-feature-settings: "tnum";
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/lib/components/SDescEmpty.vue
+++ b/lib/components/SDescEmpty.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="SDescEmpty">
+    <div class="value">—</div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SDescEmpty {
+  border-bottom: 1px dashed var(--c-divider-1);
+  padding-bottom: 7px;
+}
+
+.value {
+  line-height: 24px;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--c-text-3);
+}
+</style>

--- a/lib/components/SDescItem.vue
+++ b/lib/components/SDescItem.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import SGridItem from './SGridItem.vue'
+
+defineProps<{
+  span?: string | number
+}>()
+</script>
+
+<template>
+  <SGridItem class="SDescItem" :span="span">
+    <slot />
+  </SGridItem>
+</template>

--- a/lib/components/SDescLabel.vue
+++ b/lib/components/SDescLabel.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="SDescLabel">
+    <div class="value"><slot /></div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SDescLabel {
+  display: flex;
+  height: 24px;
+}
+
+.value {
+  line-height: 24px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--c-text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/lib/components/SDescLabel.vue
+++ b/lib/components/SDescLabel.vue
@@ -1,6 +1,15 @@
+<script setup lang="ts">
+defineProps<{
+  value?: string | null
+}>()
+</script>
+
 <template>
   <div class="SDescLabel">
-    <div class="value"><slot /></div>
+    <div class="value">
+      <slot v-if="$slots.default" />
+      <template v-else>{{ value }}</template>
+    </div>
   </div>
 </template>
 

--- a/lib/components/SDescLink.vue
+++ b/lib/components/SDescLink.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { computed, useSlots } from 'vue'
+import SDescEmpty from './SDescEmpty.vue'
+import SLink from './SLink.vue'
+
+const props = defineProps<{
+  value?: string | null
+  href?: string
+}>()
+
+const slots = useSlots()
+
+const link = computed(() => {
+  if (props.href) {
+    return props.href
+  }
+
+  const slotValue = slots.default?.()[0].children
+
+  if (typeof slotValue === 'string') {
+    return slotValue
+  }
+
+  return props.value
+})
+</script>
+
+<template>
+  <div v-if="$slots.default || value" class="SDescLink">
+    <SLink class="value" :href="link">
+      <slot v-if="$slots.default" />
+      <template v-else>{{ value }}</template>
+    </SLink>
+  </div>
+  <SDescEmpty v-else />
+</template>
+
+<style scoped lang="postcss">
+.SDescLink {
+  border-bottom: 1px dashed var(--c-divider-1);
+  padding-bottom: 7px;
+}
+
+.value {
+  display: block;
+  line-height: 24px;
+  font-size: 14px;
+  font-weight: 400;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--c-info-text);
+  transition: color 0.25s;
+
+  &:hover {
+    color: var(--c-info-text-dark);
+  }
+}
+</style>

--- a/lib/components/SDescNumber.vue
+++ b/lib/components/SDescNumber.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { computed, useSlots } from 'vue'
+import { format } from '../support/Num'
+import SDescEmpty from './SDescEmpty.vue'
+
+const props = defineProps<{
+  value?: number | null
+  separator?: boolean
+}>()
+
+const slots = useSlots()
+
+const _value = computed(() => {
+  const slotValue = slots.default?.()[0].children
+
+  const v = (typeof slotValue === 'string') ? Number(slotValue) : props.value
+
+  if (v == null) {
+    return null
+  }
+
+  return props.separator ? format(v) : v
+})
+</script>
+
+<template>
+  <div v-if="_value" class="SDescNumber">
+    <div class="value">
+      {{ _value }}
+    </div>
+  </div>
+  <SDescEmpty v-else />
+</template>
+
+<style scoped lang="postcss">
+.SDescNumber {
+  border-bottom: 1px dashed var(--c-divider-1);
+  padding-bottom: 7px;
+}
+
+.value {
+  line-height: 24px;
+  font-size: 14px;
+  font-weight: 400;
+  font-feature-settings: "tnum";
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/lib/components/SDescPill.vue
+++ b/lib/components/SDescPill.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { isArray } from '../support/Utils'
+import SDescEmpty from './SDescEmpty.vue'
+import SPill, { type Mode } from './SPill.vue'
+
+export interface Pill {
+  mode?: Mode
+  label: string
+}
+
+const props = defineProps<{
+  pill?: Pill | Pill[] | null
+}>()
+
+const pills = computed(() => {
+  return props.pill
+    ? isArray(props.pill) ? props.pill : [props.pill]
+    : null
+})
+</script>
+
+<template>
+  <div v-if="pills && pills.length" class="SDescPill">
+    <div class="value">
+      <div v-for="pill, index in pills" :key="index" class="pill">
+        <SPill tag="div" size="mini" :mode="pill.mode" :label="pill.label" />
+      </div>
+    </div>
+  </div>
+  <SDescEmpty v-else />
+</template>
+
+<style scoped lang="postcss">
+.SDescPill {
+  border-bottom: 1px dashed var(--c-divider-1);
+  padding-bottom: 7px;
+}
+
+.value {
+  display: flex;
+  gap: 4px 6px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  display: flex;
+  align-items: center;
+  height: 24px;
+}
+</style>

--- a/lib/components/SDescState.vue
+++ b/lib/components/SDescState.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import SDescEmpty from './SDescEmpty.vue'
+import SState, { type Mode } from './SState.vue'
+
+export interface State {
+  mode?: Mode
+  label: string
+}
+
+defineProps<{
+  state?: State | null
+}>()
+</script>
+
+<template>
+  <div v-if="state" class="SDescState">
+    <div class="value">
+      <SState as="div" size="mini" :mode="state.mode" :label="state.label" />
+    </div>
+  </div>
+  <SDescEmpty v-else />
+</template>
+
+<style scoped lang="postcss">
+.SDescState {
+  border-bottom: 1px dashed var(--c-divider-1);
+  padding-bottom: 7px;
+}
+
+.value {
+  display: flex;
+  align-items: center;
+  height: 24px;
+}
+</style>

--- a/lib/components/SDescText.vue
+++ b/lib/components/SDescText.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import SDescEmpty from './SDescEmpty.vue'
+
+const props = defineProps<{
+  value?: string | null
+  lineClamp?: string | number
+  preWrap?: boolean
+}>()
+
+const classes = computed(() => [
+  { 'line-clamp': props.lineClamp },
+  { 'pre-wrap': props.preWrap }
+])
+
+const lineClamp = computed(() => props.lineClamp ?? 'none')
+</script>
+
+<template>
+  <div v-if="$slots.default || value" class="SDescText" :class="classes">
+    <div class="value">
+      <slot v-if="$slots.default" />
+      <template v-else>{{ value }}</template>
+    </div>
+  </div>
+  <SDescEmpty v-else />
+</template>
+
+<style scoped lang="postcss">
+.SDescText {
+  border-bottom: 1px dashed var(--c-divider-1);
+  padding-bottom: 7px;
+}
+
+.value {
+  line-height: 24px;
+  font-size: 14px;
+  font-weight: 400;
+
+  .SDescText.line-clamp & {
+    display: -webkit-box;
+    -webkit-line-clamp: v-bind(lineClamp);
+    -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  .SDescText.pre-wrap & {
+    white-space: pre-wrap;
+  }
+}
+
+.value :deep(a) {
+  color: var(--c-info-text);
+  transition: color 0.25s;
+
+  &:hover {
+    color: var(--c-info-text-dark);
+  }
+}
+</style>

--- a/lib/mixins/Desc.ts
+++ b/lib/mixins/Desc.ts
@@ -1,0 +1,39 @@
+import { type App } from 'vue'
+import SDesc from '../components/SDesc.vue'
+import SDescDay from '../components/SDescDay.vue'
+import SDescEmpty from '../components/SDescEmpty.vue'
+import SDescItem from '../components/SDescItem.vue'
+import SDescLabel from '../components/SDescLabel.vue'
+import SDescLink from '../components/SDescLink.vue'
+import SDescNumber from '../components/SDescNumber.vue'
+import SDescPill from '../components/SDescPill.vue'
+import SDescState from '../components/SDescState.vue'
+import SDescText from '../components/SDescText.vue'
+
+export function mixin(app: App): void {
+  app.component('SDesc', SDesc)
+  app.component('SDescDay', SDescDay)
+  app.component('SDescEmpty', SDescEmpty)
+  app.component('SDescItem', SDescItem)
+  app.component('SDescLabel', SDescLabel)
+  app.component('SDescLink', SDescLink)
+  app.component('SDescNumber', SDescNumber)
+  app.component('SDescPill', SDescPill)
+  app.component('SDescState', SDescState)
+  app.component('SDescText', SDescText)
+}
+
+declare module 'vue' {
+  export interface GlobalComponents {
+    SDesc: typeof SDesc
+    SDescDay: typeof SDescDay
+    SDescEmpty: typeof SDescEmpty
+    SDescItem: typeof SDescItem
+    SDescLabel: typeof SDescLabel
+    SDescLink: typeof SDescLink
+    SDescNumber: typeof SDescNumber
+    SDescPill: typeof SDescPill
+    SDescState: typeof SDescState
+    SDescText: typeof SDescText
+  }
+}

--- a/stories/components/SDesc.01_Playground.story.vue
+++ b/stories/components/SDesc.01_Playground.story.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import SDesc from 'sefirot/components/SDesc.vue'
+import SDescDay from 'sefirot/components/SDescDay.vue'
+import SDescItem from 'sefirot/components/SDescItem.vue'
+import SDescLabel from 'sefirot/components/SDescLabel.vue'
+import SDescLink from 'sefirot/components/SDescLink.vue'
+import SDescNumber from 'sefirot/components/SDescNumber.vue'
+import SDescPill from 'sefirot/components/SDescPill.vue'
+import SDescState from 'sefirot/components/SDescState.vue'
+import SDescText from 'sefirot/components/SDescText.vue'
+
+const title = 'Components / SDesc / 01. Playground'
+const docs = '/components/desc'
+</script>
+
+<template>
+  <Story :title="title" source="Not available" auto-props-disabled>
+    <Board :title="title" :docs="docs">
+      <SDesc cols="2" gap="24">
+        <SDescItem span="1">
+          <SDescLabel>Full name</SDescLabel>
+          <SDescText>Margot Foster</SDescText>
+        </SDescItem>
+        <SDescItem span="1">
+          <SDescLabel>Website</SDescLabel>
+          <SDescLink>https://margot.example</SDescLink>
+        </SDescItem>
+        <SDescItem span="1">
+          <SDescLabel>Birthday</SDescLabel>
+          <SDescDay>1985-10-10</SDescDay>
+        </SDescItem>
+        <SDescItem span="1">
+          <SDescLabel>Age</SDescLabel>
+          <SDescNumber>37</SDescNumber>
+        </SDescItem>
+        <SDescItem span="1">
+          <SDescLabel>Application for</SDescLabel>
+          <SDescPill :pill="{ label: 'Frontend Developer' }" />
+        </SDescItem>
+        <SDescItem span="1">
+          <SDescLabel>Interview status</SDescLabel>
+          <SDescState :state="{ mode: 'info', label: 'In progress' }" />
+        </SDescItem>
+        <SDescItem span="2">
+          <SDescLabel>About</SDescLabel>
+          <SDescText>Fugiat ipsum ipsum deserunt culpa aute sint do nostrud anim incididunt cillum culpa consequat. Excepteur <a href="https://hello.com">qui ipsum aliquip consequat</a> sint. Sit id mollit nulla mollit nostrud in ea officia proident. Irure nostrud pariatur mollit ad adipisicing reprehenderit deserunt qui eu.</SDescText>
+        </SDescItem>
+      </SDesc>
+    </Board>
+  </Story>
+</template>

--- a/stories/components/SDesc.02_Within_Card.story.vue
+++ b/stories/components/SDesc.02_Within_Card.story.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import SCard from 'sefirot/components/SCard.vue'
+import SCardBlock from 'sefirot/components/SCardBlock.vue'
+import SCardHeader from 'sefirot/components/SCardHeader.vue'
+import SCardHeaderTitle from 'sefirot/components/SCardHeaderTitle.vue'
+import SDesc from 'sefirot/components/SDesc.vue'
+import SDescDay from 'sefirot/components/SDescDay.vue'
+import SDescItem from 'sefirot/components/SDescItem.vue'
+import SDescLabel from 'sefirot/components/SDescLabel.vue'
+import SDescLink from 'sefirot/components/SDescLink.vue'
+import SDescNumber from 'sefirot/components/SDescNumber.vue'
+import SDescPill from 'sefirot/components/SDescPill.vue'
+import SDescState from 'sefirot/components/SDescState.vue'
+import SDescText from 'sefirot/components/SDescText.vue'
+
+const title = 'Components / SDesc / 02. Within Card'
+const docs = '/components/desc'
+</script>
+
+<template>
+  <Story :title="title" source="Not available" auto-props-disabled>
+    <Board :title="title" :docs="docs">
+      <div class="max-w-640">
+        <SCard>
+          <SCardHeader>
+            <SCardHeaderTitle>Applicant Information</SCardHeaderTitle>
+          </SCardHeader>
+          <SCardBlock space="compact">
+            <SDesc cols="2" gap="24">
+              <SDescItem span="1">
+                <SDescLabel>Full name</SDescLabel>
+                <SDescText>Margot Foster</SDescText>
+              </SDescItem>
+              <SDescItem span="1">
+                <SDescLabel>Website</SDescLabel>
+                <SDescLink>https://margot.example</SDescLink>
+              </SDescItem>
+              <SDescItem span="1">
+                <SDescLabel>Birthday</SDescLabel>
+                <SDescDay>1985-10-10</SDescDay>
+              </SDescItem>
+              <SDescItem span="1">
+                <SDescLabel>Age</SDescLabel>
+                <SDescNumber>37</SDescNumber>
+              </SDescItem>
+              <SDescItem span="1">
+                <SDescLabel>Application for</SDescLabel>
+                <SDescPill :pill="{ label: 'Frontend Developer' }" />
+              </SDescItem>
+              <SDescItem span="1">
+                <SDescLabel>Interview status</SDescLabel>
+                <SDescState :state="{ mode: 'info', label: 'In progress' }" />
+              </SDescItem>
+              <SDescItem span="2">
+                <SDescLabel>About</SDescLabel>
+                <SDescText>Fugiat ipsum ipsum deserunt culpa aute sint do nostrud anim incididunt cillum culpa consequat. Excepteur <a href="https://hello.com">qui ipsum aliquip consequat</a> sint. Sit id mollit nulla mollit nostrud in ea officia proident. Irure nostrud pariatur mollit ad adipisicing reprehenderit deserunt qui eu.</SDescText>
+              </SDescItem>
+            </SDesc>
+          </SCardBlock>
+        </SCard>
+      </div>
+    </Board>
+  </Story>
+</template>

--- a/tests/components/SDesc.spec.ts
+++ b/tests/components/SDesc.spec.ts
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils'
+import SDesc from 'sefirot/components/SDesc.vue'
+import SDescItem from 'sefirot/components/SDescItem.vue'
+import SDescLabel from 'sefirot/components/SDescLabel.vue'
+import SDescText from 'sefirot/components/SDescText.vue'
+
+describe('components/SDesc', () => {
+  describe('SDesc', () => {
+    test('renders `SDesc` element', () => {
+      const wrapper = mount(SDesc)
+      expect(wrapper.find('.SDesc').exists()).toBe(true)
+    })
+  })
+
+  describe('SDescItem', () => {
+    test('renders `SDescItem` element', () => {
+      const wrapper = mount(SDescItem)
+      expect(wrapper.find('.SDescItem').exists()).toBe(true)
+    })
+  })
+
+  describe('SDescLabel', () => {
+    test('renders `SDescLabel` element', () => {
+      const wrapper = mount(SDescLabel)
+      expect(wrapper.find('.SDescLabel').exists()).toBe(true)
+    })
+  })
+
+  describe('SDescText', () => {
+    test('renders `:value`', () => {
+      const wrapper = mount(SDescText, {
+        props: {
+          value: 'John Doe'
+        }
+      })
+
+      expect(wrapper.find('.SDescText').text()).toBe('John Doe')
+    })
+  })
+})

--- a/tests/components/SDesc.spec.ts
+++ b/tests/components/SDesc.spec.ts
@@ -1,8 +1,14 @@
 import { mount } from '@vue/test-utils'
 import SDesc from 'sefirot/components/SDesc.vue'
+import SDescDay from 'sefirot/components/SDescDay.vue'
 import SDescItem from 'sefirot/components/SDescItem.vue'
 import SDescLabel from 'sefirot/components/SDescLabel.vue'
+import SDescLink from 'sefirot/components/SDescLink.vue'
+import SDescNumber from 'sefirot/components/SDescNumber.vue'
+import SDescPill from 'sefirot/components/SDescPill.vue'
+import SDescState from 'sefirot/components/SDescState.vue'
 import SDescText from 'sefirot/components/SDescText.vue'
+import { day } from 'sefirot/support/Day'
 
 describe('components/SDesc', () => {
   describe('SDesc', () => {
@@ -20,9 +26,24 @@ describe('components/SDesc', () => {
   })
 
   describe('SDescLabel', () => {
-    test('renders `SDescLabel` element', () => {
-      const wrapper = mount(SDescLabel)
-      expect(wrapper.find('.SDescLabel').exists()).toBe(true)
+    test('renders `#default`', () => {
+      const wrapper = mount(SDescLabel, {
+        slots: {
+          default: 'Label'
+        }
+      })
+
+      expect(wrapper.find('.SDescLabel .value').text()).toBe('Label')
+    })
+
+    test('renders `:value`', () => {
+      const wrapper = mount(SDescLabel, {
+        props: {
+          value: 'Label'
+        }
+      })
+
+      expect(wrapper.find('.SDescLabel .value').text()).toBe('Label')
     })
   })
 
@@ -34,7 +55,194 @@ describe('components/SDesc', () => {
         }
       })
 
-      expect(wrapper.find('.SDescText').text()).toBe('John Doe')
+      expect(wrapper.find('.SDescText .value').text()).toBe('John Doe')
+    })
+
+    test('shows `SDescEmpty` when the value is empty', () => {
+      const wrapper = mount(SDescText)
+
+      expect(wrapper.find('.SDescText').exists()).toBe(false)
+      expect(wrapper.find('.SDescEmpty').exists()).toBe(true)
+    })
+  })
+
+  describe('SDescNumber', () => {
+    test('renders `:value`', () => {
+      const wrapper = mount(SDescNumber, {
+        props: {
+          value: 123
+        }
+      })
+
+      expect(wrapper.find('.SDescNumber .value').text()).toBe('123')
+    })
+
+    test('adds separator when `:separator` is set with `:value`', () => {
+      const wrapper = mount(SDescNumber, {
+        props: {
+          value: 123_456,
+          separator: true
+        }
+      })
+
+      expect(wrapper.find('.SDescNumber .value').text()).toBe('123,456')
+    })
+
+    test('adds separator when `:separator` is set with `#default`', () => {
+      const wrapper = mount(SDescNumber, {
+        props: {
+          separator: true
+        },
+        slots: {
+          default: '123456'
+        }
+      })
+
+      expect(wrapper.find('.SDescNumber .value').text()).toBe('123,456')
+    })
+
+    test('shows `SDescEmpty` when the value is empty', () => {
+      const wrapper = mount(SDescNumber)
+
+      expect(wrapper.find('.SDescNumber').exists()).toBe(false)
+      expect(wrapper.find('.SDescEmpty').exists()).toBe(true)
+    })
+  })
+
+  describe('SDescLink', () => {
+    test('makes `:value` a link', () => {
+      const wrapper = mount(SDescLink, {
+        props: {
+          value: 'https://example.com'
+        }
+      })
+
+      expect(wrapper.find('.SDescLink .value').text()).toBe('https://example.com')
+      expect(wrapper.find('.SDescLink .value').attributes('href')).toBe('https://example.com')
+    })
+
+    test('makes `#default` a link', () => {
+      const wrapper = mount(SDescLink, {
+        slots: {
+          default: 'https://example.com'
+        }
+      })
+
+      expect(wrapper.find('.SDescLink .value').text()).toBe('https://example.com')
+      expect(wrapper.find('.SDescLink .value').attributes('href')).toBe('https://example.com')
+    })
+
+    test('uses `:href` for the link when it is set', () => {
+      const wrapper = mount(SDescLink, {
+        props: {
+          value: 'Website link',
+          href: 'https://example.com'
+        }
+      })
+
+      expect(wrapper.find('.SDescLink .value').text()).toBe('Website link')
+      expect(wrapper.find('.SDescLink .value').attributes('href')).toBe('https://example.com')
+    })
+
+    test('shows `SDescEmpty` when the value is empty', () => {
+      const wrapper = mount(SDescLink)
+
+      expect(wrapper.find('.SDescLink').exists()).toBe(false)
+      expect(wrapper.find('.SDescEmpty').exists()).toBe(true)
+    })
+  })
+
+  describe('SDescDay', () => {
+    test('renders `#default` as is', () => {
+      const wrapper = mount(SDescDay, {
+        slots: {
+          default: '1985-10-10'
+        }
+      })
+
+      expect(wrapper.find('.SDescDay .value').text()).toBe('1985-10-10')
+    })
+
+    test('formats `:value` with default format', () => {
+      const wrapper = mount(SDescDay, {
+        props: {
+          value: day('1985-10-10 00:00:00')
+        }
+      })
+
+      expect(wrapper.find('.SDescDay .value').text()).toBe('1985-10-10 00:00:00')
+    })
+
+    test('formats `:value` with `:format` setting', () => {
+      const wrapper = mount(SDescDay, {
+        props: {
+          value: day('1985-10-15 00:00:00'),
+          format: 'MM-DD-YYYY'
+        }
+      })
+
+      expect(wrapper.find('.SDescDay .value').text()).toBe('10-15-1985')
+    })
+
+    test('shows `SDescEmpty` when the value is empty', () => {
+      const wrapper = mount(SDescDay)
+
+      expect(wrapper.find('.SDescDay').exists()).toBe(false)
+      expect(wrapper.find('.SDescEmpty').exists()).toBe(true)
+    })
+  })
+
+  describe('SDescPill', () => {
+    test('renders a pill', () => {
+      const wrapper = mount(SDescPill, {
+        props: {
+          pill: { label: 'Pill value' }
+        }
+      })
+
+      expect(wrapper.find('.SDescPill .SPill .label').text()).toBe('Pill value')
+    })
+
+    test('renders multiple pills', () => {
+      const wrapper = mount(SDescPill, {
+        props: {
+          pill: [
+            { label: 'Pill A' },
+            { label: 'Pill B' }
+          ]
+        }
+      })
+
+      const pills = wrapper.findAll('.SDescPill .pill')
+      expect(pills.length).toBe(2)
+      expect(pills.at(0).find('.label').text()).toBe('Pill A')
+      expect(pills.at(1).find('.label').text()).toBe('Pill B')
+    })
+
+    test('shows `SDescEmpty` when the value is empty', () => {
+      const wrapper = mount(SDescPill)
+
+      expect(wrapper.find('.SDescPill').exists()).toBe(false)
+      expect(wrapper.find('.SDescEmpty').exists()).toBe(true)
+    })
+  })
+
+  describe('SDescState', () => {
+    test('renders a state', () => {
+      const wrapper = mount(SDescState, {
+        props: {
+          state: { label: 'State value' }
+        }
+      })
+
+      expect(wrapper.find('.SDescState .SState .label').text()).toBe('State value')
+    })
+
+    test('shows `SDescEmpty` when the value is empty', () => {
+      const wrapper = mount(SDescState)
+
+      expect(wrapper.find('.SDescState').exists()).toBe(false)
+      expect(wrapper.find('.SDescEmpty').exists()).toBe(true)
     })
   })
 })


### PR DESCRIPTION
`<SDesc>` is a component to create "Description List".

[Refer to the documentation](https://deploy-preview-318--sefirot-docs.netlify.app/components/desc) on how to use this component.

<img width="1392" alt="Screenshot 2023-07-19 at 18 23 18" src="https://github.com/globalbrain/sefirot/assets/3753672/1c94ec3b-9afb-47d6-a265-2f4dfea6de19">
