### PR TITLE
fix(url): change cast callback value type to any

### DIFF
--- a/lib/composables/Url.ts
+++ b/lib/composables/Url.ts
@@ -4,7 +4,7 @@ import { watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 export interface UseUrlQuerySyncOptions {
-  casts?: Record<string, (value: string) => any>
+  casts?: Record<string, (value: any) => any>
   exclude?: string[]
 }
 


### PR DESCRIPTION
The value could be for example array, if the stored object is array. So, I guess it makes sense to make this `any` 👀 

Or should we scope this to something like string or object or array?

```ts
useUrlQuerySync(options, {
  casts: {
    // It is indeed array but type error.
    // No `map`, since value is typed as `string`.
    'tags': (v) => v.map(Number),
  }
})
```