### PR TITLE
feat(local-nav): add `<SLocalNav>`

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -81,6 +81,7 @@ function sidebar(): DefaultTheme.SidebarItem[] {
         { text: 'SInputTextarea', link: '/components/input-textarea' },
         { text: 'SInputYMD', link: '/components/input-ymd' },
         { text: 'SLink', link: '/components/link' },
+        { text: 'SLocalNav', link: '/components/local-nav' },
         { text: 'SLoginPage', link: '/components/login-page' },
         { text: 'SM', link: '/components/m' },
         { text: 'SPill', link: '/components/pill' },

--- a/docs/components/local-nav.md
+++ b/docs/components/local-nav.md
@@ -1,0 +1,136 @@
+# SLocalNav
+
+`<SLocalNav>` determines the top level navigation for a specific page.
+
+## Import
+
+```ts
+import SLocalNav from '@globalbrain/sefirot/lib/components/SLocalNav.vue'
+```
+
+## Usage
+
+The only required props is `:title`. The most basic local nav that contains only the title can be defined as follows.
+
+The `:title` prop accepts array of title object. This is because title could have link, and also it can be a breadcrumb as shown at later section.
+
+```vue
+<script setup lang="ts">
+const title = [
+  { text: 'Page title' }
+]
+</script>
+
+<template>
+  <SLocalNav :title="title" />
+</template>
+```
+
+### Page breadcrumbs
+
+You may pass multiple title objects as an array to `:title` prop to render breadcrumbs. Usually, except for the latest one, each title object should have `link` set.
+
+```vue
+<script setup lang="ts">
+const title = [
+  { text: 'Parent page', link: '/parent' },
+  { text: 'Current page' }
+]
+</script>
+
+<template>
+  <SLocalNav :title="title" />
+</template>
+```
+
+### Page navigation
+
+You may define `:menu` to display a page navigation. The `:menu` props accepts "double nested" array, in order to create grouping of menu items.
+
+```vue
+<script setup lang="ts">
+const title = [
+  { text: 'Page title' },
+]
+
+const menu = [
+  [
+    { text: 'Menu item 1', link: '/menu1' },
+    { text: 'Menu item 2', link: '/menu2' },
+  ],
+  [
+    { text: 'Menu item 3', link: '/menu3' },
+    { text: 'Menu item 4', link: '/menu4' },
+  ],
+]
+</script>
+
+<template>
+  <SLocalNav :title="title" :menu="menu" />
+</template>
+```
+
+## Types
+
+### `Title`
+
+The type of the `:title` prop.
+
+```ts
+interface Title {
+  text: string
+  link?: string
+}
+```
+
+### `MenuItem`
+
+The type of menu item.
+
+```ts
+import { type IconifyIcon } from '@iconify/vue/dist/offline'
+
+interface MenuItem {
+  icon?: IconifyIcon
+  text: string
+  link: string
+  active?: boolean
+}
+```
+
+## Props
+
+```ts
+interface Props {
+  title: Title[]
+  menu?: MenuItem[][]
+}
+```
+
+### `:title`
+
+The title of the page.
+
+```ts
+interface Props {
+  title: Title[]
+}
+```
+
+```vue-html
+<SLocalNav :title="[{ text: 'Page title' }]" />
+```
+
+### `:menu`
+
+The menu of the page.
+
+```ts
+interface Props {
+  menu: MenuItem[][]
+}
+```
+
+```vue-html
+<SLocalNav :title="[{ text: 'Page title' }]" />
+```

--- a/lib/components/SLocalNav.vue
+++ b/lib/components/SLocalNav.vue
@@ -1,19 +1,27 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import SLocalNavMenu, { type MenuItem } from './SLocalNavMenu.vue'
 import SLocalNavTitle, { type Title } from './SLocalNavTitle.vue'
 
 export type { Title, MenuItem }
 
-defineProps<{
+const props = defineProps<{
   title: Title[]
   menu?: MenuItem[][]
 }>()
+
+const normalizedMenu = computed(() => {
+  return props.menu?.reduce<MenuItem[][]>((carry, group) => {
+    group.length && carry.push(group)
+    return carry
+  }, []) ?? null
+})
 </script>
 
 <template>
-  <div class="SLocalNav" :class="{ 'has-menu': menu }">
+  <div class="SLocalNav" :class="{ 'has-menu': normalizedMenu }">
     <SLocalNavTitle :title="title" />
-    <SLocalNavMenu v-if="menu" :menu="menu" />
+    <SLocalNavMenu v-if="normalizedMenu" :menu="normalizedMenu" />
   </div>
 </template>
 

--- a/lib/components/SLocalNav.vue
+++ b/lib/components/SLocalNav.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import SLocalNavMenu, { type MenuItem } from './SLocalNavMenu.vue'
+import SLocalNavTitle, { type Title } from './SLocalNavTitle.vue'
+
+export type { Title, MenuItem }
+
+defineProps<{
+  title: Title[]
+  menu?: MenuItem[][]
+}>()
+</script>
+
+<template>
+  <div class="SLocalNav">
+    <SLocalNavTitle :title="title" />
+    <SLocalNavMenu v-if="menu" :menu="menu" />
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SLocalNav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 24px;
+
+  @media (min-width: 768px) {
+    padding: 16px 32px;
+  }
+}
+
+.SLocalNav:has(.SLocalNavMenu) {
+  padding-bottom: 0;
+
+  @media (min-width: 768px) {
+    padding-bottom: 0;
+  }
+}
+</style>

--- a/lib/components/SLocalNav.vue
+++ b/lib/components/SLocalNav.vue
@@ -11,7 +11,7 @@ defineProps<{
 </script>
 
 <template>
-  <div class="SLocalNav">
+  <div class="SLocalNav" :class="{ 'has-menu': menu }">
     <SLocalNavTitle :title="title" />
     <SLocalNavMenu v-if="menu" :menu="menu" />
   </div>
@@ -29,7 +29,7 @@ defineProps<{
   }
 }
 
-.SLocalNav:has(.SLocalNavMenu) {
+.SLocalNav.has-menu {
   padding-bottom: 0;
 
   @media (min-width: 768px) {

--- a/lib/components/SLocalNavMenu.vue
+++ b/lib/components/SLocalNavMenu.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { type IconifyIcon } from '@iconify/vue/dist/offline'
+import SIcon from './SIcon.vue'
+import SLink from './SLink.vue'
+
+export interface MenuItem {
+  icon?: IconifyIcon
+  text: string
+  link: string
+  active?: boolean
+}
+
+defineProps<{
+  menu: MenuItem[][]
+}>()
+</script>
+
+<template>
+  <div class="SLocalNavMenu">
+    <div v-for="nav, index in menu" :key="index" class="group">
+      <div v-for="item in nav" :key="item.text" class="item">
+        <SLink class="link" :class="{ active: item.active }" :href="item.link">
+          <SIcon v-if="item.icon" class="icon-svg" :icon="item.icon" />
+          <span class="text">{{ item.text }}</span>
+        </SLink>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SLocalNavMenu {
+  display: flex;
+  margin: 0 -24px;
+  padding: 0 24px;
+  overflow: hidden;
+  overflow-x: auto;
+
+  @media (min-width: 768px) {
+    margin: 0 -32px;
+    padding: 0 32px;
+  }
+}
+
+.group {
+  position: relative;
+  display: flex;
+  gap: 16px;
+
+  & + & {
+    padding-left: 32px;
+  }
+
+  & + &::before {
+    position: absolute;
+    top: 4px;
+    left: 16px;
+    display: block;
+    width: 1px;
+    height: 16px;
+    background-color: var(--c-divider);
+    content: "";
+  }
+}
+
+.link {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 7px;
+  line-height: 24px;
+  font-size: 14px;
+  color: var(--c-text-2);
+  transition: border-color 0.25s, color 0.25s;
+
+  &:hover {
+    color: var(--c-text-1);
+  }
+
+  &.active,
+  &.router-link-active {
+    color: var(--c-text-1);
+    border-bottom-color: var(--c-border-info-1);
+  }
+}
+
+.icon-svg {
+  width: 16px;
+  height: 16px;
+}
+</style>

--- a/lib/components/SLocalNavTitle.vue
+++ b/lib/components/SLocalNavTitle.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import SLink from './SLink.vue'
+
+export interface Title {
+  text: string
+  link?: string
+}
+
+defineProps<{
+  title: Title[]
+}>()
+</script>
+
+<template>
+  <div class="SLocalNavTitle">
+    <div v-for="item in title" :key="item.text" class="title">
+      <SLink class="text" :href="item.link">
+        {{ item.text }}
+      </SLink>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SLocalNavTitle {
+  display: flex;
+  overflow: hidden;
+}
+
+.title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  & + &::before {
+    display: inline-block;
+    margin: 0 8px;
+    line-height: 32px;
+    font-size: 20px;
+    color: var(--c-text-3);
+    content: "/";
+  }
+}
+
+.text {
+  line-height: 32px;
+  font-size: 20px;
+  font-weight: 500;
+}
+
+.text.link {
+  color: var(--c-text-info-1);
+  cursor: pointer;
+  transition: color 0.25s;
+
+  &:hover {
+    color: var(--c-text-info-2);
+  }
+}
+</style>

--- a/stories/components/SLocalNav.01_Playground.story.vue
+++ b/stories/components/SLocalNav.01_Playground.story.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import IconActivity from '@iconify-icons/ph/activity-bold'
+import IconCurrencyCircleDollar from '@iconify-icons/ph/currency-circle-dollar-bold'
+import IconGear from '@iconify-icons/ph/gear-bold'
+import SLocalNav from 'sefirot/components/SLocalNav.vue'
+
+const title = 'Components / SLocalNav / 01. Playground'
+const docs = '/components/local-nav'
+
+const navTitle = [
+  { text: 'ABC Company', link: '#' },
+  { text: 'Series A' }
+]
+
+const navMenu = [
+  [
+    { icon: IconActivity, text: 'Overview', link: '#', active: true },
+    { icon: IconCurrencyCircleDollar, text: 'Payments', link: '#' }
+  ],
+  [
+    { icon: IconGear, text: 'Settings', link: '#' }
+  ]
+]
+</script>
+
+<template>
+  <Story :title="title" source="Not available" auto-props-disabled>
+    <Board :title="title" :docs="docs">
+      <SLocalNav
+        :title="navTitle"
+        :menu="navMenu"
+      />
+    </Board>
+  </Story>
+</template>


### PR DESCRIPTION
Adds local nav component.

```vue
<script setup lang="ts">
const navTitle = [
  { text: 'ABC Company', link: '#' },
  { text: 'Series A' }
]

const navMenu = [
  [
    { icon: IconActivity, text: 'Overview', link: '#', active: true },
    { icon: IconCurrencyCircleDollar, text: 'Payments', link: '#' }
  ],
  [
    { icon: IconGear, text: 'Settings', link: '#' }
  ]
]
</script>

<template>
  <SLocalNav :title="navTitle" :menu="navMenu" />
</template>
```

---

<img width="1392" alt="Screenshot 2023-12-18 at 20 38 02" src="https://github.com/globalbrain/sefirot/assets/3753672/1152f50d-ec03-40c3-a723-322732534ab4">
