### PR TITLE
feat(http): allow overriding fetch handler

### DIFF
--- a/lib/composables/Api.ts
+++ b/lib/composables/Api.ts
@@ -30,7 +30,7 @@ export function useQuery<Data = any>(
   const loading = ref(false)
   const data = ref<Data | undefined>()
 
-  if (options.immediate !== false) {
+  if (options.immediate !== false && !import.meta.env.SSR) {
     execute()
   }
 

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -1,19 +1,24 @@
 import { parse as parseContentDisposition } from '@tinyhttp/content-disposition'
 import { parse as parseCookie } from '@tinyhttp/cookie'
 import FileSaver from 'file-saver'
-import { type $Fetch, type FetchOptions, ofetch } from 'ofetch'
+import { type FetchOptions, type FetchRequest, type FetchResponse, ofetch } from 'ofetch'
 import { stringify } from 'qs'
+
+interface HttpClient {
+  <T = any>(request: FetchRequest, options?: Omit<FetchOptions, 'method'>): Promise<T>
+  raw<T = any>(request: FetchRequest, options?: Omit<FetchOptions, 'method'>): Promise<FetchResponse<T>>
+}
 
 interface HttpOptions {
   baseURL?: string
   xsrfURL?: string | false
-  client?: $Fetch
+  client?: HttpClient
 }
 
 export class Http {
   private static baseURL: string | undefined = undefined
   private static xsrfURL: string | false = '/api/csrf-cookie'
-  private static client: $Fetch = ofetch
+  private static client: HttpClient = ofetch
 
   static config(options: HttpOptions) {
     if (options.baseURL) {
@@ -73,11 +78,11 @@ export class Http {
   }
 
   private async performRequest<T>(url: string, options: FetchOptions = {}) {
-    return Http.client<T, any>(...(await this.buildRequest(url, options)))
+    return Http.client<T>(...(await this.buildRequest(url, options)))
   }
 
   private async performRequestRaw<T>(url: string, options: FetchOptions = {}) {
-    return Http.client.raw<T, any>(...(await this.buildRequest(url, options)))
+    return Http.client.raw<T>(...(await this.buildRequest(url, options)))
   }
 
   async get<T = any>(url: string, options?: FetchOptions): Promise<T> {

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -4,12 +4,12 @@ import FileSaver from 'file-saver'
 import { type FetchOptions, type FetchRequest, type FetchResponse, ofetch } from 'ofetch'
 import { stringify } from 'qs'
 
-interface HttpClient {
+export interface HttpClient {
   <T = any>(request: FetchRequest, options?: Omit<FetchOptions, 'method'>): Promise<T>
   raw<T = any>(request: FetchRequest, options?: Omit<FetchOptions, 'method'>): Promise<FetchResponse<T>>
 }
 
-interface HttpOptions {
+export interface HttpOptions {
   baseURL?: string
   xsrfURL?: string | false
   client?: HttpClient

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -1,22 +1,41 @@
 import { parse as parseContentDisposition } from '@tinyhttp/content-disposition'
 import { parse as parseCookie } from '@tinyhttp/cookie'
 import FileSaver from 'file-saver'
-import { $fetch, type FetchOptions } from 'ofetch'
+import { type $Fetch, type FetchOptions, ofetch } from 'ofetch'
 import { stringify } from 'qs'
 
+interface HttpOptions {
+  baseURL?: string
+  xsrfURL?: string | false
+  client?: $Fetch
+}
+
 export class Http {
-  static base: string | undefined = undefined
-  static xsrfUrl: string | false = '/api/csrf-cookie'
+  private static baseURL: string | undefined = undefined
+  private static xsrfURL: string | false = '/api/csrf-cookie'
+  private static client: $Fetch = ofetch
+
+  static config(options: HttpOptions) {
+    if (options.baseURL) {
+      Http.baseURL = options.baseURL
+    }
+    if (options.xsrfURL !== undefined) {
+      Http.xsrfURL = options.xsrfURL
+    }
+    if (options.client) {
+      Http.client = options.client
+    }
+  }
 
   private async ensureXsrfToken(): Promise<string | undefined> {
-    if (!Http.xsrfUrl) {
+    if (!Http.xsrfURL) {
       return undefined
     }
 
     let xsrfToken = parseCookie(document.cookie)['XSRF-TOKEN']
 
     if (!xsrfToken) {
-      await this.head(Http.xsrfUrl)
+      await this.head(Http.xsrfURL)
       xsrfToken = parseCookie(document.cookie)['XSRF-TOKEN']
     }
 
@@ -40,7 +59,7 @@ export class Http {
     return [
       `${url}${queryString ? `?${queryString}` : ''}`,
       {
-        baseURL: Http.base,
+        baseURL: Http.baseURL,
         method,
         credentials: 'include',
         ...options,
@@ -54,11 +73,11 @@ export class Http {
   }
 
   private async performRequest<T>(url: string, options: FetchOptions = {}) {
-    return $fetch<T, any>(...(await this.buildRequest(url, options)))
+    return Http.client<T, any>(...(await this.buildRequest(url, options)))
   }
 
   private async performRequestRaw<T>(url: string, options: FetchOptions = {}) {
-    return $fetch.raw<T, any>(...(await this.buildRequest(url, options)))
+    return Http.client.raw<T, any>(...(await this.buildRequest(url, options)))
   }
 
   async get<T = any>(url: string, options?: FetchOptions): Promise<T> {


### PR DESCRIPTION
Bit of a breaking change:

```ts
// earlier -- Http.base = '/foo' -- now:

Http.config({
  baseURL: '/foo'
})
```