### PR TITLE
feat(table): accept ref on column show option

### DIFF
--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -8,6 +8,7 @@ import {
   reactive,
   ref,
   shallowRef,
+  toValue,
   unref,
   watch
 } from 'vue'
@@ -37,7 +38,8 @@ const row = shallowRef<HTMLElement | null>(null)
 
 const ordersToShow = computed(() => {
   const orders = unref(props.options.orders).filter((key) => {
-    return unref(props.options.columns)[key]?.show !== false
+    const show = unref(props.options.columns)[key]?.show
+    return toValue(show) !== false
   })
   if (!props.selected) {
     return orders

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -1,4 +1,4 @@
-import { type Component, type MaybeRef } from 'vue'
+import { type Component, type MaybeRef, type MaybeRefOrGetter } from 'vue'
 import { type Mode } from '../components/SButton.vue'
 import { type Day } from '../support/Day'
 import { type DropdownSection } from './Dropdown'
@@ -48,7 +48,7 @@ export interface TableColumn<V, R, SV, SR> {
   resizable?: boolean
   cell?: TableCell<V, R> | TableColumnCellFn<V, R>
   summaryCell?: TableCell<SV, SR> | TableColumnCellFn<SV, SR>
-  show?: boolean
+  show?: MaybeRefOrGetter<boolean>
 }
 
 export type TableColumnCellFn<V, R> = (value: V, record: R) => TableCell<V, R>


### PR DESCRIPTION
Currently, if we use `computed` on `columns`, the types get fucked up. Usually, we wanna use reactive value for `show` option, so for now, enabling `ref` value on show to bypass the issue.

```ts
const table = useTable({
  columns: {
    name: {
      // Now we can do this.
      show: () => shouldShow.value
    }
  }
})
```