### PR TITLE
feat(button)!: add `default` mode and organize color system

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import SButton from 'sefirot/components/SButton.vue'
 
-const modes = ['neutral', 'mute', 'info', 'success', 'warning', 'danger'] as const
+const modes = ['default', 'neutral', 'info', 'success', 'warning', 'danger'] as const
 </script>
 
 # SButton
@@ -88,7 +88,7 @@ type Size = 'fill' | 'outline' | 'text'
 
 ### `:mode`
 
-Defines the color of the button. The default is `neutral`.
+Defines the color of the button. The default is `default`.
 
 ```ts
 interface Props {
@@ -96,8 +96,9 @@ interface Props {
 }
 
 type Mode =
-  | 'neutral'
+  | 'default'
   | 'mute'
+  | 'neutral'
   | 'white'
   | 'black'
   | 'info'
@@ -134,8 +135,9 @@ interface Props {
 }
 
 type Mode =
-  | 'neutral'
+  | 'default'
   | 'mute'
+  | 'neutral'
   | 'white'
   | 'black'
   | 'info'
@@ -180,8 +182,9 @@ interface Props {
 }
 
 type Mode =
-  | 'neutral'
+  | 'default'
   | 'mute'
+  | 'neutral'
   | 'white'
   | 'black'
   | 'info'
@@ -404,12 +407,48 @@ The component has several different styles based on its type and color combinati
 
 ```css
 :root {
+  --button-fill-default-border-color: var(--c-divider-1);
+  --button-fill-default-text-color: var(--c-text-1);
+  --button-fill-default-content-color: var(--c-text-1);
+  --button-fill-default-bg-color: var(--c-mute);
+  --button-fill-default-loader-color: var(--c-neutral);
+  --button-fill-default-hover-border-color: var(--c-divider-1);
+  --button-fill-default-hover-text-color: var(--c-text-1);
+  --button-fill-default-hover-bg-color: var(--c-mute-dark);
+  --button-fill-default-active-border-color: var(--c-divider-1);
+  --button-fill-default-active-text-color: var(--c-text-1);
+  --button-fill-default-active-bg-color: var(--c-mute-darker);
+  --button-fill-default-disabled-border-color: var(--c-divider-2);
+  --button-fill-default-disabled-text-color: var(--c-text-2);
+  --button-fill-default-disabled-content-color: var(--c-text-2);
+  --button-fill-default-disabled-bg-color: var(--c-mute-dark);
+
+  --button-fill-mute-border-color: var(--c-divider-1);
+  --button-fill-mute-text-color: var(--c-text-2);
+  --button-fill-mute-content-color: var(--c-text-2);
+  --button-fill-mute-bg-color: var(--c-mute);
+  --button-fill-mute-loader-color: var(--c-neutral);
+  --button-fill-mute-hover-border-color: var(--c-divider-1);
+  --button-fill-mute-hover-text-color: var(--c-text-1);
+  --button-fill-mute-hover-bg-color: var(--c-mute-dark);
+  --button-fill-mute-active-border-color: var(--c-divider-1);
+  --button-fill-mute-active-text-color: var(--c-text-2);
+  --button-fill-mute-active-bg-color: var(--c-mute-darker);
+  --button-fill-mute-disabled-border-color: var(--c-divider-2);
+  --button-fill-mute-disabled-text-color: var(--c-text-2);
+  --button-fill-mute-disabled-content-color: var(--c-text-2);
+  --button-fill-mute-disabled-bg-color: var(--c-mute-dark);
+
   --button-fill-neutral-border-color: transparent;
   --button-fill-neutral-text-color: var(--c-text-inverse-1);
   --button-fill-neutral-content-color: var(--c-text-1);
   --button-fill-neutral-bg-color: var(--c-neutral-1);
   --button-fill-neutral-loader-color: var(--c-neutral-inverse-1);
+  --button-fill-neutral-hover-border-color: transparent;
+  --button-fill-neutral-hover-text-color: var(--c-text-inverse-1);
   --button-fill-neutral-hover-bg-color: var(--c-neutral-2);
+  --button-fill-neutral-active-border-color: transparent;
+  --button-fill-neutral-active-text-color: var(--c-text-inverse-1);
   --button-fill-neutral-active-bg-color: var(--c-neutral-3);
   --button-fill-neutral-disabled-border-color: transparent;
   --button-fill-neutral-disabled-text-color: var(--c-text-inverse-2);
@@ -421,7 +460,11 @@ The component has several different styles based on its type and color combinati
   --button-fill-white-content-color: var(--c-text-dark-1);
   --button-fill-white-bg-color: var(--c-neutral-dark-1);
   --button-fill-white-loader-color: var(--c-neutral-light-1);
+  --button-fill-white-hover-border-color: transparent;
+  --button-fill-white-hover-text-color: var(--c-text-light-1);
   --button-fill-white-hover-bg-color: var(--c-neutral-dark-2);
+  --button-fill-white-active-border-color: transparent;
+  --button-fill-white-active-text-color: var(--c-text-light-1);
   --button-fill-white-active-bg-color: var(--c-neutral-dark-3);
   --button-fill-white-disabled-border-color: transparent;
   --button-fill-white-disabled-text-color: var(--c-text-light-2);
@@ -433,31 +476,27 @@ The component has several different styles based on its type and color combinati
   --button-fill-black-content-color: var(--c-text-light-1);
   --button-fill-black-bg-color: var(--c-neutral-light-1);
   --button-fill-black-loader-color: var(--c-neutral-dark-1);
+  --button-fill-black-hover-border-color: transparent;
+  --button-fill-black-hover-text-color: var(--c-text-dark-1);
   --button-fill-black-hover-bg-color: var(--c-neutral-light-2);
+  --button-fill-black-active-border-color: transparent;
+  --button-fill-black-active-text-color:var(--c-text-dark-1);
   --button-fill-black-active-bg-color: var(--c-neutral-light-3);
   --button-fill-black-disabled-border-color: transparent;
   --button-fill-black-disabled-text-color: var(--c-text-dark-2);
   --button-fill-black-disabled-content-color: var(--c-text-light-2);
   --button-fill-black-disabled-bg-color: var(--c-neutral-light-2);
 
-  --button-fill-mute-border-color: var(--c-divider-1);
-  --button-fill-mute-text-color: var(--c-text-1);
-  --button-fill-mute-content-color: var(--c-text-2);
-  --button-fill-mute-bg-color: var(--c-mute);
-  --button-fill-mute-loader-color: var(--c-neutral);
-  --button-fill-mute-hover-bg-color: var(--c-mute-dark);
-  --button-fill-mute-active-bg-color: var(--c-mute-darker);
-  --button-fill-mute-disabled-border-color: var(--c-divider-2);
-  --button-fill-mute-disabled-text-color: var(--c-text-2);
-  --button-fill-mute-disabled-content-color: var(--c-text-3);
-  --button-fill-mute-disabled-bg-color: var(--c-mute-dark);
-
   --button-fill-info-border-color: var(--c-info-light);
   --button-fill-info-text-color: var(--c-text-dark-1);
   --button-fill-info-content-color: var(--c-info-text);
   --button-fill-info-bg-color: var(--c-info-bg);
   --button-fill-info-loader-color: var(--c-white);
+  --button-fill-info-hover-border-color: var(--c-info-light);
+  --button-fill-info-hover-text-color: var(--c-white);
   --button-fill-info-hover-bg-color: var(--c-info-bg-dark);
+  --button-fill-info-active-border-color: var(--c-info-light);
+  --button-fill-info-active-text-color: var(--c-white);
   --button-fill-info-active-bg-color: var(--c-info-bg-darker);
   --button-fill-info-disabled-border-color: var(--c-info);
   --button-fill-info-disabled-text-color: var(--c-text-dark-2);
@@ -469,36 +508,68 @@ The component has several different styles based on its type and color combinati
   --button-fill-success-content-color: var(--c-success-text);
   --button-fill-success-bg-color: var(--c-success-bg);
   --button-fill-success-loader-color: var(--c-white);
+  --button-fill-success-hover-border-color: var(--c-success-light);
+  --button-fill-success-hover-text-color: var(--c-white);
   --button-fill-success-hover-bg-color: var(--c-success-bg-dark);
+  --button-fill-success-active-border-color: var(--c-success-light);
+  --button-fill-success-active-text-color: var(--c-white);
   --button-fill-success-active-bg-color: var(--c-success-bg-darker);
   --button-fill-success-disabled-border-color: var(--c-success);
   --button-fill-success-disabled-text-color: var(--c-text-dark-2);
   --button-fill-success-disabled-content-color: var(--c-success-text-dark);
   --button-fill-success-disabled-bg-color: var(--c-success-bg-dark);
 
-  --button-fill-warning-border-color: var(--c-warning-light);
-  --button-fill-warning-text-color: var(--c-text-dark-1);
+  --button-fill-warning-border-color: var(--c-divider-1);
+  --button-fill-warning-text-color: var(--c-warning-text);
   --button-fill-warning-content-color: var(--c-warning-text);
-  --button-fill-warning-bg-color: var(--c-warning-bg);
+  --button-fill-warning-bg-color: var(--c-mute);
   --button-fill-warning-loader-color: var(--c-white);
+  --button-fill-warning-hover-border-color: var(--c-warning-light);
+  --button-fill-warning-hover-text-color: var(--c-white);
   --button-fill-warning-hover-bg-color: var(--c-warning-bg-dark);
+  --button-fill-warning-active-border-color: var(--c-warning-light);
+  --button-fill-warning-active-text-color: var(--c-white);
   --button-fill-warning-active-bg-color: var(--c-warning-bg-darker);
   --button-fill-warning-disabled-border-color: var(--c-warning);
   --button-fill-warning-disabled-text-color: var(--c-text-dark-2);
   --button-fill-warning-disabled-content-color: var(--c-warning-text-dark);
   --button-fill-warning-disabled-bg-color: var(--c-warning-bg-dark);
 
-  --button-fill-danger-border-color: var(--c-danger-light);
-  --button-fill-danger-text-color: var(--c-text-dark-1);
+  --button-fill-danger-border-color: var(--c-divider-1);
+  --button-fill-danger-text-color: var(--c-danger-text);
   --button-fill-danger-content-color: var(--c-danger-text);
-  --button-fill-danger-bg-color: var(--c-danger-bg);
+  --button-fill-danger-bg-color: var(--c-mute);
   --button-fill-danger-loader-color: var(--c-white);
-  --button-fill-danger-hover-bg-color: var(--c-danger-bg-dark);
-  --button-fill-danger-active-bg-color: var(--c-danger-bg-darker);
-  --button-fill-danger-disabled-border-color: var(--c-danger);
-  --button-fill-danger-disabled-text-color: var(--c-text-dark-2);
+  --button-fill-danger-hover-border-color: var(--c-danger-light);
+  --button-fill-danger-hover-text-color: var(--c-white);
+  --button-fill-danger-hover-bg-color: var(--c-danger-bg);
+  --button-fill-danger-active-border-color: var(--c-danger-light);
+  --button-fill-danger-active-text-color: var(--c-white);
+  --button-fill-danger-active-bg-color: var(--c-danger-bg-dark);
+  --button-fill-danger-disabled-border-color: var(--c-divider-2);
+  --button-fill-danger-disabled-text-color: var(--c-danger-text-dark);
   --button-fill-danger-disabled-content-color: var(--c-danger-text-dark);
-  --button-fill-danger-disabled-bg-color: var(--c-danger-bg-dark);
+  --button-fill-danger-disabled-bg-color: var(--c-mute-dark);
+
+  --button-outline-default-border-color: var(--c-divider-1);
+  --button-outline-default-text-color: var(--c-text-1);
+  --button-outline-default-content-color: var(--c-text-1);
+  --button-outline-default-loader-color: var(--c-neutral-1);
+  --button-outline-default-hover-bg-color: var(--c-mute-dimm-1);
+  --button-outline-default-active-bg-color: var(--c-mute-dimm-2);
+  --button-outline-default-disabled-border-color: var(--c-divider-2);
+  --button-outline-default-disabled-text-color: var(--c-text-3);
+  --button-outline-default-disabled-content-color: var(--c-text-3);
+
+  --button-outline-mute-border-color: var(--c-divider-1);
+  --button-outline-mute-text-color: var(--c-text-2);
+  --button-outline-mute-content-color: var(--c-text-2);
+  --button-outline-mute-loader-color: var(--c-neutral-1);
+  --button-outline-mute-hover-bg-color: var(--c-mute-dimm-1);
+  --button-outline-mute-active-bg-color: var(--c-mute-dimm-2);
+  --button-outline-mute-disabled-border-color: var(--c-divider-2);
+  --button-outline-mute-disabled-text-color: var(--c-text-3);
+  --button-outline-mute-disabled-content-color: var(--c-text-3);
 
   --button-outline-neutral-border-color: var(--c-neutral-1);
   --button-outline-neutral-text-color: var(--c-text-1);
@@ -529,16 +600,6 @@ The component has several different styles based on its type and color combinati
   --button-outline-black-disabled-border-color: var(--c-neutral-light-3);
   --button-outline-black-disabled-text-color: var(--c-text-light-2);
   --button-outline-black-disabled-content-color: var(--c-text-light-2);
-
-  --button-outline-mute-border-color: var(--c-divider-1);
-  --button-outline-mute-text-color: var(--c-text-2);
-  --button-outline-mute-content-color: var(--c-text-2);
-  --button-outline-mute-loader-color: var(--c-neutral-1);
-  --button-outline-mute-hover-bg-color: var(--c-mute-dimm-1);
-  --button-outline-mute-active-bg-color: var(--c-mute-dimm-2);
-  --button-outline-mute-disabled-border-color: var(--c-divider-2);
-  --button-outline-mute-disabled-text-color: var(--c-text-3);
-  --button-outline-mute-disabled-content-color: var(--c-text-3);
 
   --button-outline-info-border-color: var(--c-info-light);
   --button-outline-info-text-color: var(--c-info-text);
@@ -580,6 +641,20 @@ The component has several different styles based on its type and color combinati
   --button-outline-danger-disabled-text-color: var(--c-danger-text-dark);
   --button-outline-danger-disabled-content-color: var(--c-danger-text-dark);
 
+  --button-text-default-text-color: var(--c-text-1);
+  --button-text-default-content-color: var(--c-text-1);
+  --button-text-default-hover-bg-color: var(--c-mute);
+  --button-text-default-active-bg-color: var(--c-mute-light);
+  --button-text-default-disabled-text-color: var(--c-text-3);
+  --button-text-default-disabled-content-color: var(--c-text-3);
+
+  --button-text-mute-text-color: var(--c-text-2);
+  --button-text-mute-content-color: var(--c-text-2);
+  --button-text-mute-hover-bg-color: var(--c-mute);
+  --button-text-mute-active-bg-color: var(--c-mute-light);
+  --button-text-mute-disabled-text-color: var(--c-text-3);
+  --button-text-mute-disabled-content-color: var(--c-text-3);
+
   --button-text-neutral-text-color: var(--c-text-1);
   --button-text-neutral-content-color: var(--c-text-1);
   --button-text-neutral-hover-bg-color: var(--c-neutral-dimm-1);
@@ -600,13 +675,6 @@ The component has several different styles based on its type and color combinati
   --button-text-black-active-bg-color: var(--c-neutral-light-dimm-2);
   --button-text-black-disabled-text-color: var(--c-text-light-2);
   --button-text-black-disabled-content-color: var(--c-text-light-2);
-
-  --button-text-mute-text-color: var(--c-text-2);
-  --button-text-mute-content-color: var(--c-text-2);
-  --button-text-mute-hover-bg-color: var(--c-mute-dimm-1);
-  --button-text-mute-active-bg-color: var(--c-mute-dimm-2);
-  --button-text-mute-disabled-text-color: var(--c-text-3);
-  --button-text-mute-disabled-content-color: var(--c-text-3);
 
   --button-text-info-text-color: var(--c-info-text);
   --button-text-info-content-color: var(--c-info-text);

--- a/lib/components/SButton.vue
+++ b/lib/components/SButton.vue
@@ -12,8 +12,9 @@ export type Size = 'mini' | 'small' | 'medium' | 'large' | 'jumbo'
 export type Type = 'fill' | 'outline' | 'text'
 
 export type Mode =
-  | 'neutral'
+  | 'default'
   | 'mute'
+  | 'neutral'
   | 'white'
   | 'black'
   | 'info'
@@ -54,7 +55,7 @@ const emit = defineEmits<{
 const classes = computed(() => [
   props.size ?? 'medium',
   props.type ?? 'fill',
-  props.mode ?? 'neutral',
+  props.mode ?? 'default',
   { 'has-label': props.label },
   { 'has-icon': props.icon },
   { loading: props.loading },
@@ -128,11 +129,62 @@ function handleClick(): void {
   align-items: center;
   letter-spacing: 0;
   text-align: center;
-  border: 1px solid transparent;
+  border: 1px solid var(--button-border-color);
   border-radius: 6px;
+  color: var(--button-text-color);
+  background-color: var(--button-bg-color);
   overflow: hidden;
   white-space: nowrap;
   transition: color 0.25s, border-color 0.25s, background-color 0.25s;
+
+  &:hover {
+    border-color: var(--button-hover-border-color);
+    color: var(--button-hover-text-color);
+    background-color: var(--button-hover-bg-color);
+  }
+
+  &:active {
+    border-color: var(--button-active-border-color);
+    color: var(--button-active-text-color);
+    background-color: var(--button-active-bg-color);
+  }
+}
+
+.content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  transition: opacity 0.25s, transform 0.25s;
+}
+
+.icon,
+.label {
+  color: var(--button-content-color);
+}
+
+.loader {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 10;
+  width: 32px;
+  height: 32px;
+  color: var(--c-text-1);
+  transform: translate(-50%, -50%);
+  transition: opacity 0.25s, transform 0.25s;
+}
+
+.loader.fade-enter-from,
+.loader.fade-leave-to {
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(1.5);
+}
+
+.loader-icon {
+  width: 32px;
+  height: 32px;
+  color: var(--button-loader-color);
 }
 
 .SButton.mini {
@@ -195,512 +247,481 @@ function handleClick(): void {
   .icon-svg            { width: 20px; height: 20px; }
 }
 
+.SButton.disabled {
+  border-color: var(--button-disabled-border-color);
+  color: var(--button-disabled-text-color);
+  background-color: var(--button-disabled-bg-color);
+  cursor: not-allowed;
+
+  &:hover,
+  &:active {
+    border-color: var(--button-disabled-border-color);
+    color: var(--button-disabled-text-color);
+    background-color: var(--button-disabled-bg-color);
+  }
+}
+
+.SButton.disabled .icon,
+.SButton.disabled .label {
+  color: var(--button-disabled-content-color);
+}
+
 .SButton.fill {
   font-weight: 500;
 
-  &.neutral {
-    border-color: var(--button-fill-neutral-border-color);
-    color: var(--button-fill-neutral-text-color);
-    background-color: var(--button-fill-neutral-bg-color);
-
-    &:hover  { background-color: var(--button-fill-neutral-hover-bg-color); }
-    &:active { background-color: var(--button-fill-neutral-active-bg-color); }
-
-    & .loader-icon { color: var(--button-fill-neutral-loader-color); }
+  &.default {
+    --button-border-color: var(--button-fill-default-border-color);
+    --button-text-color: var(--button-fill-default-text-color);
+    --button-bg-color: var(--button-fill-default-bg-color);
+    --button-hover-border-color: var(--button-fill-default-hover-border-color);
+    --button-hover-text-color: var(--button-fill-default-hover-text-color);
+    --button-hover-bg-color: var(--button-fill-default-hover-bg-color);
+    --button-active-border-color: var(--button-fill-default-active-border-color);
+    --button-active-text-color: var(--button-fill-default-active-text-color);
+    --button-active-bg-color: var(--button-fill-default-active-bg-color);
+    --button-loader-color: var(--button-fill-default-loader-color);
+    --button-disabled-border-color: var(--button-fill-default-disabled-border-color);
+    --button-disabled-text-color: var(--button-fill-default-disabled-text-color);
+    --button-disabled-bg-color: var(--button-fill-default-disabled-bg-color);
   }
 
   &.mute {
-    border-color: var(--button-fill-mute-border-color);
-    color: var(--button-fill-mute-text-color);
-    background-color: var(--button-fill-mute-bg-color);
+    --button-border-color: var(--button-fill-mute-border-color);
+    --button-text-color: var(--button-fill-mute-text-color);
+    --button-bg-color: var(--button-fill-mute-bg-color);
+    --button-hover-border-color: var(--button-fill-mute-hover-border-color);
+    --button-hover-text-color: var(--button-fill-mute-hover-text-color);
+    --button-hover-bg-color: var(--button-fill-mute-hover-bg-color);
+    --button-active-border-color: var(--button-fill-mute-active-border-color);
+    --button-active-text-color: var(--button-fill-mute-active-text-color);
+    --button-active-bg-color: var(--button-fill-mute-active-bg-color);
+    --button-loader-color: var(--button-fill-mute-loader-color);
+    --button-disabled-border-color: var(--button-fill-mute-disabled-border-color);
+    --button-disabled-text-color: var(--button-fill-mute-disabled-text-color);
+    --button-disabled-bg-color: var(--button-fill-mute-disabled-bg-color);
+  }
 
-    &:hover  { background-color: var(--button-fill-mute-hover-bg-color); }
-    &:active { background-color: var(--button-fill-mute-active-bg-color); }
-
-    & .loader-icon { color: var(--button-fill-mute-loader-color); }
+  &.neutral {
+    --button-border-color: var(--button-fill-neutral-border-color);
+    --button-text-color: var(--button-fill-neutral-text-color);
+    --button-bg-color: var(--button-fill-neutral-bg-color);
+    --button-hover-border-color: var(--button-fill-neutral-hover-border-color);
+    --button-hover-text-color: var(--button-fill-neutral-hover-text-color);
+    --button-hover-bg-color: var(--button-fill-neutral-hover-bg-color);
+    --button-active-border-color: var(--button-fill-neutral-active-border-color);
+    --button-active-text-color: var(--button-fill-neutral-active-text-color);
+    --button-active-bg-color: var(--button-fill-neutral-active-bg-color);
+    --button-loader-color: var(--button-fill-neutral-loader-color);
+    --button-disabled-border-color: var(--button-fill-neutral-disabled-border-color);
+    --button-disabled-text-color: var(--button-fill-neutral-disabled-text-color);
+    --button-disabled-bg-color: var(--button-fill-neutral-disabled-bg-color);
   }
 
   &.white {
-    border-color: var(--button-fill-white-border-color);
-    color: var(--button-fill-white-text-color);
-    background-color: var(--button-fill-white-bg-color);
-
-    &:hover  { background-color: var(--button-fill-white-hover-bg-color); }
-    &:active { background-color: var(--button-fill-white-active-bg-color); }
-
-    & .loader-icon { color: var(--button-fill-white-loader-color); }
+    --button-border-color: var(--button-fill-white-border-color);
+    --button-text-color: var(--button-fill-white-text-color);
+    --button-bg-color: var(--button-fill-white-bg-color);
+    --button-hover-border-color: var(--button-fill-white-hover-border-color);
+    --button-hover-text-color: var(--button-fill-white-hover-text-color);
+    --button-hover-bg-color: var(--button-fill-white-hover-bg-color);
+    --button-active-border-color: var(--button-fill-white-active-border-color);
+    --button-active-text-color: var(--button-fill-white-active-text-color);
+    --button-active-bg-color: var(--button-fill-white-active-bg-color);
+    --button-loader-color: var(--button-fill-white-loader-color);
+    --button-disabled-border-color: var(--button-fill-white-disabled-border-color);
+    --button-disabled-text-color: var(--button-fill-white-disabled-text-color);
+    --button-disabled-bg-color: var(--button-fill-white-disabled-bg-color);
   }
 
   &.black {
-    border-color: var(--button-fill-black-border-color);
-    color: var(--button-fill-black-text-color);
-    background-color: var(--button-fill-black-bg-color);
-
-    &:hover  { background-color: var(--button-fill-black-hover-bg-color); }
-    &:active { background-color: var(--button-fill-black-active-bg-color); }
-
-    & .loader-icon { color: var(--button-fill-black-loader-color); }
+    --button-border-color: var(--button-fill-black-border-color);
+    --button-text-color: var(--button-fill-black-text-color);
+    --button-bg-color: var(--button-fill-black-bg-color);
+    --button-hover-border-color: var(--button-fill-black-hover-border-color);
+    --button-hover-text-color: var(--button-fill-black-hover-text-color);
+    --button-hover-bg-color: var(--button-fill-black-hover-bg-color);
+    --button-active-border-color: var(--button-fill-black-active-border-color);
+    --button-active-text-color: var(--button-fill-black-active-text-color);
+    --button-active-bg-color: var(--button-fill-black-active-bg-color);
+    --button-loader-color: var(--button-fill-black-loader-color);
+    --button-disabled-border-color: var(--button-fill-black-disabled-border-color);
+    --button-disabled-text-color: var(--button-fill-black-disabled-text-color);
+    --button-disabled-bg-color: var(--button-fill-black-disabled-bg-color);
   }
 
   &.info {
-    border-color: var(--button-fill-info-border-color);
-    color: var(--button-fill-info-text-color);
-    background-color: var(--button-fill-info-bg-color);
-
-    &:hover  { background-color: var(--button-fill-info-hover-bg-color); }
-    &:active { background-color: var(--button-fill-info-active-bg-color); }
-
-    & .loader-icon { color: var(--button-fill-info-loader-color); }
+    --button-border-color: var(--button-fill-info-border-color);
+    --button-text-color: var(--button-fill-info-text-color);
+    --button-bg-color: var(--button-fill-info-bg-color);
+    --button-hover-border-color: var(--button-fill-info-hover-border-color);
+    --button-hover-text-color: var(--button-fill-info-hover-text-color);
+    --button-hover-bg-color: var(--button-fill-info-hover-bg-color);
+    --button-active-border-color: var(--button-fill-info-active-border-color);
+    --button-active-text-color: var(--button-fill-info-active-text-color);
+    --button-active-bg-color: var(--button-fill-info-active-bg-color);
+    --button-loader-color: var(--button-fill-info-loader-color);
+    --button-disabled-border-color: var(--button-fill-info-disabled-border-color);
+    --button-disabled-text-color: var(--button-fill-info-disabled-text-color);
+    --button-disabled-bg-color: var(--button-fill-info-disabled-bg-color);
   }
 
   &.success {
-    border-color: var(--button-fill-success-border-color);
-    color: var(--button-fill-success-text-color);
-    background-color: var(--button-fill-success-bg-color);
-
-    &:hover  { background-color: var(--button-fill-success-hover-bg-color); }
-    &:active { background-color: var(--button-fill-success-active-bg-color); }
-
-    & .loader-icon { color: var(--button-fill-success-loader-color); }
+    --button-border-color: var(--button-fill-success-border-color);
+    --button-text-color: var(--button-fill-success-text-color);
+    --button-bg-color: var(--button-fill-success-bg-color);
+    --button-hover-border-color: var(--button-fill-success-hover-border-color);
+    --button-hover-text-color: var(--button-fill-success-hover-text-color);
+    --button-hover-bg-color: var(--button-fill-success-hover-bg-color);
+    --button-active-border-color: var(--button-fill-success-active-border-color);
+    --button-active-text-color: var(--button-fill-success-active-text-color);
+    --button-active-bg-color: var(--button-fill-success-active-bg-color);
+    --button-loader-color: var(--button-fill-success-loader-color);
+    --button-disabled-border-color: var(--button-fill-success-disabled-border-color);
+    --button-disabled-text-color: var(--button-fill-success-disabled-text-color);
+    --button-disabled-bg-color: var(--button-fill-success-disabled-bg-color);
   }
 
   &.warning {
-    border-color: var(--button-fill-warning-border-color);
-    color: var(--button-fill-warning-text-color);
-    background-color: var(--button-fill-warning-bg-color);
-
-    &:hover  { background-color: var(--button-fill-warning-hover-bg-color); }
-    &:active { background-color: var(--button-fill-warning-active-bg-color); }
-
-    & .loader-icon { color: var(--button-fill-warning-loader-color); }
+    --button-border-color: var(--button-fill-warning-border-color);
+    --button-text-color: var(--button-fill-warning-text-color);
+    --button-bg-color: var(--button-fill-warning-bg-color);
+    --button-hover-border-color: var(--button-fill-warning-hover-border-color);
+    --button-hover-text-color: var(--button-fill-warning-hover-text-color);
+    --button-hover-bg-color: var(--button-fill-warning-hover-bg-color);
+    --button-active-border-color: var(--button-fill-warning-active-border-color);
+    --button-active-text-color: var(--button-fill-warning-active-text-color);
+    --button-active-bg-color: var(--button-fill-warning-active-bg-color);
+    --button-loader-color: var(--button-fill-warning-loader-color);
+    --button-disabled-border-color: var(--button-fill-warning-disabled-border-color);
+    --button-disabled-text-color: var(--button-fill-warning-disabled-text-color);
+    --button-disabled-bg-color: var(--button-fill-warning-disabled-bg-color);
   }
 
   &.danger {
-    border-color: var(--button-fill-danger-border-color);
-    color: var(--button-fill-danger-text-color);
-    background-color: var(--button-fill-danger-bg-color);
-
-    &:hover  { background-color: var(--button-fill-danger-hover-bg-color); }
-    &:active { background-color: var(--button-fill-danger-active-bg-color); }
-
-    & .loader-icon { color: var(--button-fill-danger-loader-color); }
+    --button-border-color: var(--button-fill-danger-border-color);
+    --button-text-color: var(--button-fill-danger-text-color);
+    --button-bg-color: var(--button-fill-danger-bg-color);
+    --button-hover-border-color: var(--button-fill-danger-hover-border-color);
+    --button-hover-text-color: var(--button-fill-danger-hover-text-color);
+    --button-hover-bg-color: var(--button-fill-danger-hover-bg-color);
+    --button-active-border-color: var(--button-fill-danger-active-border-color);
+    --button-active-text-color: var(--button-fill-danger-active-text-color);
+    --button-active-bg-color: var(--button-fill-danger-active-bg-color);
+    --button-loader-color: var(--button-fill-danger-loader-color);
+    --button-disabled-border-color: var(--button-fill-danger-disabled-border-color);
+    --button-disabled-text-color: var(--button-fill-danger-disabled-text-color);
+    --button-disabled-bg-color: var(--button-fill-danger-disabled-bg-color);
   }
 }
 
 .SButton.fill .icon,
 .SButton.fill .label {
-  &.neutral { color: var(--button-fill-neutral-content-color);}
-  &.mute    { color: var(--button-fill-mute-content-color); }
-  &.white   { color: var(--button-fill-white-content-color); }
-  &.black   { color: var(--button-fill-black-content-color); }
-  &.info    { color: var(--button-fill-info-content-color); }
-  &.success { color: var(--button-fill-success-content-color); }
-  &.warning { color: var(--button-fill-warning-content-color); }
-  &.danger  { color: var(--button-fill-danger-content-color); }
-}
-
-.SButton.fill.disabled {
-  &.neutral {
-    border-color: var(--button-fill-neutral-disabled-border-color);
-    color: var(--button-fill-neutral-disabled-text-color);
-    background-color: var(--button-fill-neutral-disabled-bg-color);
-
-    &:hover  { background-color: var(--button-fill-neutral-disabled-bg-color); }
-    &:active { background-color: var(--button-fill-neutral-disabled-bg-color); }
-  }
-
-  &.white {
-    border-color: var(--button-fill-white-disabled-border-color);
-    color: var(--button-fill-white-disabled-text-color);
-    background-color: var(--button-fill-white-disabled-bg-color);
-
-    &:hover  { background-color: var(--button-fill-white-disabled-bg-color); }
-    &:active { background-color: var(--button-fill-white-disabled-bg-color); }
-  }
-
-  &.black {
-    border-color: var(--button-fill-black-disabled-border-color);
-    color: var(--button-fill-black-disabled-text-color);
-    background-color: var(--button-fill-black-disabled-bg-color);
-
-    &:hover  { background-color: var(--button-fill-black-disabled-bg-color); }
-    &:active { background-color: var(--button-fill-black-disabled-bg-color); }
+  &.default {
+    --button-content-color: var(--button-fill-default-content-color);
+    --button-disabled-content-color: var(--button-fill-default-disabled-content-color);
   }
 
   &.mute {
-    border-color: var(--button-fill-mute-disabled-border-color);
-    color: var(--button-fill-mute-disabled-text-color);
-    background-color: var(--button-fill-mute-disabled-bg-color);
+    --button-content-color: var(--button-fill-mute-content-color);
+    --button-disabled-content-color: var(--button-fill-mute-disabled-content-color);
+  }
 
-    &:hover  { background-color: var(--button-fill-mute-disabled-bg-color); }
-    &:active { background-color: var(--button-fill-mute-disabled-bg-color); }
+  &.neutral {
+    --button-content-color: var(--button-fill-neutral-content-color);
+    --button-disabled-content-color: var(--button-fill-neutral-disabled-content-color);
+  }
+
+  &.white {
+    --button-content-color: var(--button-fill-white-content-color);
+    --button-disabled-content-color: var(--button-fill-white-disabled-content-color);
+  }
+
+  &.black {
+    --button-content-color: var(--button-fill-black-content-color);
+    --button-disabled-content-color: var(--button-fill-black-disabled-content-color);
   }
 
   &.info {
-    border-color: var(--button-fill-info-disabled-border-color);
-    color: var(--button-fill-info-disabled-text-color);
-    background-color: var(--button-fill-info-disabled-bg-color);
-
-    &:hover  { background-color: var(--button-fill-info-disabled-bg-color); }
-    &:active { background-color: var(--button-fill-info-disabled-bg-color); }
+    --button-content-color: var(--button-fill-info-content-color);
+    --button-disabled-content-color: var(--button-fill-info-disabled-content-color);
   }
 
   &.success {
-    border-color: var(--button-fill-success-disabled-border-color);
-    color: var(--button-fill-success-disabled-text-color);
-    background-color: var(--button-fill-success-disabled-bg-color);
-
-    &:hover  { background-color: var(--button-fill-success-disabled-bg-color); }
-    &:active { background-color: var(--button-fill-success-disabled-bg-color); }
+    --button-content-color: var(--button-fill-success-content-color);
+    --button-disabled-content-color: var(--button-fill-success-disabled-content-color);
   }
 
   &.warning {
-    border-color: var(--button-fill-warning-disabled-border-color);
-    color: var(--button-fill-warning-disabled-text-color);
-    background-color: var(--button-fill-warning-disabled-bg-color);
-
-    &:hover  { background-color: var(--button-fill-warning-disabled-bg-color); }
-    &:active { background-color: var(--button-fill-warning-disabled-bg-color); }
+    --button-content-color: var(--button-fill-warning-content-color);
+    --button-disabled-content-color: var(--button-fill-warning-disabled-content-color);
   }
 
   &.danger {
-    border-color: var(--button-fill-danger-disabled-border-color);
-    color: var(--button-fill-danger-disabled-text-color);
-    background-color: var(--button-fill-danger-disabled-bg-color);
-
-    &:hover  { background-color: var(--button-fill-danger-disabled-bg-color); }
-    &:active { background-color: var(--button-fill-danger-disabled-bg-color); }
+    --button-content-color: var(--button-fill-danger-content-color);
+    --button-disabled-content-color: var(--button-fill-danger-disabled-content-color);
   }
-}
-
-.SButton.fill.disabled .icon,
-.SButton.fill.disabled .label {
-  &.neutral { color: var(--button-fill-neutral-disabled-content-color); }
-  &.white   { color: var(--button-fill-white-disabled-content-color); }
-  &.black   { color: var(--button-fill-black-disabled-content-color); }
-  &.mute    { color: var(--button-fill-mute-disabled-content-color); }
-  &.info    { color: var(--button-fill-info-disabled-content-color); }
-  &.success { color: var(--button-fill-success-disabled-content-color); }
-  &.warning { color: var(--button-fill-warning-disabled-content-color); }
-  &.danger  { color: var(--button-fill-danger-disabled-content-color); }
 }
 
 .SButton.outline {
   font-weight: 500;
 
-  &.neutral {
-    border-color: var(--button-outline-neutral-border-color);
-    color: var(--button-outline-neutral-text-color);
+  --button-loader-color: var(--c-neutral-1);
+  --button-hover-border-color: var(--button-border-color);
+  --button-hover-text-color: var(--button-text-color);
+  --button-active-border-color: var(--button-border-color);
+  --button-active-text-color: var(--button-text-color);
 
-    &:hover  { background-color: var(--button-outline-neutral-hover-bg-color); }
-    &:active { background-color: var(--button-outline-neutral-active-bg-color); }
-
-    & .loader-icon { color: var(--button-outline-neutral-loader-color); }
-  }
-
-  &.white {
-    border-color: var(--button-outline-white-border-color);
-    color: var(--button-outline-white-text-color);
-
-    &:hover  { background-color: var(--button-outline-white-hover-bg-color); }
-    &:active { background-color: var(--button-outline-white-active-bg-color); }
-
-    & .loader-icon { color: var(--button-outline-white-loader-color); }
-  }
-
-  &.black {
-    border-color: var(--button-outline-black-border-color);
-    color: var(--button-outline-black-text-color);
-
-    &:hover  { background-color: var(--button-outline-black-hover-bg-color); }
-    &:active { background-color: var(--button-outline-black-active-bg-color); }
-
-    & .loader-icon { color: var(--button-outline-black-loader-color); }
+  &.default {
+    --button-border-color: var(--button-outline-default-border-color);
+    --button-text-color: var(--button-outline-default-text-color);
+    --button-hover-bg-color: var(--button-outline-default-hover-bg-color);
+    --button-active-bg-color: var(--button-outline-default-active-bg-color);
+    --button-disabled-border-color: var(--button-outline-default-disabled-border-color);
+    --button-disabled-text-color: var(--button-outline-default-disabled-text-color);
   }
 
   &.mute {
-    border-color: var(--button-outline-mute-border-color);
-    color: var(--button-outline-mute-text-color);
+    --button-border-color: var(--button-outline-mute-border-color);
+    --button-text-color: var(--button-outline-mute-text-color);
+    --button-hover-bg-color: var(--button-outline-mute-hover-bg-color);
+    --button-active-bg-color: var(--button-outline-mute-active-bg-color);
+    --button-disabled-border-color: var(--button-outline-mute-disabled-border-color);
+    --button-disabled-text-color: var(--button-outline-mute-disabled-text-color);
+  }
 
-    &:hover  { background-color: var(--button-outline-mute-hover-bg-color); }
-    &:active { background-color: var(--button-outline-mute-active-bg-color); }
+  &.neutral {
+    --button-border-color: var(--button-outline-neutral-border-color);
+    --button-text-color: var(--button-outline-neutral-text-color);
+    --button-hover-bg-color: var(--button-outline-neutral-hover-bg-color);
+    --button-active-bg-color: var(--button-outline-neutral-active-bg-color);
+    --button-disabled-border-color: var(--button-outline-neutral-disabled-border-color);
+    --button-disabled-text-color: var(--button-outline-neutral-disabled-text-color);
+  }
 
-    & .loader-icon { color: var(--button-outline-mute-loader-color); }
+  &.white {
+    --button-border-color: var(--button-outline-white-border-color);
+    --button-text-color: var(--button-outline-white-text-color);
+    --button-hover-bg-color: var(--button-outline-white-hover-bg-color);
+    --button-active-bg-color: var(--button-outline-white-active-bg-color);
+    --button-disabled-border-color: var(--button-outline-white-disabled-border-color);
+    --button-disabled-text-color: var(--button-outline-white-disabled-text-color);
+  }
+
+  &.black {
+    --button-border-color: var(--button-outline-black-border-color);
+    --button-text-color: var(--button-outline-black-text-color);
+    --button-hover-bg-color: var(--button-outline-black-hover-bg-color);
+    --button-active-bg-color: var(--button-outline-black-active-bg-color);
+    --button-disabled-border-color: var(--button-outline-black-disabled-border-color);
+    --button-disabled-text-color: var(--button-outline-black-disabled-text-color);
   }
 
   &.info {
-    border-color: var(--button-outline-info-border-color);
-    color: var(--button-outline-info-text-color);
-
-    &:hover  { background-color: var(--button-outline-info-hover-bg-color); }
-    &:active { background-color: var(--button-outline-info-active-bg-color); }
-
-    & .loader-icon { color: var(--button-outline-info-loader-color); }
+    --button-border-color: var(--button-outline-info-border-color);
+    --button-text-color: var(--button-outline-info-text-color);
+    --button-hover-bg-color: var(--button-outline-info-hover-bg-color);
+    --button-active-bg-color: var(--button-outline-info-active-bg-color);
+    --button-disabled-border-color: var(--button-outline-info-disabled-border-color);
+    --button-disabled-text-color: var(--button-outline-info-disabled-text-color);
   }
 
   &.success {
-    border-color: var(--button-outline-success-border-color);
-    color: var(--button-outline-success-text-color);
-
-    &:hover  { background-color: var(--button-outline-success-hover-bg-color); }
-    &:active { background-color: var(--button-outline-success-active-bg-color); }
-
-    & .loader-icon { color: var(--button-outline-success-loader-color); }
+    --button-border-color: var(--button-outline-success-border-color);
+    --button-text-color: var(--button-outline-success-text-color);
+    --button-hover-bg-color: var(--button-outline-success-hover-bg-color);
+    --button-active-bg-color: var(--button-outline-success-active-bg-color);
+    --button-disabled-border-color: var(--button-outline-success-disabled-border-color);
+    --button-disabled-text-color: var(--button-outline-success-disabled-text-color);
   }
 
   &.warning {
-    border-color: var(--button-outline-warning-border-color);
-    color: var(--button-outline-warning-text-color);
-
-    &:hover  { background-color: var(--button-outline-warning-hover-bg-color); }
-    &:active { background-color: var(--button-outline-warning-active-bg-color); }
-
-    & .loader-icon { color: var(--button-outline-warning-loader-color); }
+    --button-border-color: var(--button-outline-warning-border-color);
+    --button-text-color: var(--button-outline-warning-text-color);
+    --button-hover-bg-color: var(--button-outline-warning-hover-bg-color);
+    --button-active-bg-color: var(--button-outline-warning-active-bg-color);
+    --button-disabled-border-color: var(--button-outline-warning-disabled-border-color);
+    --button-disabled-text-color: var(--button-outline-warning-disabled-text-color);
   }
 
   &.danger {
-    border-color: var(--button-outline-danger-border-color);
-    color: var(--button-outline-danger-text-color);
-
-    &:hover  { background-color: var(--button-outline-danger-hover-bg-color); }
-    &:active { background-color: var(--button-outline-danger-active-bg-color); }
-
-    & .loader-icon { color: var(--button-outline-danger-loader-color); }
+    --button-border-color: var(--button-outline-danger-border-color);
+    --button-text-color: var(--button-outline-danger-text-color);
+    --button-hover-bg-color: var(--button-outline-danger-hover-bg-color);
+    --button-active-bg-color: var(--button-outline-danger-active-bg-color);
+    --button-disabled-border-color: var(--button-outline-danger-disabled-border-color);
+    --button-disabled-text-color: var(--button-outline-danger-disabled-text-color);
   }
 }
 
 .SButton.outline .icon,
 .SButton.outline .label {
-  &.neutral { color: var(--button-outline-neutral-content-color); }
-  &.white   { color: var(--button-outline-white-content-color); }
-  &.black   { color: var(--button-outline-black-content-color); }
-  &.mute    { color: var(--button-outline-mute-content-color); }
-  &.info    { color: var(--button-outline-info-content-color); }
-  &.success { color: var(--button-outline-success-content-color); }
-  &.warning { color: var(--button-outline-warning-content-color); }
-  &.danger  { color: var(--button-outline-danger-content-color); }
-}
-
-.SButton.outline.disabled {
-  &.neutral {
-    border-color: var(--button-outline-neutral-disabled-border-color);
-    color: var(--button-outline-neutral-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
-  }
-
-  &.white {
-    border-color: var(--button-outline-white-disabled-border-color);
-    color: var(--button-outline-white-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
-  }
-
-  &.black {
-    border-color: var(--button-outline-black-disabled-border-color);
-    color: var(--button-outline-black-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+  &.default {
+    --button-content-color: var(--button-outline-default-content-color);
+    --button-disabled-content-color: var(--button-outline-default-disabled-content-color);
   }
 
   &.mute {
-    border-color: var(--button-outline-mute-disabled-border-color);
-    color: var(--button-outline-mute-disabled-text-color);
+    --button-content-color: var(--button-outline-mute-content-color);
+    --button-disabled-content-color: var(--button-outline-mute-disabled-content-color);
+  }
 
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+  &.neutral {
+    --button-content-color: var(--button-outline-neutral-content-color);
+    --button-disabled-content-color: var(--button-outline-neutral-disabled-content-color);
+  }
+
+  &.white {
+    --button-content-color: var(--button-outline-white-content-color);
+    --button-disabled-content-color: var(--button-outline-white-disabled-content-color);
+  }
+
+  &.black {
+    --button-content-color: var(--button-outline-black-content-color);
+    --button-disabled-content-color: var(--button-outline-black-disabled-content-color);
   }
 
   &.info {
-    border-color: var(--button-outline-info-disabled-border-color);
-    color: var(--button-outline-info-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+    --button-content-color: var(--button-outline-info-content-color);
+    --button-disabled-content-color: var(--button-outline-info-disabled-content-color);
   }
 
   &.success {
-    border-color: var(--button-outline-success-disabled-border-color);
-    color: var(--button-outline-success-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+    --button-content-color: var(--button-outline-success-content-color);
+    --button-disabled-content-color: var(--button-outline-success-disabled-content-color);
   }
 
   &.warning {
-    border-color: var(--button-outline-warning-disabled-border-color);
-    color: var(--button-outline-warning-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+    --button-content-color: var(--button-outline-warning-content-color);
+    --button-disabled-content-color: var(--button-outline-warning-disabled-content-color);
   }
 
   &.danger {
-    border-color: var(--button-outline-danger-disabled-border-color);
-    color: var(--button-outline-danger-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+    --button-content-color: var(--button-outline-danger-content-color);
+    --button-disabled-content-color: var(--button-outline-danger-disabled-content-color);
   }
-}
-
-.SButton.outline.disabled .icon,
-.SButton.outline.disabled .label {
-  &.neutral { color: var(--button-outline-neutral-disabled-content-color); }
-  &.white   { color: var(--button-outline-white-disabled-content-color); }
-  &.black   { color: var(--button-outline-black-disabled-content-color); }
-  &.mute    { color: var(--button-outline-mute-disabled-content-color); }
-  &.info    { color: var(--button-outline-info-disabled-content-color); }
-  &.success { color: var(--button-outline-success-disabled-content-color); }
-  &.warning { color: var(--button-outline-warning-disabled-content-color); }
-  &.danger  { color: var(--button-outline-danger-disabled-content-color); }
 }
 
 .SButton.text {
   font-weight: 500;
 
-  & .loader-icon { color: var(--c-neutral); }
+  --button-border-color: transparent;
+  --button-loader-color: var(--c-neutral-1);
+  --button-hover-border-color: var(--button-border-color);
+  --button-hover-text-color: var(--button-text-color);
+  --button-active-border-color: var(--button-border-color);
+  --button-active-text-color: var(--button-text-color);
+  --button-disabled-border-color: var(--button-border-color);
 
-  &.neutral {
-    color: var(--button-text-neutral-text-color);
-
-    &:hover  { background-color: var(--button-text-neutral-hover-bg-color); }
-    &:active { background-color: var(--button-text-neutral-active-bg-color); }
-  }
-
-  &.white {
-    color: var(--button-text-white-text-color);
-
-    &:hover  { background-color: var(--button-text-white-hover-bg-color); }
-    &:active { background-color: var(--button-text-white-active-bg-color); }
-  }
-
-  &.black {
-    color: var(--button-text-black-text-color);
-
-    &:hover  { background-color: var(--button-text-black-hover-bg-color); }
-    &:active { background-color: var(--button-text-black-active-bg-color); }
+  &.default {
+    --button-text-color: var(--button-text-default-text-color);
+    --button-hover-bg-color: var(--button-text-default-hover-bg-color);
+    --button-active-bg-color: var(--button-text-default-active-bg-color);
+    --button-disabled-text-color: var(--button-text-default-disabled-text-color);
   }
 
   &.mute {
-    color: var(--button-text-mute-text-color);
+    --button-text-color: var(--button-text-mute-text-color);
+    --button-hover-bg-color: var(--button-text-mute-hover-bg-color);
+    --button-active-bg-color: var(--button-text-mute-active-bg-color);
+    --button-disabled-text-color: var(--button-text-mute-disabled-text-color);
+  }
 
-    &:hover  { background-color: var(--button-text-mute-hover-bg-color); }
-    &:active { background-color: var(--button-text-mute-active-bg-color); }
+  &.neutral {
+    --button-text-color: var(--button-text-neutral-text-color);
+    --button-hover-bg-color: var(--button-text-neutral-hover-bg-color);
+    --button-active-bg-color: var(--button-text-neutral-active-bg-color);
+    --button-disabled-text-color: var(--button-text-neutral-disabled-text-color);
+  }
+
+  &.white {
+    --button-text-color: var(--button-text-white-text-color);
+    --button-hover-bg-color: var(--button-text-white-hover-bg-color);
+    --button-active-bg-color: var(--button-text-white-active-bg-color);
+    --button-disabled-text-color: var(--button-text-white-disabled-text-color);
+  }
+
+  &.black {
+    --button-text-color: var(--button-text-black-text-color);
+    --button-hover-bg-color: var(--button-text-black-hover-bg-color);
+    --button-active-bg-color: var(--button-text-black-active-bg-color);
+    --button-disabled-text-color: var(--button-text-black-disabled-text-color);
   }
 
   &.info {
-    color: var(--button-text-info-text-color);
-
-    &:hover  { background-color: var(--button-text-info-hover-bg-color); }
-    &:active { background-color: var(--button-text-info-active-bg-color); }
+    --button-text-color: var(--button-text-info-text-color);
+    --button-hover-bg-color: var(--button-text-info-hover-bg-color);
+    --button-active-bg-color: var(--button-text-info-active-bg-color);
+    --button-disabled-text-color: var(--button-text-info-disabled-text-color);
   }
 
   &.success {
-    color: var(--button-text-success-text-color);
-
-    &:hover  { background-color: var(--button-text-success-hover-bg-color); }
-    &:active { background-color: var(--button-text-success-active-bg-color); }
+    --button-text-color: var(--button-text-success-text-color);
+    --button-hover-bg-color: var(--button-text-success-hover-bg-color);
+    --button-active-bg-color: var(--button-text-success-active-bg-color);
+    --button-disabled-text-color: var(--button-text-success-disabled-text-color);
   }
 
   &.warning {
-    color: var(--button-text-warning-text-color);
-
-    &:hover  { background-color: var(--button-text-warning-hover-bg-color); }
-    &:active { background-color: var(--button-text-warning-active-bg-color); }
+    --button-text-color: var(--button-text-warning-text-color);
+    --button-hover-bg-color: var(--button-text-warning-hover-bg-color);
+    --button-active-bg-color: var(--button-text-warning-active-bg-color);
+    --button-disabled-text-color: var(--button-text-warning-disabled-text-color);
   }
 
   &.danger {
-    color: var(--button-text-danger-text-color);
-
-    &:hover  { background-color: var(--button-text-danger-hover-bg-color); }
-    &:active { background-color: var(--button-text-danger-active-bg-color); }
+    --button-text-color: var(--button-text-danger-text-color);
+    --button-hover-bg-color: var(--button-text-danger-hover-bg-color);
+    --button-active-bg-color: var(--button-text-danger-active-bg-color);
+    --button-disabled-text-color: var(--button-text-danger-disabled-text-color);
   }
 }
 
 .SButton.text .icon,
 .SButton.text .label {
-  &.neutral { color: var(--button-text-neutral-content-color); }
-  &.white   { color: var(--button-text-white-content-color); }
-  &.black   { color: var(--button-text-black-content-color); }
-  &.mute    { color: var(--button-text-mute-content-color); }
-  &.info    { color: var(--button-text-info-content-color); }
-  &.success { color: var(--button-text-success-content-color); }
-  &.warning { color: var(--button-text-warning-content-color); }
-  &.danger  { color: var(--button-text-danger-content-color); }
-}
-
-.SButton.text.disabled {
-  &.neutral {
-    color: var(--button-text-neutral-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
-  }
-
-  &.white {
-    color: var(--button-text-white-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
-  }
-
-  &.black {
-    color: var(--button-text-black-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+  &.default {
+    --button-content-color: var(--button-text-default-content-color);
+    --button-disabled-content-color: var(--button-text-default-disabled-content-color);
   }
 
   &.mute {
-    color: var(--button-text-mute-disabled-text-color);
+    --button-content-color: var(--button-text-mute-content-color);
+    --button-disabled-content-color: var(--button-text-mute-disabled-content-color);
+  }
 
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+  &.neutral {
+    --button-content-color: var(--button-text-neutral-content-color);
+    --button-disabled-content-color: var(--button-text-neutral-disabled-content-color);
+  }
+
+  &.white {
+    --button-content-color: var(--button-text-white-content-color);
+    --button-disabled-content-color: var(--button-text-white-disabled-content-color);
+  }
+
+  &.black {
+    --button-content-color: var(--button-text-black-content-color);
+    --button-disabled-content-color: var(--button-text-black-disabled-content-color);
   }
 
   &.info {
-    color: var(--button-text-info-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+    --button-content-color: var(--button-text-info-content-color);
+    --button-disabled-content-color: var(--button-text-info-disabled-content-color);
   }
 
   &.success {
-    color: var(--button-text-success-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+    --button-content-color: var(--button-text-success-content-color);
+    --button-disabled-content-color: var(--button-text-success-disabled-content-color);
   }
 
   &.warning {
-    color: var(--button-text-warning-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+    --button-content-color: var(--button-text-warning-content-color);
+    --button-disabled-content-color: var(--button-text-warning-disabled-content-color);
   }
 
   &.danger {
-    color: var(--button-text-danger-disabled-text-color);
-
-    &:hover  { background-color: transparent; }
-    &:active { background-color: transparent; }
+    --button-content-color: var(--button-text-danger-content-color);
+    --button-disabled-content-color: var(--button-text-danger-disabled-content-color);
   }
-}
-
-.SButton.text.disabled .icon,
-.SButton.text.disabled .label {
-  &.neutral { color: var(--button-text-neutral-disabled-content-color); }
-  &.white   { color: var(--button-text-white-disabled-content-color); }
-  &.black   { color: var(--button-text-black-disabled-content-color); }
-  &.mute    { color: var(--button-text-mute-disabled-content-color); }
-  &.info    { color: var(--button-text-info-disabled-content-color); }
-  &.success { color: var(--button-text-success-disabled-content-color); }
-  &.warning { color: var(--button-text-warning-disabled-content-color); }
-  &.danger  { color: var(--button-text-danger-disabled-content-color); }
 }
 
 .SButton.block {
@@ -714,40 +735,5 @@ function handleClick(): void {
     opacity: 0;
     transform: scale(.9);
   }
-}
-
-.SButton.disabled {
-  cursor: not-allowed;
-}
-
-.content {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-  transition: opacity 0.25s, transform 0.25s;
-}
-
-.loader {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  z-index: 10;
-  width: 32px;
-  height: 32px;
-  color: var(--c-text-1);
-  transform: translate(-50%, -50%);
-  transition: opacity 0.25s, transform 0.25s;
-}
-
-.loader.fade-enter-from,
-.loader.fade-leave-to {
-  opacity: 0;
-  transform: translate(-50%, -50%) scale(1.5);
-}
-
-.loader-icon {
-  width: 32px;
-  height: 32px;
 }
 </style>

--- a/lib/components/STableHeaderActionItem.vue
+++ b/lib/components/STableHeaderActionItem.vue
@@ -4,7 +4,7 @@ import SButton from './SButton.vue'
 
 withDefaults(defineProps<TableHeaderAction>(), {
   show: true,
-  mode: 'mute',
+  mode: 'default',
   labelMode: 'neutral'
 })
 </script>

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -1,4 +1,5 @@
 import { type Component, type MaybeRef } from 'vue'
+import { type Mode } from '../components/SButton.vue'
 import { type Day } from '../support/Day'
 import { type DropdownSection } from './Dropdown'
 
@@ -183,11 +184,11 @@ export interface TableCellActions extends TableCellBase {
 }
 
 export interface TableCellAction {
-  mode?: ColorModes
+  mode?: Mode
   icon?: any
-  iconMode?: ColorModes
+  iconMode?: Mode
   label?: string
-  labelMode?: ColorModes
+  labelMode?: Mode
   onClick(value: any, record: any): void
 }
 
@@ -199,9 +200,9 @@ export interface TableMenu {
 
 export interface TableHeaderAction {
   show?: boolean
-  mode?: ColorModes
+  mode?: Mode
   label: string
-  labelMode?: ColorModes
+  labelMode?: Mode
   onClick(): void
 }
 

--- a/lib/styles/variables.css
+++ b/lib/styles/variables.css
@@ -477,12 +477,48 @@
   --button-large-font-size: 14px;
   --button-jumbo-font-size: 16px;
 
+  --button-fill-default-border-color: var(--c-divider-1);
+  --button-fill-default-text-color: var(--c-text-1);
+  --button-fill-default-content-color: var(--c-text-1);
+  --button-fill-default-bg-color: var(--c-mute);
+  --button-fill-default-loader-color: var(--c-neutral);
+  --button-fill-default-hover-border-color: var(--c-divider-1);
+  --button-fill-default-hover-text-color: var(--c-text-1);
+  --button-fill-default-hover-bg-color: var(--c-mute-dark);
+  --button-fill-default-active-border-color: var(--c-divider-1);
+  --button-fill-default-active-text-color: var(--c-text-1);
+  --button-fill-default-active-bg-color: var(--c-mute-darker);
+  --button-fill-default-disabled-border-color: var(--c-divider-2);
+  --button-fill-default-disabled-text-color: var(--c-text-2);
+  --button-fill-default-disabled-content-color: var(--c-text-2);
+  --button-fill-default-disabled-bg-color: var(--c-mute-dark);
+
+  --button-fill-mute-border-color: var(--c-divider-1);
+  --button-fill-mute-text-color: var(--c-text-2);
+  --button-fill-mute-content-color: var(--c-text-2);
+  --button-fill-mute-bg-color: var(--c-mute);
+  --button-fill-mute-loader-color: var(--c-neutral);
+  --button-fill-mute-hover-border-color: var(--c-divider-1);
+  --button-fill-mute-hover-text-color: var(--c-text-1);
+  --button-fill-mute-hover-bg-color: var(--c-mute-dark);
+  --button-fill-mute-active-border-color: var(--c-divider-1);
+  --button-fill-mute-active-text-color: var(--c-text-2);
+  --button-fill-mute-active-bg-color: var(--c-mute-darker);
+  --button-fill-mute-disabled-border-color: var(--c-divider-2);
+  --button-fill-mute-disabled-text-color: var(--c-text-2);
+  --button-fill-mute-disabled-content-color: var(--c-text-2);
+  --button-fill-mute-disabled-bg-color: var(--c-mute-dark);
+
   --button-fill-neutral-border-color: transparent;
   --button-fill-neutral-text-color: var(--c-text-inverse-1);
   --button-fill-neutral-content-color: var(--c-text-1);
   --button-fill-neutral-bg-color: var(--c-neutral-1);
   --button-fill-neutral-loader-color: var(--c-neutral-inverse-1);
+  --button-fill-neutral-hover-border-color: transparent;
+  --button-fill-neutral-hover-text-color: var(--c-text-inverse-1);
   --button-fill-neutral-hover-bg-color: var(--c-neutral-2);
+  --button-fill-neutral-active-border-color: transparent;
+  --button-fill-neutral-active-text-color: var(--c-text-inverse-1);
   --button-fill-neutral-active-bg-color: var(--c-neutral-3);
   --button-fill-neutral-disabled-border-color: transparent;
   --button-fill-neutral-disabled-text-color: var(--c-text-inverse-2);
@@ -494,7 +530,11 @@
   --button-fill-white-content-color: var(--c-text-dark-1);
   --button-fill-white-bg-color: var(--c-neutral-dark-1);
   --button-fill-white-loader-color: var(--c-neutral-light-1);
+  --button-fill-white-hover-border-color: transparent;
+  --button-fill-white-hover-text-color: var(--c-text-light-1);
   --button-fill-white-hover-bg-color: var(--c-neutral-dark-2);
+  --button-fill-white-active-border-color: transparent;
+  --button-fill-white-active-text-color: var(--c-text-light-1);
   --button-fill-white-active-bg-color: var(--c-neutral-dark-3);
   --button-fill-white-disabled-border-color: transparent;
   --button-fill-white-disabled-text-color: var(--c-text-light-2);
@@ -506,31 +546,27 @@
   --button-fill-black-content-color: var(--c-text-light-1);
   --button-fill-black-bg-color: var(--c-neutral-light-1);
   --button-fill-black-loader-color: var(--c-neutral-dark-1);
+  --button-fill-black-hover-border-color: transparent;
+  --button-fill-black-hover-text-color: var(--c-text-dark-1);
   --button-fill-black-hover-bg-color: var(--c-neutral-light-2);
+  --button-fill-black-active-border-color: transparent;
+  --button-fill-black-active-text-color:var(--c-text-dark-1);
   --button-fill-black-active-bg-color: var(--c-neutral-light-3);
   --button-fill-black-disabled-border-color: transparent;
   --button-fill-black-disabled-text-color: var(--c-text-dark-2);
   --button-fill-black-disabled-content-color: var(--c-text-light-2);
   --button-fill-black-disabled-bg-color: var(--c-neutral-light-2);
 
-  --button-fill-mute-border-color: var(--c-divider-1);
-  --button-fill-mute-text-color: var(--c-text-1);
-  --button-fill-mute-content-color: var(--c-text-2);
-  --button-fill-mute-bg-color: var(--c-mute);
-  --button-fill-mute-loader-color: var(--c-neutral);
-  --button-fill-mute-hover-bg-color: var(--c-mute-dark);
-  --button-fill-mute-active-bg-color: var(--c-mute-darker);
-  --button-fill-mute-disabled-border-color: var(--c-divider-2);
-  --button-fill-mute-disabled-text-color: var(--c-text-2);
-  --button-fill-mute-disabled-content-color: var(--c-text-3);
-  --button-fill-mute-disabled-bg-color: var(--c-mute-dark);
-
   --button-fill-info-border-color: var(--c-info-light);
   --button-fill-info-text-color: var(--c-text-dark-1);
   --button-fill-info-content-color: var(--c-info-text);
   --button-fill-info-bg-color: var(--c-info-bg);
   --button-fill-info-loader-color: var(--c-white);
+  --button-fill-info-hover-border-color: var(--c-info-light);
+  --button-fill-info-hover-text-color: var(--c-white);
   --button-fill-info-hover-bg-color: var(--c-info-bg-dark);
+  --button-fill-info-active-border-color: var(--c-info-light);
+  --button-fill-info-active-text-color: var(--c-white);
   --button-fill-info-active-bg-color: var(--c-info-bg-darker);
   --button-fill-info-disabled-border-color: var(--c-info);
   --button-fill-info-disabled-text-color: var(--c-text-dark-2);
@@ -542,36 +578,68 @@
   --button-fill-success-content-color: var(--c-success-text);
   --button-fill-success-bg-color: var(--c-success-bg);
   --button-fill-success-loader-color: var(--c-white);
+  --button-fill-success-hover-border-color: var(--c-success-light);
+  --button-fill-success-hover-text-color: var(--c-white);
   --button-fill-success-hover-bg-color: var(--c-success-bg-dark);
+  --button-fill-success-active-border-color: var(--c-success-light);
+  --button-fill-success-active-text-color: var(--c-white);
   --button-fill-success-active-bg-color: var(--c-success-bg-darker);
   --button-fill-success-disabled-border-color: var(--c-success);
   --button-fill-success-disabled-text-color: var(--c-text-dark-2);
   --button-fill-success-disabled-content-color: var(--c-success-text-dark);
   --button-fill-success-disabled-bg-color: var(--c-success-bg-dark);
 
-  --button-fill-warning-border-color: var(--c-warning-light);
-  --button-fill-warning-text-color: var(--c-text-dark-1);
+  --button-fill-warning-border-color: var(--c-divider-1);
+  --button-fill-warning-text-color: var(--c-warning-text);
   --button-fill-warning-content-color: var(--c-warning-text);
-  --button-fill-warning-bg-color: var(--c-warning-bg);
+  --button-fill-warning-bg-color: var(--c-mute);
   --button-fill-warning-loader-color: var(--c-white);
+  --button-fill-warning-hover-border-color: var(--c-warning-light);
+  --button-fill-warning-hover-text-color: var(--c-white);
   --button-fill-warning-hover-bg-color: var(--c-warning-bg-dark);
+  --button-fill-warning-active-border-color: var(--c-warning-light);
+  --button-fill-warning-active-text-color: var(--c-white);
   --button-fill-warning-active-bg-color: var(--c-warning-bg-darker);
   --button-fill-warning-disabled-border-color: var(--c-warning);
   --button-fill-warning-disabled-text-color: var(--c-text-dark-2);
   --button-fill-warning-disabled-content-color: var(--c-warning-text-dark);
   --button-fill-warning-disabled-bg-color: var(--c-warning-bg-dark);
 
-  --button-fill-danger-border-color: var(--c-danger-light);
-  --button-fill-danger-text-color: var(--c-text-dark-1);
+  --button-fill-danger-border-color: var(--c-divider-1);
+  --button-fill-danger-text-color: var(--c-danger-text);
   --button-fill-danger-content-color: var(--c-danger-text);
-  --button-fill-danger-bg-color: var(--c-danger-bg);
+  --button-fill-danger-bg-color: var(--c-mute);
   --button-fill-danger-loader-color: var(--c-white);
-  --button-fill-danger-hover-bg-color: var(--c-danger-bg-dark);
-  --button-fill-danger-active-bg-color: var(--c-danger-bg-darker);
-  --button-fill-danger-disabled-border-color: var(--c-danger);
-  --button-fill-danger-disabled-text-color: var(--c-text-dark-2);
+  --button-fill-danger-hover-border-color: var(--c-danger-light);
+  --button-fill-danger-hover-text-color: var(--c-white);
+  --button-fill-danger-hover-bg-color: var(--c-danger-bg);
+  --button-fill-danger-active-border-color: var(--c-danger-light);
+  --button-fill-danger-active-text-color: var(--c-white);
+  --button-fill-danger-active-bg-color: var(--c-danger-bg-dark);
+  --button-fill-danger-disabled-border-color: var(--c-divider-2);
+  --button-fill-danger-disabled-text-color: var(--c-danger-text-dark);
   --button-fill-danger-disabled-content-color: var(--c-danger-text-dark);
-  --button-fill-danger-disabled-bg-color: var(--c-danger-bg-dark);
+  --button-fill-danger-disabled-bg-color: var(--c-mute-dark);
+
+  --button-outline-default-border-color: var(--c-divider-1);
+  --button-outline-default-text-color: var(--c-text-1);
+  --button-outline-default-content-color: var(--c-text-1);
+  --button-outline-default-loader-color: var(--c-neutral-1);
+  --button-outline-default-hover-bg-color: var(--c-mute-dimm-1);
+  --button-outline-default-active-bg-color: var(--c-mute-dimm-2);
+  --button-outline-default-disabled-border-color: var(--c-divider-2);
+  --button-outline-default-disabled-text-color: var(--c-text-3);
+  --button-outline-default-disabled-content-color: var(--c-text-3);
+
+  --button-outline-mute-border-color: var(--c-divider-1);
+  --button-outline-mute-text-color: var(--c-text-2);
+  --button-outline-mute-content-color: var(--c-text-2);
+  --button-outline-mute-loader-color: var(--c-neutral-1);
+  --button-outline-mute-hover-bg-color: var(--c-mute-dimm-1);
+  --button-outline-mute-active-bg-color: var(--c-mute-dimm-2);
+  --button-outline-mute-disabled-border-color: var(--c-divider-2);
+  --button-outline-mute-disabled-text-color: var(--c-text-3);
+  --button-outline-mute-disabled-content-color: var(--c-text-3);
 
   --button-outline-neutral-border-color: var(--c-neutral-1);
   --button-outline-neutral-text-color: var(--c-text-1);
@@ -602,16 +670,6 @@
   --button-outline-black-disabled-border-color: var(--c-neutral-light-3);
   --button-outline-black-disabled-text-color: var(--c-text-light-2);
   --button-outline-black-disabled-content-color: var(--c-text-light-2);
-
-  --button-outline-mute-border-color: var(--c-divider-1);
-  --button-outline-mute-text-color: var(--c-text-2);
-  --button-outline-mute-content-color: var(--c-text-2);
-  --button-outline-mute-loader-color: var(--c-neutral-1);
-  --button-outline-mute-hover-bg-color: var(--c-mute-dimm-1);
-  --button-outline-mute-active-bg-color: var(--c-mute-dimm-2);
-  --button-outline-mute-disabled-border-color: var(--c-divider-2);
-  --button-outline-mute-disabled-text-color: var(--c-text-3);
-  --button-outline-mute-disabled-content-color: var(--c-text-3);
 
   --button-outline-info-border-color: var(--c-info-light);
   --button-outline-info-text-color: var(--c-info-text);
@@ -653,6 +711,20 @@
   --button-outline-danger-disabled-text-color: var(--c-danger-text-dark);
   --button-outline-danger-disabled-content-color: var(--c-danger-text-dark);
 
+  --button-text-default-text-color: var(--c-text-1);
+  --button-text-default-content-color: var(--c-text-1);
+  --button-text-default-hover-bg-color: var(--c-mute);
+  --button-text-default-active-bg-color: var(--c-mute-light);
+  --button-text-default-disabled-text-color: var(--c-text-3);
+  --button-text-default-disabled-content-color: var(--c-text-3);
+
+  --button-text-mute-text-color: var(--c-text-2);
+  --button-text-mute-content-color: var(--c-text-2);
+  --button-text-mute-hover-bg-color: var(--c-mute);
+  --button-text-mute-active-bg-color: var(--c-mute-light);
+  --button-text-mute-disabled-text-color: var(--c-text-3);
+  --button-text-mute-disabled-content-color: var(--c-text-3);
+
   --button-text-neutral-text-color: var(--c-text-1);
   --button-text-neutral-content-color: var(--c-text-1);
   --button-text-neutral-hover-bg-color: var(--c-neutral-dimm-1);
@@ -673,13 +745,6 @@
   --button-text-black-active-bg-color: var(--c-neutral-light-dimm-2);
   --button-text-black-disabled-text-color: var(--c-text-light-2);
   --button-text-black-disabled-content-color: var(--c-text-light-2);
-
-  --button-text-mute-text-color: var(--c-text-2);
-  --button-text-mute-content-color: var(--c-text-2);
-  --button-text-mute-hover-bg-color: var(--c-mute);
-  --button-text-mute-active-bg-color: var(--c-mute-light);
-  --button-text-mute-disabled-text-color: var(--c-text-3);
-  --button-text-mute-disabled-content-color: var(--c-text-3);
 
   --button-text-info-text-color: var(--c-info-text);
   --button-text-info-content-color: var(--c-info-text);

--- a/stories/components/SButton.01_Playground.story.vue
+++ b/stories/components/SButton.01_Playground.story.vue
@@ -6,8 +6,9 @@ const title = 'Components / SButton / 01. Playground'
 const docs = '/components/button'
 
 const modes = [
-  'neutral',
+  'default',
   'mute',
+  'neutral',
   'white',
   'black',
   'info',
@@ -17,9 +18,10 @@ const modes = [
 ]
 
 const contentModes = [
-  { label: 'null', value: null },
-  { label: 'neutral', value: 'neutral' },
+  { label: 'undefined', value: null },
+  { label: 'default', value: 'default' },
   { label: 'mute', value: 'mute' },
+  { label: 'neutral', value: 'neutral' },
   { label: 'white', value: 'white' },
   { label: 'black', value: 'black' },
   { label: 'info', value: 'info' },
@@ -31,7 +33,7 @@ const contentModes = [
 function state() {
   return {
     type: 'fill',
-    mode: 'neutral',
+    mode: 'default',
     labelMode: null,
     label: 'Button',
     loading: false,

--- a/stories/components/SButton.02_Sizes.story.vue
+++ b/stories/components/SButton.02_Sizes.story.vue
@@ -12,9 +12,21 @@ const variants = [
   { title: 'Jumbo', size: 'jumbo' }
 ] as const
 
+const modes = [
+  'default',
+  'mute',
+  'neutral',
+  'white',
+  'black',
+  'info',
+  'success',
+  'warning',
+  'danger'
+]
+
 function state() {
   return {
-    mode: 'neutral',
+    mode: 'default',
     label: 'Button',
     rounded: false
   } as const
@@ -26,10 +38,7 @@ function state() {
     <template #controls="{ state }">
       <HstSelect
         title="mode"
-        :options="{
-          neutral: 'neutral',
-          mute: 'mute'
-        }"
+        :options="modes"
         v-model="state.mode"
       />
       <HstText

--- a/stories/components/SButton.03_Types_and_Modes.story.vue
+++ b/stories/components/SButton.03_Types_and_Modes.story.vue
@@ -11,8 +11,9 @@ const variants = [
 ] as const
 
 const modes = [
-  'neutral',
+  'default',
   'mute',
+  'neutral',
   'info',
   'success',
   'warning',

--- a/stories/components/SButton.04_Icons.story.vue
+++ b/stories/components/SButton.04_Icons.story.vue
@@ -14,8 +14,9 @@ const variants = [
 ] as const
 
 const modes = [
-  'neutral',
+  'default',
   'mute',
+  'neutral',
   'white',
   'black',
   'info',
@@ -45,7 +46,7 @@ const icons = [
 function state() {
   return {
     size: 'medium',
-    mode: 'neutral',
+    mode: 'default',
     iconMode: null,
     labelMode: null,
     label: 'Button'


### PR DESCRIPTION
Add a new `default` option to `:mode` and organize the color system of the button. This will aline mode of button to other similar component such as `<SPill>` and `<SState>`.

Also, made huge refactor on how to define css inside `<SButton>`. I think I was able to reduce bunch of boilerplates 🔥 

## BREAKING CHANGE

The `mute` mode now looks slightly different. Use the new option `default` to have the same look as before.

---

<img width="1392" alt="Screenshot 2023-11-02 at 11 52 12" src="https://github.com/globalbrain/sefirot/assets/3753672/c6682e7b-cfd6-4df9-8519-9ef690b8a5bc">
