### PR TITLE
feat(desc): add `<SDescAvatar>` (#455)

### DIFF
--- a/docs/components/desc.md
+++ b/docs/components/desc.md
@@ -428,6 +428,33 @@ type Mode =
 </SDesc>
 ```
 
+## Avatar value <Badge text="3.2.7" />
+
+Use `<SDescAvatar>` component to display a value using [`<SAvatar>`](./avatar).
+
+```ts
+interface Props {
+  avatar?: Avatar | null
+}
+
+interface Avatar {
+  avatar?: string | null
+  name?: string | null
+}
+```
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Status" />
+    <SDescAvatar :avatar="{
+      avatar: "/path/to/avatar.jpg",
+      name: "John Doe"
+    }" />
+  </SDescItem>
+</SDesc>
+```
+
 ## File value
 
 Use `<SDescFile>` to display a list of files. Useful when you have a "attachment" list in the form.

--- a/lib/components/SDescAvatar.vue
+++ b/lib/components/SDescAvatar.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import SAvatar from './SAvatar.vue'
+import SDescEmpty from './SDescEmpty.vue'
+
+export interface Avatar {
+  avatar?: string | null
+  name?: string | null
+}
+
+defineProps<{
+  avatar?: Avatar | null
+}>()
+</script>
+
+<template>
+  <div v-if="avatar" class="SDescAvatar">
+    <div class="value">
+      <SAvatar
+        v-if="avatar.avatar"
+        size="nano"
+        :avatar="avatar.avatar"
+        :name="avatar.name"
+      />
+      <span v-if="avatar.name" class="name">
+        {{ avatar.name }}
+      </span>
+    </div>
+  </div>
+  <SDescEmpty v-else />
+</template>
+
+<style scoped lang="postcss">
+.value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 24px;
+}
+</style>

--- a/stories/components/SDesc.01_Playground.story.vue
+++ b/stories/components/SDesc.01_Playground.story.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import SDesc from 'sefirot/components/SDesc.vue'
+import SDescAvatar from 'sefirot/components/SDescAvatar.vue'
 import SDescDay from 'sefirot/components/SDescDay.vue'
 import SDescFile from 'sefirot/components/SDescFile.vue'
 import SDescItem from 'sefirot/components/SDescItem.vue'
@@ -36,6 +37,15 @@ function state() {
           gap="24"
           :divider="state.divider"
         >
+          <SDescItem span="2">
+            <SDescLabel>Account</SDescLabel>
+            <SDescAvatar
+              :avatar="{
+                avatar: 'https://i.pravatar.cc/64?img=1',
+                name: 'margot.foster'
+              }"
+            />
+          </SDescItem>
           <SDescItem span="1">
             <SDescLabel>Full name</SDescLabel>
             <SDescText>Margot Foster</SDescText>


### PR DESCRIPTION
- close #455

At the moment, I'm limiting this component to show only 1 user. Not sure yet how to display multiple users, especially combined with their names 🤔 

```vue
<SDescItem span="2">
  <SDescLabel>Account</SDescLabel>
  <SDescAvatar
    :avatar="{
      avatar: 'https://i.pravatar.cc/64?img=1',
      name: 'margot.foster'
    }"
  />
</SDescItem>
```

<img width="1392" alt="Screenshot 2024-01-30 at 17 38 12" src="https://github.com/globalbrain/sefirot/assets/3753672/712f2b60-fe40-41da-a605-a7b0846a6fc0">
