### PR TITLE
feat: add error boundary component

### DIFF
--- a/lib/components/SErrorBoundary.vue
+++ b/lib/components/SErrorBoundary.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { onErrorCaptured, ref } from 'vue'
+
+const emit = defineEmits<{
+  (e: 'error', value: any): void
+}>()
+
+const error = ref<Error | null>(null)
+
+onErrorCaptured((e) => {
+  if (import.meta.env.DEV) {
+    console.error(e)
+  }
+  if (!import.meta.env.SSR) {
+    error.value = e
+    emit('error', e)
+    return false
+  }
+})
+
+function clearError() {
+  error.value = null
+}
+</script>
+
+<template>
+  <slot v-if="error != null" name="error" :error="error" :clear-error="clearError" />
+  <slot v-else />
+</template>

--- a/stories/components/SErrorBoundary.01_Playground.story.vue
+++ b/stories/components/SErrorBoundary.01_Playground.story.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import SErrorBoundary from 'sefirot/components/SErrorBoundary.vue'
+import Comp from './_ErrorBoundaryDefaultSlot.vue'
+
+const title = 'Components / SErrorBoundary / 01. Playground'
+</script>
+
+<template>
+  <Story :title="title" source="Not available" auto-props-disabled>
+    <Board :title="title">
+      <SErrorBoundary>
+        <template #default>
+          <Comp />
+        </template>
+        <template #error="{ error, clearError }">
+          <div>Error slot</div>
+          <div>{{ error }}</div>
+          <button @click="clearError">Clear error</button>
+        </template>
+      </SErrorBoundary>
+    </Board>
+  </Story>
+</template>

--- a/stories/components/_ErrorBoundaryDefaultSlot.vue
+++ b/stories/components/_ErrorBoundaryDefaultSlot.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+function throwErr() {
+  throw new Error('Error!')
+}
+</script>
+
+<template>
+  <div>Default slot</div>
+  <button @click="throwErr">Throw error</button>
+</template>


### PR DESCRIPTION
A few caveats here:

- `@error="error => error.statusCode !== 404 && throw error"` -- this syntax is not supported by vue. Make a function in setup and use that instead.
- In the above case, error slot will still be rendered even if you re-throw the error
- Errors in inline children are not captured. Make sure to move the logic to separate component and put it in the default slot.

A complete example would be something like this:

```vue
<script setup lang="ts">
function check404(err: any) {
  if (err.statusCode !== 404) {
    throw err // sentry will capture this later
  }
}
</script>

<template>
  <SErrorBoundary @error="check404">
    <template #default>
      <ChildComponentHavingQuery /> // this should be a separate component
    </template>
    <template #error="{ error, clearError }">
      <div v-if="error.statusCode === 404">Page not found</div>
      <div v-else>Something went wrong</div>
      <button @click="clearError">Clear error</button> // update this to redirect page, etc.
    </template>
  </SErrorBoundary>
</template>
```