### PR TITLE
feat(table): add option to control display count of avatars (#416)

### DIFF
--- a/lib/components/STableCell.vue
+++ b/lib/components/STableCell.vue
@@ -99,6 +99,8 @@ const computedCell = computed<TableCell | undefined>(() =>
       :record="record"
       :avatars="computedCell.avatars"
       :color="computedCell.color"
+      :avatar-count="computedCell.avatarCount"
+      :name-count="computedCell.nameCount"
     />
     <STableCellActions
       v-else-if="computedCell.type === 'actions'"

--- a/lib/components/STableCellAvatars.vue
+++ b/lib/components/STableCellAvatars.vue
@@ -21,8 +21,16 @@ const _avatars = computed(() => {
     : props.avatars
 })
 
+const avatarDiff = computed(() => {
+  return _avatars.value.length - props.avatarCount
+})
+
 const displayAvatars = computed(() => {
   return _avatars.value.slice(0, props.avatarCount)
+})
+
+const nameDiff = computed(() => {
+  return _avatars.value.length - props.nameCount
 })
 
 const displayNames = computed(() => {
@@ -35,8 +43,8 @@ const displayNames = computed(() => {
 
   const names = slicedAvatars.map((avatar) => avatar.name).join(', ')
 
-  if (_avatars.value.length > slicedAvatars.length) {
-    return `${names}, +${_avatars.value.length - slicedAvatars.length}`
+  if (nameDiff.value > 0) {
+    return `${names}, ...`
   }
 
   return names
@@ -51,14 +59,15 @@ const displayNames = computed(() => {
           v-for="(avatar, index) in displayAvatars"
           :key="index"
           class="avatar"
-          :style="{ zIndex: 100 - index }"
         >
           <div class="avatar-box">
             <SAvatar size="mini" :avatar="avatar.image" :name="avatar.name" />
           </div>
         </div>
-        <div v-if="_avatars.length > avatarCount" class="avatar placeholder">
-          <div class="avatar-box" />
+        <div v-if="avatarDiff > 0" class="avatar">
+          <div class="avatar-box placeholder" :class="{ small: avatarDiff >= 10 }">
+            +{{ avatarDiff }}
+          </div>
         </div>
       </div>
       <div v-if="displayNames" class="names">
@@ -89,14 +98,15 @@ const displayNames = computed(() => {
 }
 
 .avatar.placeholder {
-  margin-left: -8px;
-
-  .avatar-box {
-    background-color: var(--c-bg-mute-1);
-  }
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .avatar-box {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: 2px solid var(--c-bg-elv-3);
   border-radius: 50%;
   width: 28px;
@@ -104,6 +114,17 @@ const displayNames = computed(() => {
 
   .row:hover & {
     border: 2px solid var(--c-bg-elv-4);
+  }
+
+  &.placeholder {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--c-text-2);
+    background-color: var(--c-bg-mute-1);
+  }
+
+  &.placeholder.small {
+    font-size: 9px;
   }
 }
 

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -158,6 +158,8 @@ export interface TableCellAvatars<V = any, R = any> extends TableCellBase {
   type: 'avatars'
   avatars: TableCellAvatarsOption[] | ((value: V, record: R) => TableCellAvatarsOption[])
   color?: 'neutral' | 'soft' | 'mute'
+  avatarCount?: number
+  nameCount?: number
 }
 
 export interface TableCellAvatarsOption {

--- a/stories/components/STable.01_Playground.story.vue
+++ b/stories/components/STable.01_Playground.story.vue
@@ -130,6 +130,10 @@ const data = shallowRef([
     status: 'Published',
     type: 'Photo',
     width: 1280,
+    authors: [
+      { image: 'https://i.pravatar.cc/64?img=1', name: 'Jane Doe' },
+      { image: 'https://i.pravatar.cc/64?img=2', name: 'Daniel Green' }
+    ],
     createdAt: day('2022-10-10'),
     tags: ['Info', 'News', 'Latest']
   },
@@ -139,6 +143,9 @@ const data = shallowRef([
     status: 'Draft',
     type: 'Icon',
     width: 1280,
+    authors: [
+      { image: 'https://i.pravatar.cc/64?img=3', name: 'John Black' }
+    ],
     createdAt: day('2022-10-09'),
     tags: ['Info']
   },
@@ -148,6 +155,16 @@ const data = shallowRef([
     status: 'Published',
     type: 'Photo',
     width: 1920,
+    authors: [
+      { image: 'https://i.pravatar.cc/64?img=4', name: 'Kris James' },
+      { image: 'https://i.pravatar.cc/64?img=5', name: 'Becky Lu' },
+      { image: 'https://i.pravatar.cc/64?img=7', name: 'Thomas Wane' },
+      { image: 'https://i.pravatar.cc/64?img=8', name: 'Thomas Wane' },
+      { image: 'https://i.pravatar.cc/64?img=9', name: 'Thomas Wane' },
+      { image: 'https://i.pravatar.cc/64?img=10', name: 'Thomas Wane' },
+      { image: 'https://i.pravatar.cc/64?img=10', name: 'Thomas Wane' },
+      { image: 'https://i.pravatar.cc/64?img=10', name: 'Thomas Wane' }
+    ],
     createdAt: day('2022-10-02'),
     tags: ['Info', 'News']
   },
@@ -157,6 +174,10 @@ const data = shallowRef([
     status: 'Published',
     type: 'Illustration',
     width: 768,
+    authors: [
+      { image: 'https://i.pravatar.cc/64?img=1', name: 'Jane Doe' },
+      { image: 'https://i.pravatar.cc/64?img=2', name: 'Daniel Green' }
+    ],
     createdAt: day('2022-09-12'),
     tags: ['Info', 'News']
   },
@@ -166,6 +187,11 @@ const data = shallowRef([
     status: 'Archived',
     type: 'Other',
     width: 512,
+    authors: [
+      { image: 'https://i.pravatar.cc/64?img=4', name: 'Kris James' },
+      { image: 'https://i.pravatar.cc/64?img=5', name: 'Becky Lu' },
+      { image: 'https://i.pravatar.cc/64?img=7', name: 'Thomas Wane' }
+    ],
     createdAt: day('2022-09-08'),
     tags: ['Info']
   }
@@ -186,6 +212,7 @@ const table = useTable({
   orders: [
     'name',
     'status',
+    'authors',
     'type',
     'width',
     'tags',
@@ -214,6 +241,14 @@ const table = useTable({
         mode: record.status === 'Published'
           ? 'success'
           : record.status === 'Draft' ? 'info' : 'mute'
+      })
+    },
+
+    authors: {
+      label: 'Authors',
+      cell: (authors) => ({
+        type: 'avatars',
+        avatars: authors
       })
     },
 
@@ -367,6 +402,7 @@ function updateTagsFilter(value: string) {
 <style scoped>
 .table :deep(.col-name)      { --table-col-width: 160px; }
 .table :deep(.col-status)    { --table-col-width: 144px; }
+.table :deep(.col-authors)   { --table-col-width: 192px; }
 .table :deep(.col-type)      { --table-col-width: 128px; }
 .table :deep(.col-width)     { --table-col-width: 128px; }
 .table :deep(.col-tags)      { --table-col-width: 192px; }

--- a/stories/components/STable.01_Playground.story.vue
+++ b/stories/components/STable.01_Playground.story.vue
@@ -402,7 +402,7 @@ function updateTagsFilter(value: string) {
 <style scoped>
 .table :deep(.col-name)      { --table-col-width: 160px; }
 .table :deep(.col-status)    { --table-col-width: 144px; }
-.table :deep(.col-authors)   { --table-col-width: 192px; }
+.table :deep(.col-authors)   { --table-col-width: 240px; }
 .table :deep(.col-type)      { --table-col-width: 128px; }
 .table :deep(.col-width)     { --table-col-width: 128px; }
 .table :deep(.col-tags)      { --table-col-width: 192px; }

--- a/stories/components/STable.01_Playground.story.vue
+++ b/stories/components/STable.01_Playground.story.vue
@@ -158,12 +158,7 @@ const data = shallowRef([
     authors: [
       { image: 'https://i.pravatar.cc/64?img=4', name: 'Kris James' },
       { image: 'https://i.pravatar.cc/64?img=5', name: 'Becky Lu' },
-      { image: 'https://i.pravatar.cc/64?img=7', name: 'Thomas Wane' },
-      { image: 'https://i.pravatar.cc/64?img=8', name: 'Thomas Wane' },
-      { image: 'https://i.pravatar.cc/64?img=9', name: 'Thomas Wane' },
-      { image: 'https://i.pravatar.cc/64?img=10', name: 'Thomas Wane' },
-      { image: 'https://i.pravatar.cc/64?img=10', name: 'Thomas Wane' },
-      { image: 'https://i.pravatar.cc/64?img=10', name: 'Thomas Wane' }
+      { image: 'https://i.pravatar.cc/64?img=7', name: 'Thomas Wane' }
     ],
     createdAt: day('2022-10-02'),
     tags: ['Info', 'News']


### PR DESCRIPTION
- close #416

Now we can control how many avatars do we wanna show on table cell. We can also set count to `0` to hide avatars or names.

```ts
const table = useTable({
  columns: {
    authors: {
      label: 'Authors',
      cell: (authors) => ({
        type: 'avatars',
        avatars: authors,
        avatarCount: 5,
        nameCount: 3
      })
    }
  }
})
```

<img width="1392" alt="Screenshot 2023-12-19 at 16 35 43" src="https://github.com/globalbrain/sefirot/assets/3753672/70703805-f3b7-45e7-aa2e-7fb5e4b62272">

