### PR TITLE
feat(lang): add useBrowserLang function

### DIFF
--- a/lib/composables/Lang.ts
+++ b/lib/composables/Lang.ts
@@ -33,7 +33,7 @@ export function useTrans<T>(messages: TransMessages<T>): Trans<T> {
   }
 }
 
-export function useBrowserLang() {
+export function useBrowserLang(): Lang {
   const lang = navigator.language
 
   return lang.split('-')[0] === 'ja' ? 'ja' : 'en'

--- a/lib/composables/Lang.ts
+++ b/lib/composables/Lang.ts
@@ -32,3 +32,9 @@ export function useTrans<T>(messages: TransMessages<T>): Trans<T> {
     t
   }
 }
+
+export function useBrowserLang() {
+  const lang = navigator.language
+
+  return lang.split('-')[0] === 'ja' ? 'ja' : 'en'
+}


### PR DESCRIPTION
closes #422

I don't think we need reactivity here. `useNavigatorLanguage` changes the language ref when a browser fires `languagechange` event, which in our case doesn't happen IG (you need to change preferred languages in browser settings to trigger it.)