### PR TITLE
feat(card): add `:mode` to root and header components

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -86,11 +86,41 @@ import SCardHeaderTitle from '@globalbrain/sefirot/lib/components/SCardHeaderTit
 
 Learn more about each child component's usage in the following sections.
 
+## Root
+
+The `<SCard>` is the root component of the card. All child components must be placed under this component.
+
+```vue-html
+<SCard>
+  <SCardHeader>...</SCardHeader>
+  <SCardBlock>...</SCardBlock>
+  <SCardFooter>...</SCardFooter>
+</SCard>
+```
+
+### Root mode
+
+You may define `:mode` to change the appearance of the card. Usually, this is most used when creating "dangerous" cards, such as a card that displays a warning message before deleting something.
+
+```ts
+interface Props {
+  mode?: 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+}
+```
+
+```vue-html
+<SCard mode="danger">
+  ...
+</SCard>
+```
+
 ## Header
 
-Use `<SCardHeader>` to display header element.
+Use `<SCardHeader>` with `<SCardHeaderTitle>` and `<SCardActions>` to construct the header. 
 
-`<SCardHeaderTitle>` allows you to display the title text.
+### Header title
+
+The `<SCardHeaderTitle>` allows you to display the title text in the header.
 
 ```vue-html
 <SCard>
@@ -102,7 +132,25 @@ Use `<SCardHeader>` to display header element.
 </SCard>
 ```
 
-### Actions
+You may also pass `:mode` to change the appearance of the title text. Combine this prop with `:mode` prop of `<SCard>` to enpassize the card's purpose.
+
+```ts
+interface Props {
+  mode?: 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+}
+```
+
+```vue-html
+<SCard mode="danger">
+  <SCardHeader>
+    <SCardHeaderTitle mode="danger">
+      Header title
+    </SCardHeaderTitle>
+  </SCardHeader>
+</SCard>
+```
+
+### Header actions
 
 You may use `<SCardHeaderActions>` with nested `<SCardHeaderAction>` to add header actions. `<SCardHeaderAction>` accepts following props, and emits `@click` event when user clicks on the button.
 
@@ -182,7 +230,7 @@ Use `<SCardBlock>` to display generic block element. This component is usually u
 </SCard>
 ```
 
-### Spacing
+### Block spacing
 
 The `<SCardBlock>` component provides a convenient way to control the padding of the block using the `:space` prop. You can choose between two values: `compact` or `wide`.
 
@@ -217,7 +265,7 @@ Similar to `<SCardHeader>`, use `<SCardFooter>` to add the "footer" section of t
 </SCard>
 ```
 
-### Actions
+### Footer actions
 
 `<SCardFooterAction>` accepts following props. As same as `<SCardHeaderAction>`, it uses [`<SButton>`](./button) component internally. Refer to the documentation of `<SButton>` for how the props work.
 
@@ -240,7 +288,7 @@ export interface Tooltip {
 }
 ```
 
-### Spacing
+### Footer spacing
 
 Same as, `<SCardBlock>`, `<SCardFooter>` also comes with `:space` props that lets you control the padding of the block. You may pass either `compact` or `wide` as a value.
 

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -132,7 +132,7 @@ The `<SCardHeaderTitle>` allows you to display the title text in the header.
 </SCard>
 ```
 
-You may also pass `:mode` to change the appearance of the title text. Combine this prop with `:mode` prop of `<SCard>` to enpassize the card's purpose.
+You may also pass `:mode` to change the appearance of the title text. Combine this prop with `:mode` prop of `<SCard>` to emphasize the card's purpose.
 
 ```ts
 interface Props {

--- a/lib/components/SCard.vue
+++ b/lib/components/SCard.vue
@@ -1,17 +1,26 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { provideCardState } from '../composables/Card'
 
 export type Size = 'small' | 'medium' | 'large'
+export type Mode = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
 
-defineProps<{
+const props = defineProps<{
   size?: Size
+  mode?: Mode
 }>()
 
 const { isCollapsed } = provideCardState()
+
+const classes = computed(() => [
+  props.size,
+  props.mode ?? 'neutral',
+  { collapsed: isCollapsed.value }
+])
 </script>
 
 <template>
-  <div class="SCard" :class="[size, { collapsed: isCollapsed }]">
+  <div class="SCard" :class="classes">
     <slot />
   </div>
 </template>
@@ -20,10 +29,16 @@ const { isCollapsed } = provideCardState()
 .SCard {
   display: grid;
   gap: 1px;
-  border: 1px solid var(--c-divider-2);
+  border: 1px solid transparent;
   border-radius: 6px;
   background-color: var(--c-gutter);
 }
+
+.SCard.neutral { border-color: var(--c-divider-2); }
+.SCard.info    { border-color: var(--c-info-border); }
+.SCard.success { border-color: var(--c-success-border); }
+.SCard.warning { border-color: var(--c-warning-border); }
+.SCard.danger  { border-color: var(--c-danger-border); }
 
 .SCard.collapsed {
   height: 48px;

--- a/lib/components/SCardHeaderTitle.vue
+++ b/lib/components/SCardHeaderTitle.vue
@@ -1,5 +1,13 @@
+<script setup lang="ts">
+export type Mode = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+
+defineProps<{
+  mode?: Mode
+}>()
+</script>
+
 <template>
-  <p class="SCardHeaderTitle">
+  <p class="SCardHeaderTitle" :class="[mode ?? 'neutral']">
     <slot />
   </p>
 </template>
@@ -12,4 +20,10 @@
   font-size: 14px;
   font-weight: 600;
 }
+
+.SCardHeaderTitle.neutral { color: var(--c-text-1); }
+.SCardHeaderTitle.info    { color: var(--c-info-text); }
+.SCardHeaderTitle.success { color: var(--c-success-text); }
+.SCardHeaderTitle.warning { color: var(--c-warning-text); }
+.SCardHeaderTitle.danger  { color: var(--c-danger-text); }
 </style>

--- a/stories/components/SCard.01_Playground.story.vue
+++ b/stories/components/SCard.01_Playground.story.vue
@@ -11,37 +11,71 @@ import SCardHeaderTitle from 'sefirot/components/SCardHeaderTitle.vue'
 
 const title = 'Components / SCard / 01. Playground'
 const docs = '/components/card'
+
+function state() {
+  return {
+    cardMode: 'neutral',
+    titleMode: 'neutral'
+  }
+}
 </script>
 
 <template>
-  <Story :title="title" source="Not available" auto-props-disabled>
-    <Board :title="title" :docs="docs">
-      <div class="max-w-512">
-        <SCard>
-          <SCardHeader>
-            <SCardHeaderTitle>Header title</SCardHeaderTitle>
-            <SCardHeaderActions>
-              <SCardHeaderActionClose />
-            </SCardHeaderActions>
-          </SCardHeader>
+  <Story :title="title" :init-state="state" source="Not available" auto-props-disabled>
+    <template #controls="{ state }">
+      <HstSelect
+        title="Card mode"
+        :options="{
+          neutral: 'neutral',
+          info: 'info',
+          success: 'success',
+          warning: 'warning',
+          danger: 'danger'
+        }"
+        v-model="state.cardMode"
+      />
+      <HstSelect
+        title="Title mode"
+        :options="{
+          neutral: 'neutral',
+          info: 'info',
+          success: 'success',
+          warning: 'warning',
+          danger: 'danger'
+        }"
+        v-model="state.titleMode"
+      />
+    </template>
 
-          <SCardBlock space="compact">
-            <p class="text-14">
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-              tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-              quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-              consequat.
-            </p>
-          </SCardBlock>
+    <template #default="{ state }">
+      <Board :title="title" :docs="docs">
+        <div class="max-w-512">
+          <SCard :mode="state.cardMode">
+            <SCardHeader>
+              <SCardHeaderTitle :mode="state.titleMode">Header title</SCardHeaderTitle>
+              <SCardHeaderActions>
+                <SCardHeaderActionClose />
+              </SCardHeaderActions>
+            </SCardHeader>
 
-          <SCardFooter>
-            <SCardFooterActions>
-              <SCardFooterAction mode="mute" label="Cancel" />
-              <SCardFooterAction mode="info" label="Submit" />
-            </SCardFooterActions>
-          </SCardFooter>
-        </SCard>
-      </div>
-    </Board>
+            <SCardBlock space="compact">
+              <p class="text-14">
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat.
+              </p>
+            </SCardBlock>
+
+            <SCardFooter>
+              <SCardFooterActions>
+                <SCardFooterAction mode="mute" label="Cancel" />
+                <SCardFooterAction mode="info" label="Submit" />
+              </SCardFooterActions>
+            </SCardFooter>
+          </SCard>
+        </div>
+      </Board>
+    </template>
   </Story>
 </template>

--- a/stories/components/SCard.02_Within_Modal.story.vue
+++ b/stories/components/SCard.02_Within_Modal.story.vue
@@ -16,41 +16,75 @@ const title = 'Components / SCard / 02. Within Modal'
 const docs = '/components/card'
 
 const open = ref(false)
+
+function state() {
+  return {
+    cardMode: 'neutral',
+    titleMode: 'neutral'
+  }
+}
 </script>
 
 <template>
-  <Story :title="title" source="Not available" auto-props-disabled>
-    <div id="sefirot-modals" />
+  <Story :title="title" :init-state="state" source="Not available" auto-props-disabled>
+    <template #controls="{ state }">
+      <HstSelect
+        title="Card mode"
+        :options="{
+          neutral: 'neutral',
+          info: 'info',
+          success: 'success',
+          warning: 'warning',
+          danger: 'danger'
+        }"
+        v-model="state.cardMode"
+      />
+      <HstSelect
+        title="Title mode"
+        :options="{
+          neutral: 'neutral',
+          info: 'info',
+          success: 'success',
+          warning: 'warning',
+          danger: 'danger'
+        }"
+        v-model="state.titleMode"
+      />
+    </template>
 
-    <Board :title="title" :docs="docs">
-      <SButton mode="info" label="Open dialog" @click="open = true" />
+    <template #default="{ state }">
+      <div id="sefirot-modals" />
 
-      <SModal :open="open" @close="open = false">
-        <SCard size="small">
-          <SCardHeader>
-            <SCardHeaderTitle>Header title</SCardHeaderTitle>
-            <SCardHeaderActions>
-              <SCardHeaderActionClose @click="open = false" />
-            </SCardHeaderActions>
-          </SCardHeader>
+      <Board :title="title" :docs="docs">
+        <SButton mode="info" label="Open dialog" @click="open = true" />
 
-          <SCardBlock space="compact">
-            <p class="text-14">
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-              tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-              quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-              consequat.
-            </p>
-          </SCardBlock>
+        <SModal :open="open" @close="open = false">
+          <SCard size="small" :mode="state.cardMode">
+            <SCardHeader>
+              <SCardHeaderTitle :mode="state.titleMode">Header title</SCardHeaderTitle>
+              <SCardHeaderActions>
+                <SCardHeaderActionClose @click="open = false" />
+              </SCardHeaderActions>
+            </SCardHeader>
 
-          <SCardFooter>
-            <SCardFooterActions>
-              <SCardFooterAction mode="mute" label="Cancel" @click="open = false" />
-              <SCardFooterAction mode="info" label="Submit" @click="open = false" />
-            </SCardFooterActions>
-          </SCardFooter>
-        </SCard>
-      </SModal>
-    </Board>
+            <SCardBlock space="compact">
+              <p class="text-14">
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat.
+              </p>
+            </SCardBlock>
+
+            <SCardFooter>
+              <SCardFooterActions>
+                <SCardFooterAction mode="mute" label="Cancel" @click="open = false" />
+                <SCardFooterAction mode="info" label="Submit" @click="open = false" />
+              </SCardFooterActions>
+            </SCardFooter>
+          </SCard>
+        </SModal>
+      </Board>
+    </template>
   </Story>
 </template>


### PR DESCRIPTION
This PR adds `:mode` to `<SCard>` and `<SCardHeaderTitle>`. This is to create this kind of card 👀  It adds "mode" to the border.

Note that `<SCardFooterAction>` already supports this by inheriting `<SButton>` props.

<img width="790" alt="Screenshot 2023-07-31 at 17 39 11" src="https://github.com/globalbrain/sefirot/assets/3753672/6c8a267f-8320-4514-8414-224530db85b0">
