### PR TITLE
fix(input): limit help and error text width

### DIFF
--- a/lib/components/SInputBase.vue
+++ b/lib/components/SInputBase.vue
@@ -155,6 +155,7 @@ function getErrorMsg(validation: Validatable) {
 
 .help-error {
   width: 100%;
+  max-width: 65ch;
   margin: 0;
   padding: 6px 0 0 0;
   line-height: 18px;
@@ -165,6 +166,7 @@ function getErrorMsg(validation: Validatable) {
 }
 
 .help-text {
+  max-width: 65ch;
   margin: 0;
   padding: 4px 0 0;
   line-height: 20px;


### PR DESCRIPTION
closes #353

Feel free to change it to 640px. I'd used 65ch because that's common with most of the other libraries like primer, tailwind/typography, most chrome and ms projects, etc.