### PR TITLE
fix(card): prevent content from expanding card

### DIFF
--- a/lib/components/SCard.vue
+++ b/lib/components/SCard.vue
@@ -28,6 +28,7 @@ const classes = computed(() => [
 <style scoped lang="postcss">
 .SCard {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 1px;
   border: 1px solid transparent;
   border-radius: 6px;


### PR DESCRIPTION
Currently if some content is long, then it expands the grid item size:

<img width="578" alt="image" src="https://github.com/globalbrain/sefirot/assets/40380293/32ba29a0-e551-4a8b-9c60-93e9a145c82e">

After this PR:

<img width="578" alt="image" src="https://github.com/globalbrain/sefirot/assets/40380293/914ca946-1d8c-4554-8901-ad4c6809bc0f">

Refer https://stackoverflow.com/q/43311943/11613622