### PR TITLE
fix(d): make init work multiple times

### DIFF
--- a/lib/composables/D.ts
+++ b/lib/composables/D.ts
@@ -6,12 +6,12 @@ export interface D<T extends Record<string, any>> {
 }
 
 export function useD<T extends Record<string, any>>(data: T): D<T> {
-  const initialData = JSON.parse(JSON.stringify(data))
+  const initialData = JSON.stringify(data)
 
   const refData = ref(data) as Ref<T>
 
   function init(): void {
-    refData.value = initialData
+    refData.value = JSON.parse(initialData)
   }
 
   return {

--- a/tests/composables/D.spec.ts
+++ b/tests/composables/D.spec.ts
@@ -17,5 +17,17 @@ describe('composables/D', () => {
 
     expect(data.value.a).toBe(1)
     expect(data.value.b).toBe(2)
+
+    // Check 2nd time reset to ensure it can reset the state multiple times.
+    data.value.a = 3
+    data.value.b = 4
+
+    expect(data.value.a).toBe(3)
+    expect(data.value.b).toBe(4)
+
+    init()
+
+    expect(data.value.a).toBe(1)
+    expect(data.value.b).toBe(2)
   })
 })


### PR DESCRIPTION
`init` was not working when executed multiple times. We need to parse the stored json when executing init, not upfront. Cause otherwise the `initialData` are passed as reference and init no longer works when hit 2nd time.