### PR TITLE
fix(style): adjust `bg-elv` color for light mode

### DIFF
--- a/lib/styles/variables.css
+++ b/lib/styles/variables.css
@@ -228,9 +228,9 @@
 
 :root {
   --c-bg-elv-1: #ffffff;
-  --c-bg-elv-2: #f9f9f9;
+  --c-bg-elv-2: #f5f5f7;
   --c-bg-elv-3: #ffffff;
-  --c-bg-elv-4: #f9f9f9;
+  --c-bg-elv-4: #fafafa;
 
   --c-bg-mute-1: var(--c-gray-4);
   --c-bg-mute-2: var(--c-gray-5);


### PR DESCRIPTION
Adjust `--c-bg-elv` color on light mode. It makes `--c-bg-elv` slightly darker.

The issue is, while `bg-elv` works the same way n both Light/Dark mode where the higher the number is, it gets brighter (elevated), light mode has upper limit on how bright it can be and that is `bg-elv-3` where it reaches `#ffffff`.

Therefore `bg-elv-4` becomes darker on light mode. This is because `bg-elv-4` is used to distinguish the element from `bg-elv-2` and `bg-elv-3`.

Until now, we were using the same color for both `bg-elv-2` and `bg-elv-4`. But it is a bit hard on eye when used on component like Card (with header) or table.

This change makes `bg-elv-2` a bit darker so that it can be a bit more easier to see the difference. Aiding the visuals.

The contrast might not be enough compared to dark mode. But, we still do place texts on top of `bg-elv-2`, so we can't be too dark in order to keep good contrast ratio with `--c-text-2` color.

---

### Card before/after

<img width="603" alt="Screenshot 2023-11-10 at 16 58 14" src="https://github.com/globalbrain/sefirot/assets/3753672/7d71571f-094e-4d3e-8e4e-76813bc513ce">

<img width="603" alt="Screenshot 2023-11-10 at 16 58 54" src="https://github.com/globalbrain/sefirot/assets/3753672/5bb15463-4ed8-4ea6-8a4c-4a801b35936f">

### Table before/after

<img width="688" alt="Screenshot 2023-11-10 at 17 06 52" src="https://github.com/globalbrain/sefirot/assets/3753672/1f3fa5d5-803e-4191-a33b-675ddeb0be74">

<img width="688" alt="Screenshot 2023-11-10 at 17 06 58" src="https://github.com/globalbrain/sefirot/assets/3753672/cadc6c27-4ca2-49be-9bd7-27e9baad1e12">