### PR TITLE
fix(grid): make styles overridable via CSS

### DIFF
--- a/lib/components/SGrid.vue
+++ b/lib/components/SGrid.vue
@@ -6,16 +6,17 @@ const props = defineProps<{
   gap?: string | number
 }>()
 
-const styles = computed(() => {
-  return {
-    gridTemplateColumns: `repeat(${props.cols ?? 1}, minmax(0, 1fr))`,
-    gap: `${props.gap ?? 0}px`
-  }
+const gridTemplateColumns = computed(() => {
+  return `repeat(${props.cols ?? 1}, minmax(0, 1fr))`
+})
+
+const gap = computed(() => {
+  return `${props.gap ?? 0}px`
 })
 </script>
 
 <template>
-  <div class="SGrid" :style="styles">
+  <div class="SGrid">
     <slot />
   </div>
 </template>
@@ -23,5 +24,7 @@ const styles = computed(() => {
 <style scoped lang="postcss">
 .SGrid {
   display: grid;
+  grid-template-columns: v-bind(gridTemplateColumns);
+  gap: v-bind(gap);
 }
 </style>

--- a/lib/components/SGrid.vue
+++ b/lib/components/SGrid.vue
@@ -6,17 +6,16 @@ const props = defineProps<{
   gap?: string | number
 }>()
 
-const gridTemplateColumns = computed(() => {
-  return `repeat(${props.cols ?? 1}, minmax(0, 1fr))`
-})
-
-const gap = computed(() => {
-  return `${props.gap ?? 0}px`
+const styles = computed(() => {
+  return {
+    '--grid-template-columns': `repeat(${props.cols ?? 1}, minmax(0, 1fr))`,
+    '--gap': `${props.gap ?? 0}px`
+  }
 })
 </script>
 
 <template>
-  <div class="SGrid">
+  <div class="SGrid" :style="styles">
     <slot />
   </div>
 </template>
@@ -24,7 +23,7 @@ const gap = computed(() => {
 <style scoped lang="postcss">
 .SGrid {
   display: grid;
-  grid-template-columns: v-bind(gridTemplateColumns);
-  gap: v-bind(gap);
+  grid-template-columns: var(--grid-template-columns);
+  gap: var(--gap);
 }
 </style>

--- a/tests/components/SGrid.spec.ts
+++ b/tests/components/SGrid.spec.ts
@@ -8,6 +8,17 @@ describe('components/SGrid', () => {
       const wrapper = mount(SGrid)
       expect(wrapper.find('.SGrid').exists()).toBe(true)
     })
+
+    test('adds proper grid-template-columns and gap styles', () => {
+      const wrapper = mount(SGrid, {
+        propsData: {
+          cols: 3,
+          gap: 10
+        }
+      })
+      expect(wrapper.html()).toContain('--grid-template-columns: repeat(3, minmax(0, 1fr));')
+      expect(wrapper.html()).toContain('--gap: 10px;')
+    })
   })
 
   describe('SGridItem', () => {


### PR DESCRIPTION
fix #321 

Can be verified by something like this in `SGrid.01_Playground.story.vue`:

```html
<style scoped>
:deep(.SGrid) {
  grid-template-columns: repeat(2, minmax(0, 1fr));
  gap: 24px;
}
</style>
```