### PR TITLE
feat(pill,state): add `default` mode

### DIFF
--- a/docs/components/pill.md
+++ b/docs/components/pill.md
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import SPill from 'sefirot/components/SPill.vue'
 
-const modes = ['neutral', 'mute', 'info', 'success', 'warning', 'danger'] as const
+const modes = ['default', 'mute', 'neutral', 'info', 'success', 'warning', 'danger'] as const
 </script>
 
 # SPill
@@ -17,21 +17,11 @@ const modes = ['neutral', 'mute', 'info', 'success', 'warning', 'danger'] as con
   </div>
 </Showcase>
 
-## Usage
+## Overview
 
-Import `<SPill>` component and it's good to go. All props are optional.
+Use this component to mark some objects. Fpr example. `<SPill>` can be used to tag certain object, such as "Important", "Urgent", "High priority", etc.
 
-```vue
-<script setup lang="ts">
-import SPill from '@globalbrain/sefirot/lib/components/SPill.vue'
-</script>
-
-<template>
-  <SPill label="Pill" />
-</template>
-```
-
-## Difference from SState
+### Difference from SState
 
 The [`<SState>`](state) is different from `<SPill>` where `<SPill>` should be used to list certain types of items for the object, but `<SState>` is used to indicate the "State" of the object.
 
@@ -39,22 +29,35 @@ For example, `<SState>` should be used for things like "Status" (Open, In progre
 
 `<SPill>` on the other hand should be used for things like "Tag" (List of available items, User's roles, etc.)
 
+## Import
+
+```ts
+import SPill from '@globalbrain/sefirot/lib/components/SPill.vue'
+```
+
+## Usage
+
+Import `<SPill>` component and it's good to go. All props are optional.
+
+```vue-html
+<SPill label="Pill" />
+```
+
 ## Props
 
-Here are the list of props you may pass to the component.
+### `:as`
 
-### `:tag`
-
-Defines the HTML tag for the pill. Any value passed to this prop will used as `<component :is="tag">`. The default tag for the button is `span`. The `tag` prop will take precedence even when the `clickable` prop is set.
+Defines the HTML tag for the pill. Any value passed to this prop will used as `<component :is="as">`. The default tag for the button is `span`. The `tag` prop will take precedence even when the `clickable` prop is set.
 
 ```ts
 interface Props {
-  tag?: string
+  // @default 'span' | 'button'
+  as?: string
 }
 ```
 
 ```vue-html
-<SPill tag="div" label="Pill" />
+<SPill as="div" label="Pill" />
 ```
 
 ### `:size`
@@ -73,10 +76,11 @@ interface Props {
 
 ### `:type`
 
-Defines how the pill look. The default is `dimm`.
+Defines how the pill look.
 
 ```ts
 interface Props {
+  // @default 'dimm'
   type?: 'dimm' | 'fill'
 }
 ```
@@ -87,16 +91,18 @@ interface Props {
 
 ### `:mode`
 
-Defines the color of the pill. The default is `neutral`.
+Defines the color of the pill.
 
 ```ts
 interface Props {
+  // @default 'default'
   mode?: Mode
 }
 
 type Mode =
-  | 'neutral'
+  | 'default'
   | 'mute'
+  | 'neutral'
   | 'info'
   | 'success'
   | 'warning'
@@ -135,9 +141,25 @@ interface Props {
 <SPill label="Button" clickable />
 ```
 
-## Events
+### `:tag`
 
-Here are the list of events the component may emit.
+::: warning Deprecated
+`:tag` is deprectated. Use `:as` instead.
+:::
+
+Defines the HTML tag for the pill. Any value passed to this prop will used as `<component :is="tag">`. The default tag for the button is `span`. The `tag` prop will take precedence even when the `clickable` prop is set.
+
+```ts
+interface Props {
+  tag?: string
+}
+```
+
+```vue-html
+<SPill tag="div" label="Pill" />
+```
+
+## Events
 
 ### `@click`
 
@@ -159,41 +181,59 @@ The component has several different styles based on its type and color combinati
 
 ```css
 :root {
-  --pill-dimm-neutral-border-color: var(--c-divider-1);
-  --pill-dimm-neutral-text-color: var(--c-text-1);
-  --pill-dimm-neutral-bg-color: var(--c-mute);
-  --pill-dimm-neutral-hover-bg-color: var(--c-mute-dimm-1);
-  --pill-dimm-neutral-active-bg-color: var(--c-mute-dimm-2);
+  --pill-dimm-default-border-color: var(--c-border-mute-1);
+  --pill-dimm-default-text-color: var(--c-text-1);
+  --pill-dimm-default-bg-color: var(--c-bg-mute-1);
+  --pill-dimm-default-hover-bg-color: var(--c-bg-mute-2);
+  --pill-dimm-default-active-bg-color: var(--c-bg-mute-3);
 
-  --pill-dimm-mute-border-color: var(--c-divider-1);
+  --pill-dimm-mute-border-color: var(--c-border-mute-1);
   --pill-dimm-mute-text-color: var(--c-text-2);
-  --pill-dimm-mute-bg-color: var(--c-mute);
-  --pill-dimm-mute-hover-bg-color: var(--c-mute-dimm-1);
-  --pill-dimm-mute-active-bg-color: var(--c-mute-dimm-2);
+  --pill-dimm-mute-bg-color: var(--c-bg-mute-1);
+  --pill-dimm-mute-hover-bg-color: var(--c-bg-mute-2);
+  --pill-dimm-mute-active-bg-color: var(--c-bg-mute-3);
 
-  --pill-dimm-info-border-color: var(--c-info-light);
-  --pill-dimm-info-text-color: var(--c-info-light);
-  --pill-dimm-info-bg-color: var(--c-info-dimm-1);
-  --pill-dimm-info-hover-bg-color: var(--c-info-dimm-2);
-  --pill-dimm-info-active-bg-color: var(--c-info-dimm-3);
+  --pill-dimm-neutral-border-color: var(--c-neutral-1);
+  --pill-dimm-neutral-text-color: var(--c-text-inverse-1);
+  --pill-dimm-neutral-bg-color: var(--c-neutral-1);
+  --pill-dimm-neutral-hover-bg-color: var(--c-neutral-2);
+  --pill-dimm-neutral-active-bg-color: var(--c-neutral-3);
 
-  --pill-dimm-success-border-color: var(--c-success-light);
-  --pill-dimm-success-text-color: var(--c-success-light);
-  --pill-dimm-success-bg-color: var(--c-success-dimm-1);
-  --pill-dimm-success-hover-bg-color: var(--c-success-dimm-2);
-  --pill-dimm-success-active-bg-color: var(--c-success-dimm-3);
+  --pill-dimm-info-border-color: var(--c-border-info-1);
+  --pill-dimm-info-text-color: var(--c-text-info-1);
+  --pill-dimm-info-bg-color: var(--c-bg-info-dimm-a1);
+  --pill-dimm-info-hover-bg-color: var(--c-bg-info-dimm-a2);
+  --pill-dimm-info-active-bg-color: var(--c-bg-info-dimm-a2);
 
-  --pill-dimm-warning-border-color: var(--c-warning-light);
-  --pill-dimm-warning-text-color: var(--c-warning-light);
-  --pill-dimm-warning-bg-color: var(--c-warning-dimm-1);
-  --pill-dimm-warning-hover-bg-color: var(--c-warning-dimm-2);
-  --pill-dimm-warning-active-bg-color: var(--c-warning-dimm-3);
+  --pill-dimm-success-border-color: var(--c-border-success-1);
+  --pill-dimm-success-text-color: var(--c-text-success-1);
+  --pill-dimm-success-bg-color: var(--c-bg-success-dimm-a1);
+  --pill-dimm-success-hover-bg-color: var(--c-bg-success-dimm-a2);
+  --pill-dimm-success-active-bg-color: var(--c-bg-success-dimm-a2);
 
-  --pill-dimm-danger-border-color: var(--c-danger-light);
-  --pill-dimm-danger-text-color: var(--c-danger-light);
-  --pill-dimm-danger-bg-color: var(--c-danger-dimm-1);
-  --pill-dimm-danger-hover-bg-color: var(--c-danger-dimm-2);
-  --pill-dimm-danger-active-bg-color: var(--c-danger-dimm-3);
+  --pill-dimm-warning-border-color: var(--c-border-warning-1);
+  --pill-dimm-warning-text-color: var(--c-text-warning-1);
+  --pill-dimm-warning-bg-color: var(--c-bg-warning-dimm-a1);
+  --pill-dimm-warning-hover-bg-color: var(--c-bg-warning-dimm-a2);
+  --pill-dimm-warning-active-bg-color: var(--c-bg-warning-dimm-a2);
+
+  --pill-dimm-danger-border-color: var(--c-border-danger-1);
+  --pill-dimm-danger-text-color: var(--c-text-danger-1);
+  --pill-dimm-danger-bg-color: var(--c-bg-danger-dimm-a1);
+  --pill-dimm-danger-hover-bg-color: var(--c-bg-danger-dimm-a2);
+  --pill-dimm-danger-active-bg-color: var(--c-bg-danger-dimm-a2);
+
+  --pill-fill-default-border-color: transparent;
+  --pill-fill-default-text-color: var(--c-text-1);
+  --pill-fill-default-bg-color: var(--c-bg-mute-1);
+  --pill-fill-default-hover-bg-color: var(--c-bg-mute-2);
+  --pill-fill-default-active-bg-color: var(--c-bg-mute-3);
+
+  --pill-fill-mute-border-color: transparent;
+  --pill-fill-mute-text-color: var(--c-text-2);
+  --pill-fill-mute-bg-color: var(--c-bg-mute-1);
+  --pill-fill-mute-hover-bg-color: var(--c-bg-mute-2);
+  --pill-fill-mute-active-bg-color: var(--c-bg-mute-3);
 
   --pill-fill-neutral-border-color: transparent;
   --pill-fill-neutral-text-color: var(--c-text-inverse-1);
@@ -201,34 +241,28 @@ The component has several different styles based on its type and color combinati
   --pill-fill-neutral-hover-bg-color: var(--c-neutral-2);
   --pill-fill-neutral-active-bg-color: var(--c-neutral-3);
 
-  --pill-fill-mute-border-color: transparent;
-  --pill-fill-mute-text-color: var(--c-text-1);
-  --pill-fill-mute-bg-color: var(--c-mute);
-  --pill-fill-mute-hover-bg-color: var(--c-mute-dimm-1);
-  --pill-fill-mute-active-bg-color: var(--c-mute-dimm-2);
-
   --pill-fill-info-border-color: transparent;
-  --pill-fill-info-text-color: var(--c-text-dark-1);
-  --pill-fill-info-bg-color: var(--c-info);
-  --pill-fill-info-hover-bg-color: var(--c-info-dark);
-  --pill-fill-info-active-bg-color: var(--c-info-darker);
+  --pill-fill-info-text-color: var(--c-white-1);
+  --pill-fill-info-bg-color: var(--c-bg-info-1);
+  --pill-fill-info-hover-bg-color: var(--c-bg-info-2);
+  --pill-fill-info-active-bg-color: var(--c-bg-info-3);
 
   --pill-fill-success-border-color: transparent;
-  --pill-fill-success-text-color: var(--c-text-dark-1);
-  --pill-fill-success-bg-color: var(--c-success);
-  --pill-fill-success-hover-bg-color: var(--c-success-dark);
-  --pill-fill-success-active-bg-color: var(--c-success-darker);
+  --pill-fill-success-text-color: var(--c-white-1);
+  --pill-fill-success-bg-color: var(--c-bg-success-1);
+  --pill-fill-success-hover-bg-color: var(--c-bg-success-2);
+  --pill-fill-success-active-bg-color: var(--c-bg-success-3);
 
   --pill-fill-warning-border-color: transparent;
-  --pill-fill-warning-text-color: var(--c-text-dark-1);
-  --pill-fill-warning-bg-color: var(--c-warning);
-  --pill-fill-warning-hover-bg-color: var(--c-warning-dark);
-  --pill-fill-warning-active-bg-color: var(--c-warning-darker);
+  --pill-fill-warning-text-color: var(--c-white-1);
+  --pill-fill-warning-bg-color: var(--c-bg-warning-1);
+  --pill-fill-warning-hover-bg-color: var(--c-bg-warning-2);
+  --pill-fill-warning-active-bg-color: var(--c-bg-warning-3);
 
   --pill-fill-danger-border-color: transparent;
-  --pill-fill-danger-text-color: var(--c-text-dark-1);
-  --pill-fill-danger-bg-color: var(--c-danger);
-  --pill-fill-danger-hover-bg-color: var(--c-danger-dark);
-  --pill-fill-danger-active-bg-color: var(--c-danger-darker);
+  --pill-fill-danger-text-color: var(--c-white-1);
+  --pill-fill-danger-bg-color: var(--c-bg-danger-1);
+  --pill-fill-danger-hover-bg-color: var(--c-bg-danger-2);
+  --pill-fill-danger-active-bg-color: var(--c-bg-danger-3);
 }
 ```

--- a/docs/components/state.md
+++ b/docs/components/state.md
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import SState from 'sefirot/components/SState.vue'
 
-const modes = ['neutral', 'mute', 'info', 'success', 'warning', 'danger'] as const
+const modes = ['default', 'neutral', 'info', 'success', 'warning', 'danger'] as const
 </script>
 
 # SState
@@ -17,21 +17,11 @@ const modes = ['neutral', 'mute', 'info', 'success', 'warning', 'danger'] as con
   </div>
 </Showcase>
 
-## Usage
+## Overview
 
-Import `<SState>` component and set `:mode` and `:label`.
+Use this component to indicate the state of the object. For example, `<SState>` can be used to note certain object's status, such as "Open", "In progress", "Completed", etc.
 
-```vue
-<script setup lang="ts">
-import SState from '@globalbrain/sefirot/lib/components/SState.vue'
-</script>
-
-<template>
-  <SState mode="success" label="Completed" />
-</template>
-```
-
-## Difference from SPill
+### Difference from `<SPill>`
 
 The `<SState>` is different from [`<SPill>`](pill) where `<SPill>` should be used to list certain types of items for the object, but `<SState>` is used to indicate the "State" of the object.
 
@@ -39,16 +29,29 @@ For example, `<SState>` should be used for things like "Status" (Open, In progre
 
 `<SPill>` on the other hand should be used for things like "Tag" (List of available items, User's roles, etc.)
 
-## Props
+## Import
 
-Here are the list of props you may pass to the component.
+```ts
+import SState from '@globalbrain/sefirot/lib/components/SState.vue'
+```
+
+## Usage
+
+Import `<SState>` component and set `:mode` and `:label`.
+
+```vue-html
+<SState mode="success" label="Completed" />
+```
+
+## Props
 
 ### `:as`
 
-Defines the HTML tag for the pill. Any value passed to this prop will used as `<component :is="as">`. The default is `span`.
+Defines the HTML tag for the pill. Any value passed to this prop will used as `<component :is="as">`.
 
 ```ts
 interface Props {
+  // @default 'span'
   as?: string
 }
 ```
@@ -59,10 +62,11 @@ interface Props {
 
 ### `:size`
 
-Defines the size of the component. The default is `small`.
+Defines the size of the component.
 
 ```ts
 interface Props {
+  // @default 'small'
   size?: 'mini' | 'small' | 'medium' | 'large'
 }
 ```
@@ -73,16 +77,18 @@ interface Props {
 
 ### `:mode`
 
-Defines the color of the state. The default is `neutral`.
+Defines the color of the state.
 
 ```ts
 interface Props {
+  // @default 'default'
   mode?: Mode
 }
 
 type Mode =
-  | 'neutral'
+  | 'default'
   | 'mute'
+  | 'neutral'
   | 'info'
   | 'success'
   | 'warning'
@@ -99,7 +105,7 @@ Defines the label text of the state.
 
 ```ts
 interface Props {
-  label?: string
+  label: string
 }
 ```
 

--- a/lib/components/SPill.vue
+++ b/lib/components/SPill.vue
@@ -3,15 +3,18 @@ import { computed } from 'vue'
 
 export type Size = 'mini' | 'small' | 'medium' | 'large'
 export type Type = 'dimm' | 'fill'
-export type Mode = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
+export type Mode = 'default' | 'mute' | 'neutral' | 'info' | 'success' | 'warning' | 'danger'
 
 const props = defineProps<{
-  tag?: string
+  as?: string
   size?: Size
   type?: Type
   mode?: Mode
   label?: string
   clickable?: boolean
+
+  // @deprecated Use `as` instead.
+  tag?: string
 }>()
 
 const emit = defineEmits<{
@@ -21,14 +24,13 @@ const emit = defineEmits<{
 const classes = computed(() => [
   props.size ?? 'small',
   props.type ?? 'dimm',
-  props.mode ?? 'neutral',
+  props.mode ?? 'default',
   { clickable: props.clickable }
 ])
 
 const computedTag = computed(() => {
-  return props.tag
-    ? props.tag
-    : props.clickable ? 'button' : 'span'
+  const as = props.as ?? props.tag
+  return as || (props.clickable ? 'button' : 'span')
 })
 
 function onClick() {
@@ -82,17 +84,17 @@ function onClick() {
   border-radius: 16px;
   padding: 0 12px;
   line-height: 30px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .SPill.dimm {
-  &.neutral {
-    border-color: var(--pill-dimm-neutral-border-color);
-    color: var(--pill-dimm-neutral-text-color);
-    background-color: var(--pill-dimm-neutral-bg-color);
+  &.default {
+    border-color: var(--pill-dimm-default-border-color);
+    color: var(--pill-dimm-default-text-color);
+    background-color: var(--pill-dimm-default-bg-color);
 
-    &.clickable:hover { background-color: var(--pill-dimm-neutral-hover-bg-color); }
-    &.clickable:active { background-color: var(--pill-dimm-neutral-active-bg-color); }
+    &.clickable:hover { background-color: var(--pill-dimm-default-hover-bg-color); }
+    &.clickable:active { background-color: var(--pill-dimm-default-active-bg-color); }
   }
 
   &.mute {
@@ -102,6 +104,15 @@ function onClick() {
 
     &.clickable:hover { background-color: var(--pill-dimm-mute-hover-bg-color); }
     &.clickable:active { background-color: var(--pill-dimm-mute-active-bg-color); }
+  }
+
+  &.neutral {
+    border-color: var(--pill-dimm-neutral-border-color);
+    color: var(--pill-dimm-neutral-text-color);
+    background-color: var(--pill-dimm-neutral-bg-color);
+
+    &.clickable:hover { background-color: var(--pill-dimm-neutral-hover-bg-color); }
+    &.clickable:active { background-color: var(--pill-dimm-neutral-active-bg-color); }
   }
 
   &.info {
@@ -142,13 +153,13 @@ function onClick() {
 }
 
 .SPill.fill {
-  &.neutral {
-    border-color: var(--pill-fill-neutral-border-color);
-    color: var(--pill-fill-neutral-text-color);
-    background-color: var(--pill-fill-neutral-bg-color);
+  &.default {
+    border-color: var(--pill-fill-default-border-color);
+    color: var(--pill-fill-default-text-color);
+    background-color: var(--pill-fill-default-bg-color);
 
-    &.clickable:hover { background-color: var(--pill-fill-neutral-hover-bg-color); }
-    &.clickable:active { background-color: var(--pill-fill-neutral-active-bg-color); }
+    &.clickable:hover { background-color: var(--pill-fill-default-hover-bg-color); }
+    &.clickable:active { background-color: var(--pill-fill-default-active-bg-color); }
   }
 
   &.mute {
@@ -158,6 +169,15 @@ function onClick() {
 
     &.clickable:hover { background-color: var(--pill-fill-mute-hover-bg-color); }
     &.clickable:active { background-color: var(--pill-fill-mute-active-bg-color); }
+  }
+
+  &.neutral {
+    border-color: var(--pill-fill-neutral-border-color);
+    color: var(--pill-fill-neutral-text-color);
+    background-color: var(--pill-fill-neutral-bg-color);
+
+    &.clickable:hover { background-color: var(--pill-fill-neutral-hover-bg-color); }
+    &.clickable:active { background-color: var(--pill-fill-neutral-active-bg-color); }
   }
 
   &.info {

--- a/lib/components/SState.vue
+++ b/lib/components/SState.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 
 export type Size = 'mini' | 'small' | 'medium' | 'large'
-export type Mode = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
+export type Mode = 'default' | 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
 const props = defineProps<{
   as?: string
@@ -13,7 +13,7 @@ const props = defineProps<{
 
 const classes = computed(() => [
   props.size ?? 'small',
-  props.mode ?? 'neutral'
+  props.mode ?? 'default'
 ])
 </script>
 
@@ -29,7 +29,6 @@ const classes = computed(() => [
   display: inline-flex;
   align-items: center;
   border: 1px solid var(--c-border-mute-1);
-  border-radius: 6px;
   font-weight: 500;
   white-space: nowrap;
   background-color: var(--c-bg-mute-1);
@@ -37,11 +36,11 @@ const classes = computed(() => [
 
 .SState.mini {
   gap: 6px;
+  border-radius: 10px;
   padding: 0 6px;
   height: 20px;
 
   .indicator {
-    border-radius: 2px;
     width: 8px;
     height: 8px;
   }
@@ -52,12 +51,12 @@ const classes = computed(() => [
 }
 
 .SState.small {
-  gap: 8px;
+  gap: 6px;
+  border-radius: 12px;
   padding: 0 8px;
   height: 24px;
 
   .indicator {
-    border-radius: 3px;
     width: 10px;
     height: 10px;
   }
@@ -68,12 +67,12 @@ const classes = computed(() => [
 }
 
 .SState.medium {
-  gap: 8px;
+  gap: 6px;
+  border-radius: 14px;
   padding: 0 8px;
   height: 28px;
 
   .indicator {
-    border-radius: 3px;
     width: 10px;
     height: 10px;
   }
@@ -84,12 +83,12 @@ const classes = computed(() => [
 }
 
 .SState.large {
-  gap: 10px;
+  gap: 8px;
+  border-radius: 16px;
   padding: 0 10px;
   height: 32px;
 
   .indicator {
-    border-radius: 4px;
     width: 12px;
     height: 12px;
   }
@@ -99,28 +98,38 @@ const classes = computed(() => [
   }
 }
 
-.SState.neutral {
-  .indicator { background-color: var(--c-neutral-1); }
+.SState.default {
+  .label     { color: var(--c-text-1); }
+  .indicator { background-color: var(--c-fg-gray-1); }
 }
 
-.SState.mute  {
+.SState.mute {
   .label     { color: var(--c-text-2); }
   .indicator { background-color: var(--c-fg-gray-1); }
 }
 
-.SState.info  {
+.SState.neutral {
+  .label     { color: var(--c-text-1); }
+  .indicator { background-color: var(--c-neutral-1); }
+}
+
+.SState.info {
+  .label     { color: var(--c-text-1); }
   .indicator { background-color: var(--c-fg-info-1); }
 }
 
-.SState.success  {
+.SState.success {
+  .label     { color: var(--c-text-1); }
   .indicator { background-color: var(--c-fg-success-1); }
 }
 
-.SState.warning  {
+.SState.warning {
+  .label     { color: var(--c-text-1); }
   .indicator { background-color: var(--c-fg-warning-1); }
 }
 
-.SState.danger  {
+.SState.danger {
+  .label     { color: var(--c-text-1); }
   .indicator { background-color: var(--c-fg-danger-1); }
 }
 
@@ -130,6 +139,7 @@ const classes = computed(() => [
 
 .indicator {
   display: block;
+  border-radius: 50%;
   transition: background-color 0.25s;
 }
 </style>

--- a/lib/styles/variables.css
+++ b/lib/styles/variables.css
@@ -717,17 +717,23 @@
  * -------------------------------------------------------------------------- */
 
 :root {
-  --pill-dimm-neutral-border-color: var(--c-border-mute-1);
-  --pill-dimm-neutral-text-color: var(--c-text-1);
-  --pill-dimm-neutral-bg-color: var(--c-bg-mute-1);
-  --pill-dimm-neutral-hover-bg-color: var(--c-bg-mute-2);
-  --pill-dimm-neutral-active-bg-color: var(--c-bg-mute-3);
+  --pill-dimm-default-border-color: var(--c-border-mute-1);
+  --pill-dimm-default-text-color: var(--c-text-1);
+  --pill-dimm-default-bg-color: var(--c-bg-mute-1);
+  --pill-dimm-default-hover-bg-color: var(--c-bg-mute-2);
+  --pill-dimm-default-active-bg-color: var(--c-bg-mute-3);
 
   --pill-dimm-mute-border-color: var(--c-border-mute-1);
   --pill-dimm-mute-text-color: var(--c-text-2);
   --pill-dimm-mute-bg-color: var(--c-bg-mute-1);
   --pill-dimm-mute-hover-bg-color: var(--c-bg-mute-2);
   --pill-dimm-mute-active-bg-color: var(--c-bg-mute-3);
+
+  --pill-dimm-neutral-border-color: var(--c-neutral-1);
+  --pill-dimm-neutral-text-color: var(--c-text-inverse-1);
+  --pill-dimm-neutral-bg-color: var(--c-neutral-1);
+  --pill-dimm-neutral-hover-bg-color: var(--c-neutral-2);
+  --pill-dimm-neutral-active-bg-color: var(--c-neutral-3);
 
   --pill-dimm-info-border-color: var(--c-border-info-1);
   --pill-dimm-info-text-color: var(--c-text-info-1);
@@ -753,17 +759,23 @@
   --pill-dimm-danger-hover-bg-color: var(--c-bg-danger-dimm-a2);
   --pill-dimm-danger-active-bg-color: var(--c-bg-danger-dimm-a2);
 
-  --pill-fill-neutral-border-color: transparent;
-  --pill-fill-neutral-text-color: var(--c-text-inverse-1);
-  --pill-fill-neutral-bg-color: var(--c-neutral-1);
-  --pill-fill-neutral-hover-bg-color: var(--c-neutral-2);
-  --pill-fill-neutral-active-bg-color: var(--c-neutral-3);
+  --pill-fill-default-border-color: transparent;
+  --pill-fill-default-text-color: var(--c-text-1);
+  --pill-fill-default-bg-color: var(--c-bg-mute-1);
+  --pill-fill-default-hover-bg-color: var(--c-bg-mute-2);
+  --pill-fill-default-active-bg-color: var(--c-bg-mute-3);
 
   --pill-fill-mute-border-color: transparent;
   --pill-fill-mute-text-color: var(--c-text-2);
   --pill-fill-mute-bg-color: var(--c-bg-mute-1);
   --pill-fill-mute-hover-bg-color: var(--c-bg-mute-2);
   --pill-fill-mute-active-bg-color: var(--c-bg-mute-3);
+
+  --pill-fill-neutral-border-color: transparent;
+  --pill-fill-neutral-text-color: var(--c-text-inverse-1);
+  --pill-fill-neutral-bg-color: var(--c-neutral-1);
+  --pill-fill-neutral-hover-bg-color: var(--c-neutral-2);
+  --pill-fill-neutral-active-bg-color: var(--c-neutral-3);
 
   --pill-fill-info-border-color: transparent;
   --pill-fill-info-text-color: var(--c-white-1);

--- a/stories/components/SPill.01_Playground.story.vue
+++ b/stories/components/SPill.01_Playground.story.vue
@@ -9,7 +9,7 @@ function state() {
   return {
     size: 'small',
     type: 'dimm',
-    mode: 'neutral',
+    mode: 'default',
     label: 'Pill',
     clickable: false
   }
@@ -40,8 +40,9 @@ function state() {
       <HstSelect
         title="mode"
         :options="{
-          neutral: 'neutral',
+          default: 'default',
           mute: 'mute',
+          neutral: 'neutral',
           info: 'info',
           success: 'success',
           warning: 'warning',

--- a/stories/components/SPill.02_Sizes.story.vue
+++ b/stories/components/SPill.02_Sizes.story.vue
@@ -16,7 +16,7 @@ const types = ['dimm', 'fill'] as const
 
 function state() {
   return {
-    mode: 'neutral',
+    mode: 'default',
     label: 'Pill',
     clickable: false
   }
@@ -29,8 +29,9 @@ function state() {
       <HstSelect
         title="mode"
         :options="{
-          neutral: 'neutral',
+          default: 'default',
           mute: 'mute',
+          neutral: 'neutral',
           info: 'info',
           success: 'success',
           warning: 'warning',

--- a/stories/components/SPill.03_Types_and_Modes.story.vue
+++ b/stories/components/SPill.03_Types_and_Modes.story.vue
@@ -10,7 +10,7 @@ const variants = [
   { title: 'Fill', type: 'fill' }
 ] as const
 
-const modes = ['neutral', 'mute', 'info', 'success', 'warning', 'danger'] as const
+const modes = ['default', 'mute', 'neutral', 'info', 'success', 'warning', 'danger'] as const
 
 function state() {
   return {

--- a/stories/components/SState.01_Playground.story.vue
+++ b/stories/components/SState.01_Playground.story.vue
@@ -7,7 +7,7 @@ const docs = '/components/state'
 function state() {
   return {
     size: 'small',
-    mode: 'neutral',
+    mode: 'default',
     label: 'State'
   }
 }
@@ -29,8 +29,9 @@ function state() {
       <HstSelect
         title="mode"
         :options="{
-          neutral: 'neutral',
+          default: 'default',
           mute: 'mute',
+          neutral: 'neutral',
           info: 'info',
           success: 'success',
           warning: 'warning',

--- a/stories/components/SState.02_Sizes.story.vue
+++ b/stories/components/SState.02_Sizes.story.vue
@@ -13,7 +13,7 @@ const variants = [
 
 function state() {
   return {
-    mode: 'neutral',
+    mode: 'default',
     label: 'State'
   }
 }
@@ -25,8 +25,9 @@ function state() {
       <HstSelect
         title="mode"
         :options="{
-          neutral: 'neutral',
+          default: 'default',
           mute: 'mute',
+          neutral: 'neutral',
           info: 'info',
           success: 'success',
           warning: 'warning',

--- a/stories/components/SState.03_Modes.story.vue
+++ b/stories/components/SState.03_Modes.story.vue
@@ -4,7 +4,7 @@ import SState from 'sefirot/components/SState.vue'
 const title = 'Components / SState / 03. Types'
 const docs = '/components/state'
 
-const modes = ['neutral', 'mute', 'info', 'success', 'warning', 'danger'] as const
+const modes = ['default', 'mute', 'neutral', 'info', 'success', 'warning', 'danger'] as const
 
 function state() {
   return {

--- a/tests/components/SPill.spec.ts
+++ b/tests/components/SPill.spec.ts
@@ -19,20 +19,20 @@ describe('components/SPill', () => {
     expect(wrapper.find('.SPill').element.tagName).toBe('BUTTON')
   })
 
-  test('tag is set to given `tag` if it exists', () => {
+  test('tag is set to given `:as` if it exists', () => {
     const wrapper = mount(SPill, {
       props: {
-        tag: 'div'
+        as: 'div'
       }
     })
 
     expect(wrapper.find('.SPill').element.tagName).toBe('DIV')
   })
 
-  test('tag is set to given `tag` if it exists even if `clickable` is set', () => {
+  test('tag is set to given `:as` if it exists even if `clickable` is set', () => {
     const wrapper = mount(SPill, {
       props: {
-        tag: 'div',
+        as: 'div',
         clickable: true
       }
     })


### PR DESCRIPTION
Add `default` mode to `<SPill>` and `<SState>`.

This aligns with how `<SButton>` mode works right now. Also, change the shape of `<SState>` to be round, as it is in the latest Figma design.

Plus, I've re-organized docs for these 2 components to match the latest pattern used in `<SM>`.

---

<img width="1392" alt="Screenshot 2023-11-13 at 15 46 36" src="https://github.com/globalbrain/sefirot/assets/3753672/d54b4c1d-0778-410f-867f-dbadb3d4d524">

<img width="1392" alt="Screenshot 2023-11-13 at 15 37 42" src="https://github.com/globalbrain/sefirot/assets/3753672/1dd96c56-a7c8-4d18-9cf4-b48db181e4ac">