### PR TITLE
feat(dropdown): add date range section

### DIFF
--- a/lib/components/SDropdownSection.vue
+++ b/lib/components/SDropdownSection.vue
@@ -2,6 +2,7 @@
 import { type DropdownSection } from '../composables/Dropdown'
 import SDropdownSectionActions from './SDropdownSectionActions.vue'
 import SDropdownSectionComponent from './SDropdownSectionComponent.vue'
+import SDropdownSectionDateRange from './SDropdownSectionDateRange.vue'
 import SDropdownSectionFilter from './SDropdownSectionFilter.vue'
 import SDropdownSectionMenu from './SDropdownSectionMenu.vue'
 
@@ -22,8 +23,13 @@ defineProps<{
     :options="section.options"
     :on-click="section.onClick"
   />
+  <SDropdownSectionDateRange
+    v-else-if="section.type === 'date-range'"
+    :range="section.range"
+    :on-apply="section.onApply"
+  />
   <SDropdownSectionActions
-    v-if="section.type === 'actions'"
+    v-else-if="section.type === 'actions'"
     :options="section.options"
   />
   <SDropdownSectionComponent

--- a/lib/components/SDropdownSectionDateRange.vue
+++ b/lib/components/SDropdownSectionDateRange.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { type MaybeRefOrGetter, computed, shallowRef, toValue } from 'vue'
+import { type DropdownSectionActionsOption } from '../composables/Dropdown'
+import { useTrans } from '../composables/Lang'
+import { DateRange, type DateRangePreset, type DateRangePresetType } from '../support/DateRange'
+import SDropdownSectionActions from './SDropdownSectionActions.vue'
+import SDropdownSectionDateRangeDateFromTo from './SDropdownSectionDateRangeDateFromTo.vue'
+import SDropdownSectionDateRangeYear from './SDropdownSectionDateRangeYear.vue'
+import SDropdownSectionDateRangeYearHalf from './SDropdownSectionDateRangeYearHalf.vue'
+import SDropdownSectionDateRangeYearQuarter from './SDropdownSectionDateRangeYearQuarter.vue'
+import SInputSelect from './SInputSelect.vue'
+
+const props = defineProps<{
+  range: MaybeRefOrGetter<DateRange>
+  onApply: (range: DateRange) => void
+}>()
+
+const { t } = useTrans({
+  en: {
+    p_date_from_to: 'Custom period',
+    p_year: 'Year',
+    p_year_half: 'Year half',
+    p_year_quarter: 'Year quarter'
+  },
+  ja: {
+    p_date_from_to: '日付指定',
+    p_year: '年',
+    p_year_half: '半期',
+    p_year_quarter: '四半期'
+  }
+})
+
+const _range = shallowRef(toValue(props.range))
+
+const presetValue = computed(() => {
+  return _range.value.preset.type
+})
+
+const presetOptions = [
+  { label: t.p_date_from_to, value: 'date-from-to' },
+  { label: t.p_year, value: 'year' },
+  { label: t.p_year_half, value: 'year-half' },
+  { label: t.p_year_quarter, value: 'year-quarter' }
+]
+
+const actions: DropdownSectionActionsOption[] = [
+  { label: 'Apply', mode: 'info', onClick: onApply }
+]
+
+function onPresetChange(value: any) {
+  _range.value = new DateRange().setPreset(value as DateRangePresetType)
+}
+
+function onValueChange(value: DateRangePreset) {
+  _range.value = new DateRange().setPreset(value)
+}
+
+function onApply() {
+  props.onApply(_range.value)
+}
+</script>
+
+<template>
+  <div class="SDropdownSectionDateRange">
+    <div class="preset">
+      <SInputSelect
+        size="mini"
+        :options="presetOptions"
+        :value="presetValue"
+        @change="onPresetChange"
+      />
+    </div>
+    <div class="control">
+      <SDropdownSectionDateRangeDateFromTo
+        v-if="_range.preset.type === 'date-from-to'"
+        :preset="_range.preset"
+        @change="onValueChange"
+      />
+      <SDropdownSectionDateRangeYear
+        v-else-if="_range.preset.type === 'year'"
+        :preset="_range.preset"
+        @change="onValueChange"
+      />
+      <SDropdownSectionDateRangeYearHalf
+        v-else-if="_range.preset.type === 'year-half'"
+        :preset="_range.preset"
+        @change="onValueChange"
+      />
+      <SDropdownSectionDateRangeYearQuarter
+        v-else-if="_range.preset.type === 'year-quarter'"
+        :preset="_range.preset"
+        @change="onValueChange"
+      />
+    </div>
+    <div class="actions">
+      <SDropdownSectionActions
+        :options="actions"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SDropdownSectionDateRange {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background-color: var(--c-bg-elv-1);
+}
+
+.preset {
+  padding: 8px;
+  background-color: var(--c-bg-elv-3);
+}
+
+.control {
+  background-color: var(--c-bg-elv-3);
+}
+</style>

--- a/lib/components/SDropdownSectionDateRange.vue
+++ b/lib/components/SDropdownSectionDateRange.vue
@@ -20,13 +20,15 @@ const { t } = useTrans({
     p_date_from_to: 'Custom period',
     p_year: 'Year',
     p_year_half: 'Year half',
-    p_year_quarter: 'Year quarter'
+    p_year_quarter: 'Year quarter',
+    a_apply: 'Apply'
   },
   ja: {
     p_date_from_to: '日付指定',
     p_year: '年',
     p_year_half: '半期',
-    p_year_quarter: '四半期'
+    p_year_quarter: '四半期',
+    a_apply: '適用する'
   }
 })
 
@@ -44,7 +46,7 @@ const presetOptions = [
 ]
 
 const actions: DropdownSectionActionsOption[] = [
-  { label: 'Apply', mode: 'info', onClick: onApply }
+  { label: t.a_apply, mode: 'info', onClick: onApply }
 ]
 
 function onPresetChange(value: any) {

--- a/lib/components/SDropdownSectionDateRange.vue
+++ b/lib/components/SDropdownSectionDateRange.vue
@@ -2,6 +2,7 @@
 import { type MaybeRefOrGetter, computed, shallowRef, toValue } from 'vue'
 import { type DropdownSectionActionsOption } from '../composables/Dropdown'
 import { useTrans } from '../composables/Lang'
+import { useV } from '../composables/V'
 import { DateRange, type DateRangePreset, type DateRangePresetType } from '../support/DateRange'
 import SDropdownSectionActions from './SDropdownSectionActions.vue'
 import SDropdownSectionDateRangeDateFromTo from './SDropdownSectionDateRangeDateFromTo.vue'
@@ -49,6 +50,8 @@ const actions: DropdownSectionActionsOption[] = [
   { label: t.a_apply, mode: 'info', onClick: onApply }
 ]
 
+const { validate } = useV()
+
 function onPresetChange(value: any) {
   _range.value = new DateRange().setPreset(value as DateRangePresetType)
 }
@@ -57,8 +60,10 @@ function onValueChange(value: DateRangePreset) {
   _range.value = new DateRange().setPreset(value)
 }
 
-function onApply() {
-  props.onApply(_range.value)
+async function onApply() {
+  if (await validate()) {
+    props.onApply(_range.value)
+  }
 }
 </script>
 

--- a/lib/components/SDropdownSectionDateRangeDateFromTo.vue
+++ b/lib/components/SDropdownSectionDateRangeDateFromTo.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { useV } from '../composables/V'
+import { DateFromTo } from '../support/DateRange'
+import { type Day } from '../support/Day'
+import { required } from '../validation/rules'
+import SInputDate from './SInputDate.vue'
+
+const props = defineProps<{
+  preset: DateFromTo
+}>()
+
+const emit = defineEmits<{
+  (e: 'change', value: DateFromTo): void
+}>()
+
+const { validation } = useV(() => ({
+  from: props.preset.from,
+  to: props.preset.to
+}), {
+  from: { required: required() },
+  to: { required: required() }
+})
+
+function onFromChange(value: Day | null) {
+  emit('change', new DateFromTo().setFrom(value).setTo(props.preset.to))
+}
+
+function onToChange(value: Day | null) {
+  emit('change', new DateFromTo().setFrom(props.preset.from).setTo(value))
+}
+</script>
+
+<template>
+  <div class="SDropdownSectionDateRangeDateFromTo">
+    <div class="group">
+      <div class="label">From</div>
+      <div class="input">
+        <SInputDate
+          size="mini"
+          block
+          :model-value="preset.from"
+          :validation="validation.from"
+          hide-error
+          @change="onFromChange"
+        />
+      </div>
+    </div>
+    <div class="group">
+      <div class="label">To</div>
+      <div class="input">
+        <SInputDate
+          size="mini"
+          block
+          :model-value="preset.to"
+          :validation="validation.to"
+          hide-error
+          @change="onToChange"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SDropdownSectionDateRangeDateFromTo {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.group {
+  display: flex;
+  align-items: center;
+  padding: 0 8px 0 16px;
+}
+
+.label {
+  flex-shrink: 0;
+  width: 64px;
+  font-size: 12px;
+  color: var(--c-text-2);
+}
+
+.input {
+  flex-grow: 1;
+}
+</style>

--- a/lib/components/SDropdownSectionDateRangeYear.vue
+++ b/lib/components/SDropdownSectionDateRangeYear.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { useV } from '../composables/V'
+import { Year } from '../support/DateRange'
+import { maxValue, minValue, required } from '../validation/rules'
+import SInputNumber from './SInputNumber.vue'
+
+const props = defineProps<{
+  preset: Year
+}>()
+
+const emit = defineEmits<{
+  (e: 'change', value: Year): void
+}>()
+
+const { validation } = useV(() => ({
+  year: props.preset.year
+}), {
+  year: {
+    required: required(),
+    minValue: minValue(1),
+    maxValue: maxValue(9999)
+  }
+})
+
+function onInput(value: number | null) {
+  emit('change', new Year().setYear(value))
+}
+</script>
+
+<template>
+  <div class="SDropdownSectionDateRangeYear">
+    <div class="group">
+      <div class="label">Year</div>
+      <div class="input">
+        <SInputNumber
+          size="mini"
+          placeholder="YYYY"
+          block
+          :model-value="preset.year"
+          :validation="validation.year"
+          hide-error
+          @input="onInput"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SDropdownSectionDateRangeYear {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.group {
+  display: flex;
+  align-items: center;
+  padding: 0 8px 0 16px;
+}
+
+.label {
+  flex-shrink: 0;
+  width: 64px;
+  font-size: 12px;
+  color: var(--c-text-2);
+}
+
+.input {
+  flex-grow: 1;
+}
+</style>

--- a/lib/components/SDropdownSectionDateRangeYearHalf.vue
+++ b/lib/components/SDropdownSectionDateRangeYearHalf.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { useV } from '../composables/V'
+import { YearHalf } from '../support/DateRange'
+import { maxValue, minValue, required } from '../validation/rules'
+import SInputNumber from './SInputNumber.vue'
+import SInputSelect from './SInputSelect.vue'
+
+const props = defineProps<{
+  preset: YearHalf
+}>()
+
+const emit = defineEmits<{
+  (e: 'change', value: YearHalf): void
+}>()
+
+const { validation } = useV(() => ({
+  year: props.preset.year
+}), {
+  year: {
+    required: required(),
+    minValue: minValue(1),
+    maxValue: maxValue(9999)
+  }
+})
+
+const halfOptions = [
+  { label: 'H1', value: 1 },
+  { label: 'H2', value: 2 }
+]
+
+function onYearInput(value: number | null) {
+  emit('change', new YearHalf().setYear(value).setHalf(props.preset.half))
+}
+
+function onHalfChange(value: any) {
+  emit('change', new YearHalf().setYear(props.preset.year).setHalf(value))
+}
+</script>
+
+<template>
+  <div class="SDropdownSectionDateRangeYearHalf">
+    <div class="group">
+      <div class="label">Year</div>
+      <div class="input">
+        <SInputNumber
+          size="mini"
+          placeholder="YYYY"
+          block
+          :model-value="preset.year"
+          :validation="validation.year"
+          hide-error
+          @input="onYearInput"
+        />
+      </div>
+    </div>
+    <div class="group">
+      <div class="label">Half</div>
+      <div class="input">
+        <SInputSelect
+          size="mini"
+          :options="halfOptions"
+          :model-value="preset.half"
+          @change="onHalfChange"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SDropdownSectionDateRangeYearHalf {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.group {
+  display: flex;
+  align-items: center;
+  padding: 0 8px 0 16px;
+}
+
+.label {
+  flex-shrink: 0;
+  width: 64px;
+  font-size: 12px;
+  color: var(--c-text-2);
+}
+
+.input {
+  flex-grow: 1;
+}
+</style>

--- a/lib/components/SDropdownSectionDateRangeYearQuarter.vue
+++ b/lib/components/SDropdownSectionDateRangeYearQuarter.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { useV } from '../composables/V'
+import { YearQuarter } from '../support/DateRange'
+import { maxValue, minValue, required } from '../validation/rules'
+import SInputNumber from './SInputNumber.vue'
+import SInputSelect from './SInputSelect.vue'
+
+const props = defineProps<{
+  preset: YearQuarter
+}>()
+
+const emit = defineEmits<{
+  (e: 'change', value: YearQuarter): void
+}>()
+
+const { validation } = useV(() => ({
+  year: props.preset.year
+}), {
+  year: {
+    required: required(),
+    minValue: minValue(1),
+    maxValue: maxValue(9999)
+  }
+})
+
+const quarterOptions = [
+  { label: 'Q1', value: 1 },
+  { label: 'Q2', value: 2 },
+  { label: 'Q3', value: 3 },
+  { label: 'Q4', value: 4 }
+]
+
+function onYearInput(value: number | null) {
+  emit('change', new YearQuarter().setYear(value).setQuarter(props.preset.quarter))
+}
+
+function onQuarterChange(value: any) {
+  emit('change', new YearQuarter().setYear(props.preset.year).setQuarter(value))
+}
+</script>
+
+<template>
+  <div class="SDropdownSectionDateRangeYearQuarter">
+    <div class="group">
+      <div class="label">Year</div>
+      <div class="input">
+        <SInputNumber
+          size="mini"
+          placeholder="YYYY"
+          block
+          :model-value="preset.year"
+          :validation="validation.year"
+          hide-error
+          @input="onYearInput"
+        />
+      </div>
+    </div>
+    <div class="group">
+      <div class="label">Quarter</div>
+      <div class="input">
+        <SInputSelect
+          size="mini"
+          :options="quarterOptions"
+          :model-value="preset.quarter"
+          @change="onQuarterChange"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SDropdownSectionDateRangeYearQuarter {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.group {
+  display: flex;
+  align-items: center;
+  padding: 0 8px 0 16px;
+}
+
+.label {
+  flex-shrink: 0;
+  width: 64px;
+  font-size: 12px;
+  color: var(--c-text-2);
+}
+
+.input {
+  flex-grow: 1;
+}
+</style>

--- a/lib/composables/Dropdown.ts
+++ b/lib/composables/Dropdown.ts
@@ -1,13 +1,20 @@
 import { useElementBounding, useWindowSize } from '@vueuse/core'
-import { type Component, type MaybeRef, type Ref, ref, unref } from 'vue'
+import { type Component, type MaybeRef, type MaybeRefOrGetter, type Ref, ref, unref } from 'vue'
+import { type DateRange } from '../support/DateRange'
 
 export type DropdownSection =
   | DropdownSectionMenu
   | DropdownSectionFilter
+  | DropdownSectionDateRange
   | DropdownSectionComponent
   | DropdownSectionActions
 
-export type DropdownSectionType = 'menu' | 'filter' | 'actions' | 'component'
+export type DropdownSectionType =
+  | 'menu'
+  | 'filter'
+  | 'date-range'
+  | 'actions'
+  | 'component'
 
 export interface DropdownSectionBase {
   type: DropdownSectionType
@@ -60,6 +67,12 @@ export interface DropdownSectionFilterOptionAvatar extends DropdownSectionFilter
   image?: string | null
 }
 
+export interface DropdownSectionDateRange extends DropdownSectionBase {
+  type: 'date-range'
+  range: MaybeRefOrGetter<DateRange>
+  onApply(range: DateRange): void
+}
+
 export interface DropdownSectionActions extends DropdownSectionBase {
   type: 'actions'
   options: DropdownSectionActionsOption[]
@@ -85,6 +98,12 @@ export interface ManualDropdownPosition {
 
 export function createDropdown(section: DropdownSection[]): DropdownSection[] {
   return section
+}
+
+export function createDropdownDateRange(
+  section: Omit<DropdownSectionDateRange, 'type'>
+): DropdownSectionDateRange {
+  return { type: 'date-range', ...section }
 }
 
 export function useManualDropdownPosition(

--- a/lib/composables/Dropdown.ts
+++ b/lib/composables/Dropdown.ts
@@ -95,7 +95,6 @@ export function createDropdown(section: DropdownSection[]): DropdownSection[] {
   return section
 }
 
-
 export function createDropdownDateRange(
   section: Omit<DropdownSectionDateRange, 'type'>
 ): DropdownSectionDateRange {

--- a/lib/composables/V.ts
+++ b/lib/composables/V.ts
@@ -28,8 +28,8 @@ export function useV<
   Data extends { [key in keyof Rules]: any },
   Rules extends ValidationArgs = ValidationArgs
 >(
-  data: MaybeRefOrGetter<Data>,
-  rules: MaybeRefOrGetter<Rules>
+  data?: MaybeRefOrGetter<Data>,
+  rules?: MaybeRefOrGetter<Rules>
 ): V<Data, Rules> {
   const { t } = useTrans({
     en: { notify: 'Form contains errors. Please correct them and try again.' },
@@ -38,10 +38,10 @@ export function useV<
 
   const snackbars = useSnackbars()
 
-  const d = computed(() => toValue(data))
-  const r = computed(() => toValue(rules))
+  const d = computed(() => toValue(data) ?? {})
+  const r = computed(() => toValue(rules) ?? {})
 
-  const validation = useVuelidate(r, d)
+  const validation = useVuelidate(r, d) as any
 
   function reset(): void {
     validation.value.$reset()

--- a/lib/support/DateRange.ts
+++ b/lib/support/DateRange.ts
@@ -48,11 +48,16 @@ export class DateRange {
   getTo(): Day | null {
     return this.preset.getTo()
   }
+
+  getLabeltext(): string {
+    return this.preset.getLabeltext()
+  }
 }
 
 export abstract class DateRangePresetBase {
   abstract getFrom(): Day | null
   abstract getTo(): Day | null
+  abstract getLabeltext(): string
 
   protected getYear(year: number | null): Day | null {
     if (!year) {
@@ -84,6 +89,13 @@ export class DateFromTo extends DateRangePresetBase {
     return this.to
   }
 
+  getLabeltext(): string {
+    const f = this.getFrom()?.format('YYYY-MM-DD')
+    const t = this.getTo()?.format('YYYY-MM-DD')
+
+    return (f && t) ? `${f} – ${t}` : 'Error'
+  }
+
   setFrom(from: Day | null): this {
     this.from = from
     return this
@@ -110,6 +122,10 @@ export class Year extends DateRangePresetBase {
 
   getTo(): Day | null {
     return this.getYear(this.year)?.endOf('year') ?? null
+  }
+
+  getLabeltext(): string {
+    return this.getYear(this.year)?.format('YYYY') ?? 'Error'
   }
 
   setYear(year: number | null): this {
@@ -144,6 +160,12 @@ export class YearHalf extends DateRangePresetBase {
     return this.getYear(this.year)
       ?.month(this.monthDict[this.half] + 5)
       .endOf('month') ?? null
+  }
+
+  getLabeltext(): string {
+    const y = this.getYear(this.year)?.format('YYYY')
+
+    return y ? `${y}H${this.half}` : 'Error'
   }
 
   setYear(year: number | null): this {
@@ -185,6 +207,12 @@ export class YearQuarter extends DateRangePresetBase {
     return this.getYear(this.year)
       ?.month(this.monthDict[this.quarter] + 2)
       .endOf('month') ?? null
+  }
+
+  getLabeltext(): string {
+    const y = this.getYear(this.year)?.format('YYYY')
+
+    return y ? `${y}Q${this.quarter}` : 'Error'
   }
 
   setYear(year: number | null): this {

--- a/lib/support/DateRange.ts
+++ b/lib/support/DateRange.ts
@@ -1,0 +1,199 @@
+import { type Day, day } from './Day'
+
+export type DateRangePreset =
+  | DateFromTo
+  | Year
+  | YearHalf
+  | YearQuarter
+
+export type DateRangePresetType =
+  | 'date-from-to'
+  | 'year'
+  | 'year-half'
+  | 'year-quarter'
+
+export type DateRangePresetDict = {
+  'date-from-to': typeof DateFromTo
+  'year': typeof Year
+  'year-half': typeof YearHalf
+  'year-quarter': typeof YearQuarter
+}
+
+export class DateRange {
+  preset: DateRangePreset
+
+  presetDict: DateRangePresetDict = {
+    'date-from-to': DateFromTo,
+    'year': Year,
+    'year-half': YearHalf,
+    'year-quarter': YearQuarter
+  }
+
+  constructor() {
+    this.preset = new DateFromTo()
+  }
+
+  setPreset(preset: DateRangePreset | DateRangePresetType): this {
+    preset = typeof preset === 'string' ? new this.presetDict[preset]() : preset
+
+    this.preset = preset
+
+    return this
+  }
+
+  getFrom(): Day | null {
+    return this.preset.getFrom()
+  }
+
+  getTo(): Day | null {
+    return this.preset.getTo()
+  }
+}
+
+export abstract class DateRangePresetBase {
+  abstract getFrom(): Day | null
+  abstract getTo(): Day | null
+
+  protected getYear(year: number | null): Day | null {
+    if (!year) {
+      return null
+    }
+
+    const d = day().year(year)
+
+    return d.isValid() ? d : null
+  }
+}
+
+export class DateFromTo extends DateRangePresetBase {
+  type = 'date-from-to' as const
+  from: Day | null
+  to: Day | null
+
+  constructor() {
+    super()
+    this.from = day().subtract(30, 'days')
+    this.to = day()
+  }
+
+  getFrom(): Day | null {
+    return this.from
+  }
+
+  getTo(): Day | null {
+    return this.to
+  }
+
+  setFrom(from: Day | null): this {
+    this.from = from
+    return this
+  }
+
+  setTo(to: Day | null): this {
+    this.to = to
+    return this
+  }
+}
+
+export class Year extends DateRangePresetBase {
+  type = 'year' as const
+  year: number | null = null
+
+  constructor() {
+    super()
+    this.year = day().year()
+  }
+
+  getFrom(): Day | null {
+    return this.getYear(this.year)?.startOf('year') ?? null
+  }
+
+  getTo(): Day | null {
+    return this.getYear(this.year)?.endOf('year') ?? null
+  }
+
+  setYear(year: number | null): this {
+    this.year = year
+    return this
+  }
+}
+
+export class YearHalf extends DateRangePresetBase {
+  type = 'year-half' as const
+  year: number | null
+  half: 1 | 2
+
+  protected monthDict: Record<number, number> = {
+    1: 0,
+    2: 6
+  }
+
+  constructor() {
+    super()
+    this.year = day().year()
+    this.half = 1
+  }
+
+  getFrom(): Day | null {
+    return this.getYear(this.year)
+      ?.month(this.monthDict[this.half])
+      .startOf('month') ?? null
+  }
+
+  getTo(): Day | null {
+    return this.getYear(this.year)
+      ?.month(this.monthDict[this.half] + 5)
+      .endOf('month') ?? null
+  }
+
+  setYear(year: number | null): this {
+    this.year = year
+    return this
+  }
+
+  setHalf(half: 1 | 2): this {
+    this.half = half
+    return this
+  }
+}
+
+export class YearQuarter extends DateRangePresetBase {
+  type = 'year-quarter' as const
+  year: number | null
+  quarter: 1 | 2 | 3 | 4
+
+  protected monthDict: Record<number, number> = {
+    1: 0,
+    2: 3,
+    3: 6,
+    4: 9
+  }
+
+  constructor() {
+    super()
+    this.year = day().year()
+    this.quarter = 1
+  }
+
+  getFrom(): Day | null {
+    return this.getYear(this.year)
+      ?.month(this.monthDict[this.quarter])
+      .startOf('month') ?? null
+  }
+
+  getTo(): Day | null {
+    return this.getYear(this.year)
+      ?.month(this.monthDict[this.quarter] + 2)
+      .endOf('month') ?? null
+  }
+
+  setYear(year: number | null): this {
+    this.year = year
+    return this
+  }
+
+  setQuarter(quarter: 1 | 2 | 3 | 4): this {
+    this.quarter = quarter
+    return this
+  }
+}

--- a/stories/components/SDropdown.02_Section_Date_Range.story.vue
+++ b/stories/components/SDropdown.02_Section_Date_Range.story.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import SDropdown from 'sefirot/components/SDropdown.vue'
+import { createDropdownDateRange } from 'sefirot/composables/Dropdown'
+import { DateRange } from 'sefirot/support/DateRange'
+import { shallowRef } from 'vue'
+
+const title = 'Components / SDropdown / 02. Section Date Range'
+
+const range = shallowRef(new DateRange())
+
+const sections = [
+  createDropdownDateRange({
+    range,
+    onApply: (r) => { range.value = r }
+  })
+]
+</script>
+
+<template>
+  <Story :title="title" source="Not available" auto-props-disabled>
+    <Board :title="title">
+      <div class="max-w-256">
+        <SDropdown :sections="sections" />
+      </div>
+    </Board>
+  </Story>
+</template>


### PR DESCRIPTION
Add dropdown section to handle "Date Range" selection.

I've added new class `DateRange` which holds `from` and `to` dates, with `presets`. The usage would look like this.

```vue
<script setup lang="ts">
// Create a new `DateRange` instance.
const range = shallowRef(new DateRange())

const sections = [
  createDropdownDateRange({
    range,

    // This callback will only be called when user hits
    // `Apply` button in dropdown menu.
    onApply: (r) => { range.value = r }
  })
]

// Access `from` and `to` value.
range.value.getFrom() // Day instance
range.value.getTo()   // Day instance
</script>

<template>
<SDropdown :sections="sections" />
</template>
```

You can define custom preset as a default value by creating the preset at the beginning.

```ts
const range = shallowRef(
  new DateRange.setPreset(
    new YearHalf().setYear(2018).setHalf(2)
  )
)
```

---

<img width="1392" alt="Screenshot 2023-12-25 at 16 57 34" src="https://github.com/globalbrain/sefirot/assets/3753672/69157217-d2b0-438f-a615-c695ccc8ee67">

<img width="1392" alt="Screenshot 2023-12-25 at 16 57 50" src="https://github.com/globalbrain/sefirot/assets/3753672/60e9f712-eaff-4f6a-b397-049990966ee7">