### PR TITLE
fix(m): make `SMFade` `:once` default to `true`

### DIFF
--- a/lib/components/SMFade.vue
+++ b/lib/components/SMFade.vue
@@ -2,7 +2,8 @@
 import SM, { type Props } from './SM.vue'
 
 withDefaults(defineProps<Props>(), {
-  opacity: 0
+  opacity: 0,
+  once: true
 })
 </script>
 


### PR DESCRIPTION
`SMFade` default value for `:once` was set to false due to boolean default. Well maybe I should have named this prop `:always` or something and made it default to `false` 😅 