### PR TITLE
feat(desc): add `:dir` option

### DIFF
--- a/docs/components/desc.md
+++ b/docs/components/desc.md
@@ -87,6 +87,41 @@ At the top level, use `<SDesc>` and `<SDescItem>` to define the layout. `<SDesc>
 </SDesc>
 ```
 
+You may also define `:dir` to control the direction of the label and value stack. The default is set to `column` which stacks the label and value vertically. You may set it to `row` to stack them horizontally.
+
+When setting `:dir` to `row`, you should also specify `labelWidth` prop which will determine how much width should the label are have in the grid system. The value is in `px`.
+
+```ts
+interface Prop {
+  // Defaults to `column`.
+  dir?: 'column' | 'row'
+
+  // Defaults to 128.
+  labelWidth?: string | number
+}
+```
+
+```vue-html
+<SDesc cols="2" gap="24" dir="row" label-width="96">
+  ...
+</SDesc>
+```
+
+At last, you may show/hide divider via `:divider`. It defaults to `true`.
+
+```ts
+interface Prop {
+  // Defaults to `true`.
+  divider?: boolean
+}
+```
+
+```vue-html
+<SDesc cols="2" gap="24" :divider="false">
+  ...
+</SDesc>
+```
+
 ## Label
 
 Place labels with `<SDescLabel>` followed by value components such as `<SDescText>` or `<SDescLink>` under `<SDescItem>`.

--- a/docs/components/desc.md
+++ b/docs/components/desc.md
@@ -89,7 +89,7 @@ At the top level, use `<SDesc>` and `<SDescItem>` to define the layout. `<SDesc>
 
 You may also define `:dir` to control the direction of the label and value stack. The default is set to `column` which stacks the label and value vertically. You may set it to `row` to stack them horizontally.
 
-When setting `:dir` to `row`, you should also specify `labelWidth` prop which will determine how much width should the label are have in the grid system. The value is in `px`.
+When setting `:dir` to `row`, you should also specify `labelWidth` prop which will determine how much width the label should have in the grid system. The value is in `px`.
 
 ```ts
 interface Prop {

--- a/docs/components/desc.md
+++ b/docs/components/desc.md
@@ -107,7 +107,7 @@ interface Prop {
 </SDesc>
 ```
 
-At last, you may show/hide divider via `:divider`. It defaults to `true`.
+You may show/hide the divider by setting `:divider`. It defaults to `true`.
 
 ```ts
 interface Prop {

--- a/lib/components/SDesc.vue
+++ b/lib/components/SDesc.vue
@@ -1,14 +1,28 @@
 <script setup lang="ts">
+import { provide } from 'vue'
 import SGrid from './SGrid.vue'
 
-defineProps<{
+const props = withDefaults(defineProps<{
   cols?: string | number
   gap?: string | number
-}>()
+  dir?: 'column' | 'row'
+  labelWidth?: string | number
+  divider?: boolean
+}>(), {
+  dir: 'column',
+  divider: true
+})
+
+provide('sefirot-desc-label-wdith', () => props.labelWidth)
 </script>
 
 <template>
-  <SGrid class="SDesc" :cols="cols" :gap="gap">
+  <SGrid
+    class="SDesc"
+    :class="[dir, { divider }]"
+    :cols="cols"
+    :gap="gap"
+  >
     <slot />
   </SGrid>
 </template>

--- a/lib/components/SDescDay.vue
+++ b/lib/components/SDescDay.vue
@@ -34,11 +34,6 @@ const _value = computed(() => {
 </template>
 
 <style scoped lang="postcss">
-.SDescDay {
-  border-bottom: 1px dashed var(--c-divider-1);
-  padding-bottom: 7px;
-}
-
 .value {
   line-height: 24px;
   font-size: 14px;

--- a/lib/components/SDescEmpty.vue
+++ b/lib/components/SDescEmpty.vue
@@ -5,11 +5,6 @@
 </template>
 
 <style scoped lang="postcss">
-.SDescEmpty {
-  border-bottom: 1px dashed var(--c-divider-1);
-  padding-bottom: 7px;
-}
-
 .value {
   line-height: 24px;
   font-size: 14px;

--- a/lib/components/SDescItem.vue
+++ b/lib/components/SDescItem.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
+import { computed, inject } from 'vue'
 import SGridItem from './SGridItem.vue'
 
 defineProps<{
   span?: string | number
 }>()
+
+const labelWidthProp = inject<() => string | number | undefined>('sefirot-desc-label-wdith')
+
+const labelWidth = computed(() => {
+  const w = labelWidthProp?.()
+  return w ? `${w}px` : '1fr'
+})
 </script>
 
 <template>
@@ -11,3 +19,18 @@ defineProps<{
     <slot />
   </SGridItem>
 </template>
+
+<style scoped lang="postcss">
+.SDescItem {
+  display: grid;
+}
+
+.SDesc.row > .SDescItem {
+  grid-template-columns: var(--desc-label-width, v-bind(labelWidth)) 1fr;
+}
+
+.SDesc.divider > .SDescItem {
+  border-bottom: 1px dashed var(--c-divider-1);
+  padding-bottom: 7px;
+}
+</style>

--- a/lib/components/SDescLink.vue
+++ b/lib/components/SDescLink.vue
@@ -33,11 +33,6 @@ const link = computed(() => {
 </template>
 
 <style scoped lang="postcss">
-.SDescLink {
-  border-bottom: 1px dashed var(--c-divider-1);
-  padding-bottom: 7px;
-}
-
 .value {
   display: block;
   line-height: 24px;

--- a/lib/components/SDescNumber.vue
+++ b/lib/components/SDescNumber.vue
@@ -34,11 +34,6 @@ const _value = computed(() => {
 </template>
 
 <style scoped lang="postcss">
-.SDescNumber {
-  border-bottom: 1px dashed var(--c-divider-1);
-  padding-bottom: 7px;
-}
-
 .value {
   line-height: 24px;
   font-size: 14px;

--- a/lib/components/SDescPill.vue
+++ b/lib/components/SDescPill.vue
@@ -32,11 +32,6 @@ const pills = computed(() => {
 </template>
 
 <style scoped lang="postcss">
-.SDescPill {
-  border-bottom: 1px dashed var(--c-divider-1);
-  padding-bottom: 7px;
-}
-
 .value {
   display: flex;
   gap: 4px 6px;

--- a/lib/components/SDescState.vue
+++ b/lib/components/SDescState.vue
@@ -22,11 +22,6 @@ defineProps<{
 </template>
 
 <style scoped lang="postcss">
-.SDescState {
-  border-bottom: 1px dashed var(--c-divider-1);
-  padding-bottom: 7px;
-}
-
 .value {
   display: flex;
   align-items: center;

--- a/lib/components/SDescText.vue
+++ b/lib/components/SDescText.vue
@@ -30,11 +30,6 @@ const lineClamp = computed(() => props.lineClamp ?? 'none')
 </template>
 
 <style scoped lang="postcss">
-.SDescText {
-  border-bottom: 1px dashed var(--c-divider-1);
-  padding-bottom: 7px;
-}
-
 .value {
   line-height: 24px;
   font-size: 14px;

--- a/stories/components/SDesc.01_Playground.story.vue
+++ b/stories/components/SDesc.01_Playground.story.vue
@@ -14,8 +14,6 @@ const docs = '/components/desc'
 
 function state() {
   return {
-    cols: 2,
-    gap: 24,
     divider: true
   }
 }
@@ -24,14 +22,6 @@ function state() {
 <template>
   <Story :title="title" :init-state="state" source="Not available" auto-props-disabled>
     <template #controls="{ state }">
-      <HstNumber
-        title="cols"
-        v-model="state.cols"
-      />
-      <HstNumber
-        title="gap"
-        v-model="state.gap"
-      />
       <HstCheckbox
         title="divider"
         v-model="state.divider"
@@ -41,8 +31,8 @@ function state() {
     <template #default="{ state }">
       <Board :title="title" :docs="docs">
         <SDesc
-          :cols="state.cols"
-          :gap="state.gap"
+          cols="2"
+          gap="24"
           :divider="state.divider"
         >
           <SDescItem span="1">

--- a/stories/components/SDesc.02_Row_Direction.story.vue
+++ b/stories/components/SDesc.02_Row_Direction.story.vue
@@ -9,14 +9,15 @@ import SDescPill from 'sefirot/components/SDescPill.vue'
 import SDescState from 'sefirot/components/SDescState.vue'
 import SDescText from 'sefirot/components/SDescText.vue'
 
-const title = 'Components / SDesc / 01. Playground'
+const title = 'Components / SDesc / 02. Row Direction'
 const docs = '/components/desc'
 
 function state() {
   return {
-    cols: 2,
-    gap: 24,
-    divider: true
+    cols: 1,
+    gap: 16,
+    labelWidth: 128,
+    divider: false
   }
 }
 </script>
@@ -32,6 +33,10 @@ function state() {
         title="gap"
         v-model="state.gap"
       />
+      <HstNumber
+        title="labelWidth"
+        v-model="state.labelWidth"
+      />
       <HstCheckbox
         title="divider"
         v-model="state.divider"
@@ -43,33 +48,35 @@ function state() {
         <SDesc
           :cols="state.cols"
           :gap="state.gap"
+          dir="row"
+          :label-width="state.labelWidth"
           :divider="state.divider"
         >
-          <SDescItem span="1">
+          <SDescItem>
             <SDescLabel>Full name</SDescLabel>
             <SDescText>Margot Foster</SDescText>
           </SDescItem>
-          <SDescItem span="1">
+          <SDescItem>
             <SDescLabel>Website</SDescLabel>
             <SDescLink>https://margot.example</SDescLink>
           </SDescItem>
-          <SDescItem span="1">
+          <SDescItem>
             <SDescLabel>Birthday</SDescLabel>
             <SDescDay>1985-10-10</SDescDay>
           </SDescItem>
-          <SDescItem span="1">
+          <SDescItem>
             <SDescLabel>Age</SDescLabel>
             <SDescNumber>37</SDescNumber>
           </SDescItem>
-          <SDescItem span="1">
+          <SDescItem>
             <SDescLabel>Application for</SDescLabel>
             <SDescPill :pill="{ label: 'Frontend Developer' }" />
           </SDescItem>
-          <SDescItem span="1">
+          <SDescItem>
             <SDescLabel>Interview status</SDescLabel>
             <SDescState :state="{ mode: 'info', label: 'In progress' }" />
           </SDescItem>
-          <SDescItem span="2">
+          <SDescItem>
             <SDescLabel>About</SDescLabel>
             <SDescText>Fugiat ipsum ipsum deserunt culpa aute sint do nostrud anim incididunt cillum culpa consequat. Excepteur <a href="https://hello.com">qui ipsum aliquip consequat</a> sint. Sit id mollit nulla mollit nostrud in ea officia proident. Irure nostrud pariatur mollit ad adipisicing reprehenderit deserunt qui eu.</SDescText>
           </SDescItem>

--- a/stories/components/SDesc.03_Within_Card.story.vue
+++ b/stories/components/SDesc.03_Within_Card.story.vue
@@ -13,7 +13,7 @@ import SDescPill from 'sefirot/components/SDescPill.vue'
 import SDescState from 'sefirot/components/SDescState.vue'
 import SDescText from 'sefirot/components/SDescText.vue'
 
-const title = 'Components / SDesc / 02. Within Card'
+const title = 'Components / SDesc / 03. Within Card'
 const docs = '/components/desc'
 </script>
 


### PR DESCRIPTION
Adds `:dir` option to `SDesc`. This will align label and value horizontally.

To control the divider, I've moved divider to `SDescItem`. And added additional prop to disable it.

Finally, when setting `:dir` to `false`, specify `:labelWidth` to define the width of label area grid.

```html
<SDesc cols="2" gap="24" dir="row" label-width="96" :divider="false">
  ...
</SDesc>
```

---

<img width="1392" alt="Screenshot 2023-08-24 at 16 15 17" src="https://github.com/globalbrain/sefirot/assets/3753672/b223d3d6-a152-49f7-b6d8-4aa110257d88">
