### PR TITLE
refactor(validation): change validator argument types

### DIFF
--- a/lib/components/SInputAddon.vue
+++ b/lib/components/SInputAddon.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import IconCaretDown from '@iconify-icons/ph/caret-down-bold'
+import { computed, ref } from 'vue'
 import {
   type DropdownSection,
   getSelectedOption,
   useManualDropdownPosition
-} from 'sefirot/composables/Dropdown'
-import { useFlyout } from 'sefirot/composables/Flyout'
-import { computed, ref } from 'vue'
+} from '../composables/Dropdown'
+import { useFlyout } from '../composables/Flyout'
 import { isString } from '../support/Utils'
 import SDropdown from './SDropdown.vue'
 import SIcon from './SIcon.vue'

--- a/lib/components/STableCellNumber.vue
+++ b/lib/components/STableCellNumber.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { format } from 'sefirot/support/Num'
 import { computed } from 'vue'
 import { type TableCellValueColor } from '../composables/Table'
+import { format } from '../support/Num'
 import SIcon from './SIcon.vue'
 import SLink from './SLink.vue'
 

--- a/lib/support/Day.ts
+++ b/lib/support/Day.ts
@@ -19,6 +19,14 @@ export interface Ymd {
   date: number | null
 }
 
+export type YmdType = 'y' | 'm' | 'd'
+
+export const YmdMap = {
+  y: 'year',
+  m: 'month',
+  d: 'date'
+} as const
+
 /**
  * The hour, minute, and second object interface.
  */
@@ -27,6 +35,14 @@ export interface Hms {
   minute: string | null
   second: string | null
 }
+
+export type HmsType = 'h' | 'm' | 's'
+
+export const HmsMap = {
+  h: 'hour',
+  m: 'minute',
+  s: 'second'
+} as const
 
 export function day(input?: Input): Day {
   return dayjs(input)

--- a/lib/support/Day.ts
+++ b/lib/support/Day.ts
@@ -2,6 +2,7 @@ import dayjs, { type ConfigType, type Dayjs } from 'dayjs'
 import PluginRelativeTime from 'dayjs/plugin/relativeTime'
 import PluginTimezone from 'dayjs/plugin/timezone'
 import PluginUtc from 'dayjs/plugin/utc'
+import { isNumber, isObject, isString } from './Utils'
 
 dayjs.extend(PluginUtc)
 dayjs.extend(PluginTimezone)
@@ -84,4 +85,30 @@ export function createHms(
     minute,
     second
   }
+}
+
+export function isYmd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): value is Ymd {
+  if (!isObject(value)) {
+    return false
+  }
+
+  return required
+    .reduce<string[]>((keys, type) => {
+      keys.push(YmdMap[type])
+      return keys
+    }, [])
+    .every((key) => value[key] === null || isNumber(value[key]))
+}
+
+export function isHms(value: unknown, required: HmsType[] = ['h', 'm', 's']): value is Hms {
+  if (!isObject(value)) {
+    return false
+  }
+
+  return required
+    .reduce<string[]>((keys, type) => {
+      keys.push(HmsMap[type])
+      return keys
+    }, [])
+    .every((key) => value[key] === null || isString(value[key]))
 }

--- a/lib/support/Utils.ts
+++ b/lib/support/Utils.ts
@@ -25,7 +25,7 @@ export function isFile(value: unknown): value is File {
 }
 
 export function isYmd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): value is Ymd {
-  if (value === null || typeof value !== 'object') {
+  if (!isObject(value)) {
     return false
   }
 
@@ -34,11 +34,11 @@ export function isYmd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): va
       keys.push(YmdMap[type])
       return keys
     }, [])
-    .every((v) => Object.hasOwn(value, v))
+    .every((key) => value[key] === null || isString(value[key]) || isNumber(value[key]))
 }
 
 export function isHms(value: unknown, required: HmsType[] = ['h', 'm', 's']): value is Hms {
-  if (value === null || typeof value !== 'object') {
+  if (!isObject(value)) {
     return false
   }
 
@@ -47,5 +47,5 @@ export function isHms(value: unknown, required: HmsType[] = ['h', 'm', 's']): va
       keys.push(HmsMap[type])
       return keys
     }, [])
-    .every((v) => Object.hasOwn(value, v))
+    .every((key) => value[key] === null || isString(value[key]) || isNumber(value[key]))
 }

--- a/lib/support/Utils.ts
+++ b/lib/support/Utils.ts
@@ -1,4 +1,4 @@
-import { type Hms, HmsMap, type Ymd, YmdMap } from './Day'
+import { type Hms, HmsMap, type HmsType, type Ymd, YmdMap, type YmdType } from './Day'
 
 export function isNullish(value: unknown): value is undefined | null {
   return value === null || value === undefined
@@ -24,18 +24,28 @@ export function isFile(value: unknown): value is File {
   return value instanceof File
 }
 
-export function isYmd(value: unknown): value is Ymd {
-  return (
-    value !== null
-    && typeof value === 'object'
-    && Object.values(YmdMap).every((v) => Object.hasOwn(value, v))
-  )
+export function isYmd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): value is Ymd {
+  if (value === null || typeof value !== 'object') {
+    return false
+  }
+
+  return required
+    .reduce<string[]>((keys, type) => {
+      keys.push(YmdMap[type])
+      return keys
+    }, [])
+    .every((v) => Object.hasOwn(value, v))
 }
 
-export function isHms(value: unknown): value is Hms {
-  return (
-    value !== null
-    && typeof value === 'object'
-    && Object.values(HmsMap).every((v) => Object.hasOwn(value, v))
-  )
+export function isHms(value: unknown, required: HmsType[] = ['h', 'm', 's']): value is Hms {
+  if (value === null || typeof value !== 'object') {
+    return false
+  }
+
+  return required
+    .reduce<string[]>((keys, type) => {
+      keys.push(HmsMap[type])
+      return keys
+    }, [])
+    .every((v) => Object.hasOwn(value, v))
 }

--- a/lib/support/Utils.ts
+++ b/lib/support/Utils.ts
@@ -34,7 +34,7 @@ export function isYmd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): va
       keys.push(YmdMap[type])
       return keys
     }, [])
-    .every((key) => value[key] === null || isString(value[key]) || isNumber(value[key]))
+    .every((key) => value[key] === null || isNumber(value[key]))
 }
 
 export function isHms(value: unknown, required: HmsType[] = ['h', 'm', 's']): value is Hms {
@@ -47,5 +47,5 @@ export function isHms(value: unknown, required: HmsType[] = ['h', 'm', 's']): va
       keys.push(HmsMap[type])
       return keys
     }, [])
-    .every((key) => value[key] === null || isString(value[key]) || isNumber(value[key]))
+    .every((key) => value[key] === null || isString(value[key]))
 }

--- a/lib/support/Utils.ts
+++ b/lib/support/Utils.ts
@@ -1,5 +1,3 @@
-import { type Hms, HmsMap, type HmsType, type Ymd, YmdMap, type YmdType } from './Day'
-
 export function isNullish(value: unknown): value is undefined | null {
   return value === null || value === undefined
 }
@@ -22,30 +20,4 @@ export function isObject(value: unknown): value is Record<string, any> {
 
 export function isFile(value: unknown): value is File {
   return value instanceof File
-}
-
-export function isYmd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): value is Ymd {
-  if (!isObject(value)) {
-    return false
-  }
-
-  return required
-    .reduce<string[]>((keys, type) => {
-      keys.push(YmdMap[type])
-      return keys
-    }, [])
-    .every((key) => value[key] === null || isNumber(value[key]))
-}
-
-export function isHms(value: unknown, required: HmsType[] = ['h', 'm', 's']): value is Hms {
-  if (!isObject(value)) {
-    return false
-  }
-
-  return required
-    .reduce<string[]>((keys, type) => {
-      keys.push(HmsMap[type])
-      return keys
-    }, [])
-    .every((key) => value[key] === null || isString(value[key]))
 }

--- a/lib/support/Utils.ts
+++ b/lib/support/Utils.ts
@@ -1,3 +1,5 @@
+import { type Hms, HmsMap, type Ymd, YmdMap } from './Day'
+
 export function isNullish(value: unknown): value is undefined | null {
   return value === null || value === undefined
 }
@@ -20,4 +22,20 @@ export function isObject(value: unknown): value is Record<string, any> {
 
 export function isFile(value: unknown): value is File {
   return value instanceof File
+}
+
+export function isYmd(value: unknown): value is Ymd {
+  return (
+    value !== null
+    && typeof value === 'object'
+    && Object.values(YmdMap).every((v) => Object.hasOwn(value, v))
+  )
+}
+
+export function isHms(value: unknown): value is Hms {
+  return (
+    value !== null
+    && typeof value === 'object'
+    && Object.values(HmsMap).every((v) => Object.hasOwn(value, v))
+  )
 }

--- a/lib/validation/rules/checked.ts
+++ b/lib/validation/rules/checked.ts
@@ -10,6 +10,6 @@ export function checked(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
     optional: true,
-    validation: (value: boolean) => baseChecked(value)
+    validation: baseChecked
   })
 }

--- a/lib/validation/rules/decimal.ts
+++ b/lib/validation/rules/decimal.ts
@@ -9,6 +9,6 @@ export const message = {
 export function decimal(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
-    validation: (value: string) => !hyphen(value) && baseDecimal(value)
+    validation: (value) => !hyphen(value) && baseDecimal(value)
   })
 }

--- a/lib/validation/rules/decimalOrHyphen.ts
+++ b/lib/validation/rules/decimalOrHyphen.ts
@@ -9,6 +9,6 @@ export const message = {
 export function decimalOrHyphen(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
-    validation: (value: string) => hyphen(value) || baseDecimal(value)
+    validation: (value) => hyphen(value) || baseDecimal(value)
   })
 }

--- a/lib/validation/rules/email.ts
+++ b/lib/validation/rules/email.ts
@@ -9,6 +9,6 @@ export const message = {
 export function email(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
-    validation: (value: string) => baseEmail(value)
+    validation: baseEmail
   })
 }

--- a/lib/validation/rules/fileExtension.ts
+++ b/lib/validation/rules/fileExtension.ts
@@ -10,6 +10,6 @@ export function fileExtension(extensions: string[], msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
     optional: true,
-    validation: (value: File) => baseFileExtension(value, extensions)
+    validation: (value) => baseFileExtension(value, extensions)
   })
 }

--- a/lib/validation/rules/hms.ts
+++ b/lib/validation/rules/hms.ts
@@ -13,6 +13,6 @@ export function hms(required?: HmsType[], msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
     optional: true,
-    validation: (value: Hms) => baseHms(value, required)
+    validation: (value) => baseHms(value, required)
   })
 }

--- a/lib/validation/rules/hms.ts
+++ b/lib/validation/rules/hms.ts
@@ -1,4 +1,3 @@
-import { type Hms } from '../../support/Day'
 import { createRule } from '../Rule'
 import { hms as baseHms } from '../validators/hms'
 

--- a/lib/validation/rules/maxFileSize.ts
+++ b/lib/validation/rules/maxFileSize.ts
@@ -10,6 +10,6 @@ export function maxFileSize(size: string, msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang](size),
     optional: true,
-    validation: (value: File) => baseMaxFileSize(value, size)
+    validation: (value) => baseMaxFileSize(value, size)
   })
 }

--- a/lib/validation/rules/maxLength.ts
+++ b/lib/validation/rules/maxLength.ts
@@ -10,6 +10,6 @@ export function maxLength(length: number, msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang](length),
     optional: true,
-    validation: (value: string) => baseMaxLength(value, length)
+    validation: (value) => baseMaxLength(value, length)
   })
 }

--- a/lib/validation/rules/maxTotalFileSize.ts
+++ b/lib/validation/rules/maxTotalFileSize.ts
@@ -10,6 +10,6 @@ export function maxTotalFileSize(size: string, msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang](size),
     optional: true,
-    validation: (value: File[]) => baseMaxTotalFileSize(value, size)
+    validation: (value) => baseMaxTotalFileSize(value, size)
   })
 }

--- a/lib/validation/rules/maxValue.ts
+++ b/lib/validation/rules/maxValue.ts
@@ -9,6 +9,6 @@ export const message = {
 export function maxValue(max: number, msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang](max),
-    validation: (value: unknown) => baseMaxValue(value, max)
+    validation: (value) => baseMaxValue(value, max)
   })
 }

--- a/lib/validation/rules/minLength.ts
+++ b/lib/validation/rules/minLength.ts
@@ -10,6 +10,6 @@ export function minLength(length: number, msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang](length),
     optional: true,
-    validation: (value: string) => baseMinLength(value, length)
+    validation: (value) => baseMinLength(value, length)
   })
 }

--- a/lib/validation/rules/minValue.ts
+++ b/lib/validation/rules/minValue.ts
@@ -9,6 +9,6 @@ export const message = {
 export function minValue(min: number, msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang](min),
-    validation: (value: unknown) => baseMinValue(value, min)
+    validation: (value) => baseMinValue(value, min)
   })
 }

--- a/lib/validation/rules/month.ts
+++ b/lib/validation/rules/month.ts
@@ -10,6 +10,6 @@ export function month(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
     optional: true,
-    validation: (value: number) => baseMonth(value)
+    validation: baseMonth
   })
 }

--- a/lib/validation/rules/negativeInteger.ts
+++ b/lib/validation/rules/negativeInteger.ts
@@ -9,6 +9,6 @@ export const message = {
 export function negativeInteger(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
-    validation: (value: number) => baseNegativeInteger(value)
+    validation: baseNegativeInteger
   })
 }

--- a/lib/validation/rules/positiveInteger.ts
+++ b/lib/validation/rules/positiveInteger.ts
@@ -9,6 +9,6 @@ export const message = {
 export function positiveInteger(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
-    validation: (value: number) => basePositiveInteger(value)
+    validation: basePositiveInteger
   })
 }

--- a/lib/validation/rules/required.ts
+++ b/lib/validation/rules/required.ts
@@ -9,6 +9,6 @@ export const message = {
 export function required(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
-    validation: (value) => baseRequired(value)
+    validation: baseRequired
   })
 }

--- a/lib/validation/rules/requiredHms.ts
+++ b/lib/validation/rules/requiredHms.ts
@@ -12,6 +12,6 @@ export const message = {
 export function requiredHms(required?: HmsType[], msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
-    validation: (value: Hms) => baseRequiredHms(value, required)
+    validation: (value) => baseRequiredHms(value, required)
   })
 }

--- a/lib/validation/rules/requiredHms.ts
+++ b/lib/validation/rules/requiredHms.ts
@@ -1,4 +1,3 @@
-import { type Hms } from '../../support/Day'
 import { createRule } from '../Rule'
 import { requiredHms as baseRequiredHms } from '../validators/requiredHms'
 

--- a/lib/validation/rules/requiredYmd.ts
+++ b/lib/validation/rules/requiredYmd.ts
@@ -1,4 +1,3 @@
-import { type Ymd } from '../../support/Day'
 import { createRule } from '../Rule'
 import { requiredYmd as baseRequiredYmd } from '../validators/requiredYmd'
 

--- a/lib/validation/rules/requiredYmd.ts
+++ b/lib/validation/rules/requiredYmd.ts
@@ -13,6 +13,6 @@ export function requiredYmd(required?: YmdType[], msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
     optional: true,
-    validation: (value: Ymd) => baseRequiredYmd(value, required)
+    validation: (value) => baseRequiredYmd(value, required)
   })
 }

--- a/lib/validation/rules/url.ts
+++ b/lib/validation/rules/url.ts
@@ -9,6 +9,6 @@ export const message = {
 export function url(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
-    validation: (value: string) => baseUrl(value)
+    validation: baseUrl
   })
 }

--- a/lib/validation/rules/ymd.ts
+++ b/lib/validation/rules/ymd.ts
@@ -1,4 +1,3 @@
-import { type Ymd } from '../../support/Day'
 import { createRule } from '../Rule'
 import { ymd as baseYmd } from '../validators/ymd'
 

--- a/lib/validation/rules/ymd.ts
+++ b/lib/validation/rules/ymd.ts
@@ -13,6 +13,6 @@ export function ymd(required?: YmdType[], msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
     optional: true,
-    validation: (value: Ymd) => baseYmd(value, required)
+    validation: (value) => baseYmd(value, required)
   })
 }

--- a/lib/validation/rules/zeroOrNegativeInteger.ts
+++ b/lib/validation/rules/zeroOrNegativeInteger.ts
@@ -9,6 +9,6 @@ export const message = {
 export function zeroOrNegativeInteger(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
-    validation: (value: number) => zero(value) || baseNegativeInteger(value)
+    validation: (value) => zero(value) || baseNegativeInteger(value)
   })
 }

--- a/lib/validation/rules/zeroOrPositiveInteger.ts
+++ b/lib/validation/rules/zeroOrPositiveInteger.ts
@@ -9,6 +9,6 @@ export const message = {
 export function zeroOrPositiveInteger(msg?: string) {
   return createRule({
     message: ({ lang }) => msg ?? message[lang],
-    validation: (value: number) => zero(value) || basePositiveInteger(value)
+    validation: (value) => zero(value) || basePositiveInteger(value)
   })
 }

--- a/lib/validation/validators/checked.ts
+++ b/lib/validation/validators/checked.ts
@@ -1,3 +1,3 @@
-export function checked(value: boolean): boolean {
+export function checked(value: unknown): boolean {
   return value === true
 }

--- a/lib/validation/validators/decimal.ts
+++ b/lib/validation/validators/decimal.ts
@@ -1,11 +1,11 @@
-import { isString } from '../../support/Utils'
+import { isNumber, isString } from '../../support/Utils'
 
 const regExp = /^[-]?\d*(\.\d+)?$/
 
 export function decimal(value: unknown): boolean {
-  if (!isString(value)) {
+  if (!(isString(value) || isNumber(value))) {
     return false
   }
 
-  return regExp.test(value)
+  return regExp.test(String(value))
 }

--- a/lib/validation/validators/decimal.ts
+++ b/lib/validation/validators/decimal.ts
@@ -1,5 +1,11 @@
+import { isString } from '../../support/Utils'
+
 const regExp = /^[-]?\d*(\.\d+)?$/
 
-export function decimal(value: string): boolean {
+export function decimal(value: unknown): boolean {
+  if (!isString(value)) {
+    return false
+  }
+
   return regExp.test(value)
 }

--- a/lib/validation/validators/email.ts
+++ b/lib/validation/validators/email.ts
@@ -1,6 +1,12 @@
+import { isString } from '../../support/Utils'
+
 /* eslint-disable-next-line no-control-regex */
 const regExp = /^(?:[A-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|[\x01-\x09\x0B\x0C\x0E-\x7F])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9]{2,}(?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21-\x5A\x53-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])+)\])$/i
 
 export function email(value: string): boolean {
+  if (!isString(value)) {
+    return false
+  }
+
   return regExp.test(value)
 }

--- a/lib/validation/validators/fileExtension.ts
+++ b/lib/validation/validators/fileExtension.ts
@@ -1,7 +1,12 @@
+import { isFile } from 'sefirot/support/Utils'
 import { getExtension } from '../../support/File'
 
-export function fileExtension(file: File, extensions: string[]): boolean {
-  const fileExtension = getExtension(file)
+export function fileExtension(value: unknown, extensions: string[]): boolean {
+  if (!isFile(value)) {
+    return false
+  }
+
+  const fileExtension = getExtension(value)
 
   return extensions.some((extension) => {
     // If the extention option is `jpg`, we'll consider other variants such as

--- a/lib/validation/validators/fileExtension.ts
+++ b/lib/validation/validators/fileExtension.ts
@@ -1,5 +1,5 @@
-import { isFile } from 'sefirot/support/Utils'
 import { getExtension } from '../../support/File'
+import { isFile } from '../../support/Utils'
 
 export function fileExtension(value: unknown, extensions: string[]): boolean {
   if (!isFile(value)) {

--- a/lib/validation/validators/hms.ts
+++ b/lib/validation/validators/hms.ts
@@ -1,5 +1,4 @@
-import { HmsMap, type HmsType } from '../../support/Day'
-import { isHms } from '../../support/Utils'
+import { HmsMap, type HmsType, isHms } from '../../support/Day'
 
 export function hms(value: unknown, required: HmsType[] = ['h', 'm', 's']): boolean {
   if (!isHms(value, required)) {

--- a/lib/validation/validators/hms.ts
+++ b/lib/validation/validators/hms.ts
@@ -2,7 +2,7 @@ import { HmsMap, type HmsType } from '../../support/Day'
 import { isHms } from '../../support/Utils'
 
 export function hms(value: unknown, required: HmsType[] = ['h', 'm', 's']): boolean {
-  if (!isHms(value)) {
+  if (!isHms(value, required)) {
     return false
   }
 

--- a/lib/validation/validators/hms.ts
+++ b/lib/validation/validators/hms.ts
@@ -1,22 +1,19 @@
-import { type Hms } from '../../support/Day'
+import { HmsMap, type HmsType } from '../../support/Day'
+import { isHms } from '../../support/Utils'
 
-type HmsType = 'h' | 'm' | 's'
+export function hms(value: unknown, required: HmsType[] = ['h', 'm', 's']): boolean {
+  if (!isHms(value)) {
+    return false
+  }
 
-const HmsMap = {
-  h: 'hour',
-  m: 'minute',
-  s: 'second'
-} as const
-
-export function hms(hms: Hms, required: HmsType[] = ['h', 'm', 's']): boolean {
   return required.every((r) => {
-    const value = hms[HmsMap[r]]
+    const _value = value[HmsMap[r]]
 
-    if (value === null) {
+    if (_value === null) {
       return true
     }
 
-    const valueAsNumber = Number(value)
+    const valueAsNumber = Number(_value)
 
     return (r === 'h')
       ? (valueAsNumber >= 0 && valueAsNumber < 24)

--- a/lib/validation/validators/hyphen.ts
+++ b/lib/validation/validators/hyphen.ts
@@ -1,3 +1,3 @@
-export function hyphen(value: string): boolean {
+export function hyphen(value: unknown): boolean {
   return value === '-'
 }

--- a/lib/validation/validators/maxFileSize.ts
+++ b/lib/validation/validators/maxFileSize.ts
@@ -1,4 +1,10 @@
-export function maxFileSize(file: File, size: string): boolean {
+import { isFile } from '../../support/Utils'
+
+export function maxFileSize(value: unknown, size: string): boolean {
+  if (!isFile(value)) {
+    return false
+  }
+
   const factor = /gb/i.test(size)
     ? 1e9
     : /mb/i.test(size)
@@ -6,5 +12,6 @@ export function maxFileSize(file: File, size: string): boolean {
       : /kb/i.test(size)
         ? 1e3
         : 1
-  return file.size <= factor * +size.replace(/[^\d\.]/g, '')
+
+  return value.size <= factor * +size.replace(/[^\d\.]/g, '')
 }

--- a/lib/validation/validators/maxLength.ts
+++ b/lib/validation/validators/maxLength.ts
@@ -1,3 +1,9 @@
-export function maxLength(value: string, length: number): boolean {
+import { isArray, isString } from '../../support/Utils'
+
+export function maxLength(value: unknown, length: number): boolean {
+  if (!(isString(value) || isArray(value))) {
+    return false
+  }
+
   return value.length <= length
 }

--- a/lib/validation/validators/maxTotalFileSize.ts
+++ b/lib/validation/validators/maxTotalFileSize.ts
@@ -1,8 +1,14 @@
+import { isFile } from '../../support/Utils'
+
 /**
  * Validates if the total size of the given files is smaller than the
  * given size.
  */
-export function maxTotalFileSize(files: File[], size: string): boolean {
+export function maxTotalFileSize(value: unknown, size: string): boolean {
+  if (!isArrayOfFiles(value)) {
+    return false
+  }
+
   const factor = /gb/i.test(size)
     ? 1e9
     : /mb/i.test(size)
@@ -11,7 +17,11 @@ export function maxTotalFileSize(files: File[], size: string): boolean {
         ? 1e3
         : 1
 
-  const total = files.reduce((total, file) => total + file.size, 0)
+  const total = value.reduce((total, file) => total + file.size, 0)
 
   return total <= factor * +size.replace(/[^\d\.]/g, '')
+}
+
+function isArrayOfFiles(value: unknown): value is File[] {
+  return Array.isArray(value) && value.every((v) => isFile(v))
 }

--- a/lib/validation/validators/minLength.ts
+++ b/lib/validation/validators/minLength.ts
@@ -1,3 +1,9 @@
-export function minLength(value: string, length: number): boolean {
+import { isArray, isString } from '../../support/Utils'
+
+export function minLength(value: unknown, length: number): boolean {
+  if (!(isString(value) || isArray(value))) {
+    return false
+  }
+
   return value.length >= length
 }

--- a/lib/validation/validators/month.ts
+++ b/lib/validation/validators/month.ts
@@ -1,3 +1,9 @@
-export function month(value: number): boolean {
+import { isNumber } from '../../support/Utils'
+
+export function month(value: unknown): boolean {
+  if (!isNumber(value)) {
+    return false
+  }
+
   return value > 0 && value < 13
 }

--- a/lib/validation/validators/negativeInteger.ts
+++ b/lib/validation/validators/negativeInteger.ts
@@ -1,3 +1,9 @@
-export function negativeInteger(value: number): boolean {
+import { isNumber } from '../../support/Utils'
+
+export function negativeInteger(value: unknown): boolean {
+  if (!isNumber(value)) {
+    return false
+  }
+
   return Number.isInteger(value) && value < 0
 }

--- a/lib/validation/validators/positiveInteger.ts
+++ b/lib/validation/validators/positiveInteger.ts
@@ -1,3 +1,9 @@
-export function positiveInteger(value: number): boolean {
+import { isNumber } from '../../support/Utils'
+
+export function positiveInteger(value: unknown): boolean {
+  if (!isNumber(value)) {
+    return false
+  }
+
   return Number.isInteger(value) && value > 0
 }

--- a/lib/validation/validators/requiredHms.ts
+++ b/lib/validation/validators/requiredHms.ts
@@ -1,5 +1,4 @@
-import { HmsMap, type HmsType } from '../../support/Day'
-import { isHms } from '../../support/Utils'
+import { HmsMap, type HmsType, isHms } from '../../support/Day'
 
 export function requiredHms(value: unknown, required: HmsType[] = ['h', 'm', 's']): boolean {
   if (!isHms(value, required)) {

--- a/lib/validation/validators/requiredHms.ts
+++ b/lib/validation/validators/requiredHms.ts
@@ -2,7 +2,7 @@ import { HmsMap, type HmsType } from '../../support/Day'
 import { isHms } from '../../support/Utils'
 
 export function requiredHms(value: unknown, required: HmsType[] = ['h', 'm', 's']): boolean {
-  if (!isHms(value)) {
+  if (!isHms(value, required)) {
     return false
   }
 

--- a/lib/validation/validators/requiredHms.ts
+++ b/lib/validation/validators/requiredHms.ts
@@ -1,13 +1,10 @@
-import { type Hms } from '../../support/Day'
+import { HmsMap, type HmsType } from '../../support/Day'
+import { isHms } from '../../support/Utils'
 
-type HmsType = 'h' | 'm' | 's'
+export function requiredHms(value: unknown, required: HmsType[] = ['h', 'm', 's']): boolean {
+  if (!isHms(value)) {
+    return false
+  }
 
-const HmsMap = {
-  h: 'hour',
-  m: 'minute',
-  s: 'second'
-} as const
-
-export function requiredHms(hms: Hms, required: HmsType[] = ['h', 'm', 's']): boolean {
-  return required.every((r) => hms[HmsMap[r]] != null)
+  return required.every((r) => value[HmsMap[r]] != null)
 }

--- a/lib/validation/validators/requiredYmd.ts
+++ b/lib/validation/validators/requiredYmd.ts
@@ -1,13 +1,10 @@
-import { type Ymd } from '../../support/Day'
+import { YmdMap, type YmdType } from '../../support/Day'
+import { isYmd } from '../../support/Utils'
 
-type YmdType = 'y' | 'm' | 'd'
+export function requiredYmd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): boolean {
+  if (!isYmd(value)) {
+    return false
+  }
 
-const YmdMap = {
-  y: 'year',
-  m: 'month',
-  d: 'date'
-} as const
-
-export function requiredYmd(ymd: Ymd, required: YmdType[] = ['y', 'm', 'd']): boolean {
-  return required.every((r) => ymd[YmdMap[r]] != null)
+  return required.every((r) => value[YmdMap[r]] != null)
 }

--- a/lib/validation/validators/requiredYmd.ts
+++ b/lib/validation/validators/requiredYmd.ts
@@ -2,7 +2,7 @@ import { YmdMap, type YmdType } from '../../support/Day'
 import { isYmd } from '../../support/Utils'
 
 export function requiredYmd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): boolean {
-  if (!isYmd(value)) {
+  if (!isYmd(value, required)) {
     return false
   }
 

--- a/lib/validation/validators/requiredYmd.ts
+++ b/lib/validation/validators/requiredYmd.ts
@@ -1,5 +1,4 @@
-import { YmdMap, type YmdType } from '../../support/Day'
-import { isYmd } from '../../support/Utils'
+import { YmdMap, type YmdType, isYmd } from '../../support/Day'
 
 export function requiredYmd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): boolean {
   if (!isYmd(value, required)) {

--- a/lib/validation/validators/url.ts
+++ b/lib/validation/validators/url.ts
@@ -1,5 +1,11 @@
+import { isString } from '../../support/Utils'
+
 const regExp = /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00A1-\uFFFF][a-z0-9\u00A1-\uFFFF_-]{0,62})?[a-z0-9\u00A1-\uFFFF]\.)+(?:[a-z\u00A1-\uFFFF]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i
 
-export function url(value: string): boolean {
+export function url(value: unknown): boolean {
+  if (!isString(value)) {
+    return false
+  }
+
   return regExp.test(value)
 }

--- a/lib/validation/validators/ymd.ts
+++ b/lib/validation/validators/ymd.ts
@@ -1,33 +1,30 @@
 import day from 'dayjs'
-import { type Ymd } from '../../support/Day'
+import { isYmd } from 'sefirot/support/Utils'
+import { YmdMap, type YmdType } from '../../support/Day'
 
-type YmdType = 'y' | 'm' | 'd'
+export function ymd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): boolean {
+  if (!isYmd(value)) {
+    return false
+  }
 
-const YmdMap = {
-  y: 'year',
-  m: 'month',
-  d: 'date'
-} as const
-
-export function ymd(ymd: Ymd, required: YmdType[] = ['y', 'm', 'd']): boolean {
   return required.every((r) => {
-    const value = ymd[YmdMap[r]]
+    const _value = value[YmdMap[r]]
 
-    if (value === null) {
+    if (_value === null) {
       return true
     }
 
     if (r === 'y') {
-      return value > 0 && value <= 9999
+      return _value > 0 && _value <= 9999
     }
 
     if (r === 'm') {
-      return value > 0 && value <= 12
+      return _value > 0 && _value <= 12
     }
 
-    const d = day(new Date(2020, ymd.month ? ymd.month - 1 : 1, value))
+    const d = day(new Date(2020, value.month ? value.month - 1 : 1, _value))
 
-    if (d.month() + 1 !== (ymd.month ?? 1)) {
+    if (d.month() + 1 !== (value.month ?? 1)) {
       return false
     }
 

--- a/lib/validation/validators/ymd.ts
+++ b/lib/validation/validators/ymd.ts
@@ -1,6 +1,5 @@
 import day from 'dayjs'
-import { isYmd } from 'sefirot/support/Utils'
-import { YmdMap, type YmdType } from '../../support/Day'
+import { YmdMap, type YmdType, isYmd } from '../../support/Day'
 
 export function ymd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): boolean {
   if (!isYmd(value, required)) {

--- a/lib/validation/validators/ymd.ts
+++ b/lib/validation/validators/ymd.ts
@@ -3,7 +3,7 @@ import { isYmd } from 'sefirot/support/Utils'
 import { YmdMap, type YmdType } from '../../support/Day'
 
 export function ymd(value: unknown, required: YmdType[] = ['y', 'm', 'd']): boolean {
-  if (!isYmd(value)) {
+  if (!isYmd(value, required)) {
     return false
   }
 

--- a/lib/validation/validators/zero.ts
+++ b/lib/validation/validators/zero.ts
@@ -1,3 +1,3 @@
-export function zero(value: number): boolean {
+export function zero(value: unknown): boolean {
   return value === 0
 }

--- a/tests/validation/validators/checked.spec.ts
+++ b/tests/validation/validators/checked.spec.ts
@@ -4,5 +4,6 @@ describe('validation/validators/checked', () => {
   it('should validates if the value is true', () => {
     expect(checked(true)).toBe(true)
     expect(checked(false)).toBe(false)
+    expect(checked('true')).toBe(false)
   })
 })

--- a/tests/validation/validators/fileExtension.spec.ts
+++ b/tests/validation/validators/fileExtension.spec.ts
@@ -7,6 +7,7 @@ describe('vaidation/validators/fileExtension', () => {
     expect(fileExtension(file, ['txt'])).toBe(true)
     expect(fileExtension(file, ['txt', 'png'])).toBe(true)
     expect(fileExtension(file, ['png'])).toBe(false)
+    expect(fileExtension('file', ['png'])).toBe(false)
   })
 
   it('should treat `jpg` extension with extra care', () => {

--- a/tests/validation/validators/hms.spec.ts
+++ b/tests/validation/validators/hms.spec.ts
@@ -18,5 +18,9 @@ describe('validation/validators/hms', () => {
     expect(hms({ hour: '23', minute: '59', second: '60' }, ['h', 'm'])).toBe(true)
     expect(hms({ hour: '23', minute: '60', second: '60' }, ['h', 'm'])).toBe(false)
     expect(hms({ hour: '23', minute: '59' }, ['h', 'm'])).toBe(true)
+    expect(hms({ hour: '23', minute: null }, ['h', 'm'])).toBe(true)
+
+    expect(hms({ hour: '23' }, ['h', 'm'])).toBe(false)
+    expect(hms({ hour: '23', minute: undefined }, ['h', 'm'])).toBe(false)
   })
 })

--- a/tests/validation/validators/hms.spec.ts
+++ b/tests/validation/validators/hms.spec.ts
@@ -8,10 +8,15 @@ describe('validation/validators/hms', () => {
     expect(hms({ hour: '24', minute: '59', second: '59' })).toBe(false)
     expect(hms({ hour: '23', minute: '60', second: '59' })).toBe(false)
     expect(hms({ hour: '23', minute: '59', second: '60' })).toBe(false)
+
+    expect(hms({})).toBe(false)
+    expect(hms({ hour: '23' })).toBe(false)
+    expect(hms({ hour: '23', minute: '59' })).toBe(false)
   })
 
   it('should validate only the given types', () => {
     expect(hms({ hour: '23', minute: '59', second: '60' }, ['h', 'm'])).toBe(true)
     expect(hms({ hour: '23', minute: '60', second: '60' }, ['h', 'm'])).toBe(false)
+    expect(hms({ hour: '23', minute: '59' }, ['h', 'm'])).toBe(true)
   })
 })

--- a/tests/validation/validators/hyphen.spec.ts
+++ b/tests/validation/validators/hyphen.spec.ts
@@ -4,5 +4,6 @@ describe('validation/validators/hyphen', () => {
   it('should validates if the value is true', () => {
     expect(hyphen('-')).toBe(true)
     expect(hyphen('')).toBe(false)
+    expect(hyphen(1)).toBe(false)
   })
 })

--- a/tests/validation/validators/maxFileSize.spec.ts
+++ b/tests/validation/validators/maxFileSize.spec.ts
@@ -8,6 +8,7 @@ describe('vaidation/validators/maxFileSize', () => {
     expect(maxFileSize(file, '1 MB')).toBe(true)
     expect(maxFileSize(file, '1 KB')).toBe(false)
     expect(maxFileSize(file, '10 B')).toBe(false)
+    expect(maxFileSize('file', '10 B')).toBe(false)
   })
 
   it('assumes size in bytes if no unit is provided', () => {
@@ -17,5 +18,6 @@ describe('vaidation/validators/maxFileSize', () => {
     expect(maxFileSize(file, '10000')).toBe(true)
     expect(maxFileSize(file, '1 KB')).toBe(false)
     expect(maxFileSize(file, '1000')).toBe(false)
+    expect(maxFileSize('file', '1000')).toBe(false)
   })
 })

--- a/tests/validation/validators/maxTotalFileSize.spec.ts
+++ b/tests/validation/validators/maxTotalFileSize.spec.ts
@@ -10,5 +10,6 @@ describe('vaidation/validators/maxTotalFileSize', () => {
     expect(maxTotalFileSize([file1mb], '2mb')).toBe(true)
     expect(maxTotalFileSize([file1mb], '5kb')).toBe(false)
     expect(maxTotalFileSize([file1mb], '1')).toBe(false)
+    expect(maxTotalFileSize([file1mb, 'file1mb'], '1')).toBe(false)
   })
 })

--- a/tests/validation/validators/month.spec.ts
+++ b/tests/validation/validators/month.spec.ts
@@ -7,5 +7,6 @@ describe('validation/validators/month', () => {
     expect(month(6)).toBe(true)
     expect(month(12)).toBe(true)
     expect(month(13)).toBe(false)
+    expect(month('1')).toBe(false)
   })
 })

--- a/tests/validation/validators/negativeInteger.spec.ts
+++ b/tests/validation/validators/negativeInteger.spec.ts
@@ -14,5 +14,7 @@ describe('validation/validators/negativeInteger', () => {
     expect(negativeInteger(1.1)).toBe(false)
     expect(negativeInteger(+1)).toBe(false)
     expect(negativeInteger(+1.1)).toBe(false)
+
+    expect(negativeInteger('-1')).toBe(false)
   })
 })

--- a/tests/validation/validators/positiveInteger.spec.ts
+++ b/tests/validation/validators/positiveInteger.spec.ts
@@ -15,5 +15,7 @@ describe('validation/validators/positiveInteger', () => {
     expect(positiveInteger(-1)).toBe(false)
     expect(positiveInteger(1.1)).toBe(false)
     expect(positiveInteger(-1.1)).toBe(false)
+
+    expect(positiveInteger('1')).toBe(false)
   })
 })

--- a/tests/validation/validators/requiredHms.spec.ts
+++ b/tests/validation/validators/requiredHms.spec.ts
@@ -14,5 +14,9 @@ describe('validation/validators/requiredHms', () => {
   test('validates only given types', () => {
     expect(requiredHms({ hour: '01', minute: '02', second: null }, ['h', 'm'])).toBe(true)
     expect(requiredHms({ hour: '01', minute: '02' }, ['h', 'm'])).toBe(true)
+
+    expect(requiredHms({ hour: '01' }, ['h', 'm'])).toBe(false)
+    expect(requiredHms({ hour: '01', minute: undefined }, ['h', 'm'])).toBe(false)
+    expect(requiredHms({ hour: '01', minute: null }, ['h', 'm'])).toBe(false)
   })
 })

--- a/tests/validation/validators/requiredHms.spec.ts
+++ b/tests/validation/validators/requiredHms.spec.ts
@@ -5,11 +5,14 @@ describe('validation/validators/requiredHms', () => {
     expect(requiredHms({ hour: null, minute: null, second: null })).toBe(false)
     expect(requiredHms({ hour: '01', minute: '02', second: '03' })).toBe(true)
     expect(requiredHms({ hour: '01', minute: '03', second: null })).toBe(false)
+
+    expect(requiredHms({})).toBe(false)
+    expect(requiredHms({ hour: '01' })).toBe(false)
+    expect(requiredHms({ hour: '01', minute: '02' })).toBe(false)
   })
 
   test('validates only given types', () => {
-    const data = { hour: '01', minute: '02', second: null }
-
-    expect(requiredHms(data, ['h', 'm'])).toBe(true)
+    expect(requiredHms({ hour: '01', minute: '02', second: null }, ['h', 'm'])).toBe(true)
+    expect(requiredHms({ hour: '01', minute: '02' }, ['h', 'm'])).toBe(true)
   })
 })

--- a/tests/validation/validators/requiredYmd.spec.ts
+++ b/tests/validation/validators/requiredYmd.spec.ts
@@ -5,11 +5,14 @@ describe('validation/validators/requiredYmd', () => {
     expect(requiredYmd({ year: null, month: null, date: null })).toBe(false)
     expect(requiredYmd({ year: 2000, month: 12, date: 31 })).toBe(true)
     expect(requiredYmd({ year: 2000, month: null, date: 2 })).toBe(false)
+
+    expect(requiredYmd({})).toBe(false)
+    expect(requiredYmd({ year: 2000 })).toBe(false)
+    expect(requiredYmd({ year: 2000, month: 12 })).toBe(false)
   })
 
   test('validates only given types', () => {
-    const data = { year: 2000, month: 12, date: null }
-
-    expect(requiredYmd(data, ['y', 'm'])).toBe(true)
+    expect(requiredYmd({ year: 2000, month: 12, date: null }, ['y', 'm'])).toBe(true)
+    expect(requiredYmd({ year: 2000, month: 12 }, ['y', 'm'])).toBe(true)
   })
 })

--- a/tests/validation/validators/requiredYmd.spec.ts
+++ b/tests/validation/validators/requiredYmd.spec.ts
@@ -14,5 +14,9 @@ describe('validation/validators/requiredYmd', () => {
   test('validates only given types', () => {
     expect(requiredYmd({ year: 2000, month: 12, date: null }, ['y', 'm'])).toBe(true)
     expect(requiredYmd({ year: 2000, month: 12 }, ['y', 'm'])).toBe(true)
+
+    expect(requiredYmd({ year: 2000 }, ['y', 'm'])).toBe(false)
+    expect(requiredYmd({ year: 2000, month: undefined }, ['y', 'm'])).toBe(false)
+    expect(requiredYmd({ year: 2000, month: null }, ['y', 'm'])).toBe(false)
   })
 })

--- a/tests/validation/validators/ymd.spec.ts
+++ b/tests/validation/validators/ymd.spec.ts
@@ -23,5 +23,9 @@ describe('validation/validators/ymd', () => {
     expect(ymd({ year: 2000, month: 12, date: 32 }, ['y', 'm'])).toBe(true)
     expect(ymd({ year: 2000, month: 13, date: 13 }, ['y', 'm'])).toBe(false)
     expect(ymd({ year: 2000, month: 13 }, ['y', 'm'])).toBe(false)
+    expect(ymd({ year: 2000, month: null }, ['y', 'm'])).toBe(true)
+
+    expect(ymd({ year: 2000 }, ['y', 'm'])).toBe(false)
+    expect(ymd({ year: 2000, month: undefined }, ['y', 'm'])).toBe(false)
   })
 })

--- a/tests/validation/validators/ymd.spec.ts
+++ b/tests/validation/validators/ymd.spec.ts
@@ -13,10 +13,15 @@ describe('validation/validators/ymd', () => {
     expect(ymd({ year: 2000, month: 1, date: 32 })).toBe(false)
     expect(ymd({ year: 2000, month: 2, date: 30 })).toBe(false)
     expect(ymd({ year: 2000, month: 4, date: 31 })).toBe(false)
+
+    expect(ymd({})).toBe(false)
+    expect(ymd({ year: 2000 })).toBe(false)
+    expect(ymd({ year: 2000, month: 4 })).toBe(false)
   })
 
   it('should validate only the given types', () => {
     expect(ymd({ year: 2000, month: 12, date: 32 }, ['y', 'm'])).toBe(true)
     expect(ymd({ year: 2000, month: 13, date: 13 }, ['y', 'm'])).toBe(false)
+    expect(ymd({ year: 2000, month: 13 }, ['y', 'm'])).toBe(false)
   })
 })

--- a/tests/validation/validators/zero.spec.ts
+++ b/tests/validation/validators/zero.spec.ts
@@ -4,5 +4,6 @@ describe('validation/validators/zero', () => {
   it('should validates if the value is true', () => {
     expect(zero(0)).toBe(true)
     expect(zero(1)).toBe(false)
+    expect(zero('0')).toBe(false)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "sourceMap": true,
     "skipLibCheck": true,
 
-    "lib": ["es2020", "dom", "dom.iterable"],
+    "lib": ["es2022", "dom", "dom.iterable"],
 
     "paths": {
       "sefirot/*": ["lib/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "sourceMap": true,
     "skipLibCheck": true,
 
-    "lib": ["es2022", "dom", "dom.iterable"],
+    "lib": ["es2020", "dom", "dom.iterable"],
 
     "paths": {
       "sefirot/*": ["lib/*"]


### PR DESCRIPTION
Resolves #438

This PR changes first argument of validator functions are changed as of type `unknown`.

I made validator functions return `false` if type of the passed argument is not expected by them, but should I make them return `true` instead?

Other details are written as inline comments.