### PR TITLE
fix(table): the count of avatar is wrong on the `STableCellAvatars`

### DIFF
--- a/lib/components/STableCellAvatars.vue
+++ b/lib/components/STableCellAvatars.vue
@@ -33,7 +33,7 @@ const names = computed(() => {
     return `${_avatars.value[0].name}, ${_avatars.value[1].name}`
   }
 
-  return `${_avatars.value[0].name}, ${_avatars.value[1].name} +${_avatars.value.length - 1}`
+  return `${_avatars.value[0].name}, ${_avatars.value[1].name} +${_avatars.value.length - 2}`
 })
 </script>
 


### PR DESCRIPTION
The count of avatars is wrong when more than 2 avatars are shown.

In following example, it looks like there are 4 assignees though there are 3 assignees actually.
![image](https://github.com/globalbrain/sefirot/assets/62658104/628f6bef-f924-446e-a273-578e9c2a110d)
