### PR TITLE
feat(head): add `:mode` to title component

### DIFF
--- a/docs/components/head.md
+++ b/docs/components/head.md
@@ -37,4 +37,19 @@ import SHeadTitle from '@globalbrain/sefirot/lib/components/SHeadTitle.vue'
 </template>
 ```
 
-Note that the `<SHeadLead>` component also styles `<a>` elements when it is passed so there is no need to style links manually.
+You may also define `:mode` on `<SHeadTitle>` to change the title's appearance. The default mode is `neutral`.
+
+```ts
+interface Props {
+  mode?: 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+}
+```
+
+```vue-html
+<SHead>
+  <SHeadTitle mode="danger">Dangerous title</SHeadTitle>
+  <SHeadLead>Lorem ipsum dolor sit, amet consectetur.</SHeadLead>
+</SHead>
+```
+
+Also, note that the `<SHeadLead>` component also styles `<a>` elements when it is passed so there is no need to style links manually.

--- a/lib/components/SHeadTitle.vue
+++ b/lib/components/SHeadTitle.vue
@@ -1,5 +1,13 @@
+<script setup lang="ts">
+export type Mode = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+
+defineProps<{
+  mode?: Mode
+}>()
+</script>
+
 <template>
-  <div class="SHeadTitle">
+  <div class="SHeadTitle" :class="[mode]">
     <slot />
   </div>
 </template>
@@ -11,4 +19,10 @@
   font-weight: 500;
   color: var(--c-text-1);
 }
+
+.SHeadTitle.neutral { color: var(--c-text-1); }
+.SHeadTitle.info    { color: var(--c-info-text); }
+.SHeadTitle.success { color: var(--c-success-text); }
+.SHeadTitle.warning { color: var(--c-warning-text); }
+.SHeadTitle.danger  { color: var(--c-danger-text); }
 </style>

--- a/stories/components/SHead.01_Playground.story.vue
+++ b/stories/components/SHead.01_Playground.story.vue
@@ -8,6 +8,7 @@ const docs = '/components/head'
 
 function state() {
   return {
+    mode: 'neutral',
     title: 'The head title',
     lead: 'Lorem ipsum dolor sit, amet consectetur.'
   }
@@ -17,6 +18,17 @@ function state() {
 <template>
   <Story :title="title" :init-state="state" source="Not available" auto-props-disabled>
     <template #controls="{ state }">
+      <HstSelect
+        title="mode"
+        :options="{
+          neutral: 'neutral',
+          info: 'info',
+          success: 'success',
+          warning: 'warning',
+          danger: 'danger'
+        }"
+        v-model="state.mode"
+      />
       <HstText
         title="Title"
         v-model="state.title"
@@ -31,7 +43,7 @@ function state() {
       <Board :title="title" :docs="docs">
         <div class="max-w-512">
           <SHead>
-            <SHeadTitle v-if="state.title">{{ state.title }}</SHeadTitle>
+            <SHeadTitle v-if="state.title" :mode="state.mode">{{ state.title }}</SHeadTitle>
             <SHeadLead v-if="state.lead">{{ state.lead }}</SHeadLead>
           </SHead>
         </div>


### PR DESCRIPTION
Add `:mode` to `<SHeadTitle>`. To create this design along with #325.

<img width="790" alt="Screenshot 2023-07-31 at 17 39 11" src="https://github.com/globalbrain/sefirot/assets/3753672/74f94179-7711-4bbc-b5d5-db6717ccd18a">
