### PR TITLE
fix(input-ymd): don't apply hover styles if input is disabled

### DIFF
--- a/lib/components/SInputYMD.vue
+++ b/lib/components/SInputYMD.vue
@@ -277,6 +277,9 @@ function createRequiredTouched(): boolean[] {
   .container {
     background-color: var(--input-disabled-bg-color);
   }
+
+  .container:hover { border-color: var(--input-border-color); }
+  .container.focus { border-color: var(--input-border-color); }
 }
 
 .SInputYMD.has-error {


### PR DESCRIPTION
closes #330

`SInputHMS` already have this:

https://github.com/globalbrain/sefirot/blob/97b1bf33b0003c2028192ab1ec899f17be41c694/lib/components/SInputHMS.vue#L279-L291