### PR TITLE
fix(input-date): fix prop value to prevent warning

### DIFF
--- a/lib/components/SInputDate.vue
+++ b/lib/components/SInputDate.vue
@@ -86,7 +86,7 @@ function emitBlur() {
           autocomplete="off"
           :value="inputValue"
           :disabled="disabled"
-          v-on="disabled || inputEvents"
+          v-on="disabled ? {} : inputEvents"
           @blur="emitBlur"
         >
       </DatePicker>


### PR DESCRIPTION
No related issues.

When `disabled` prop of `SInputDate` component is set true, Vue show the following warning:

> [Vue warn]: v-on with no argument expects an object value.

This PR fixes runtime type error and prevent the warning.