### PR TITLE
fix(desc): show non-image avatar correctly

### DIFF
--- a/lib/components/SDescAvatar.vue
+++ b/lib/components/SDescAvatar.vue
@@ -16,7 +16,6 @@ defineProps<{
   <div v-if="avatar" class="SDescAvatar">
     <div class="value">
       <SAvatar
-        v-if="avatar.avatar"
         size="nano"
         :avatar="avatar.avatar"
         :name="avatar.name"


### PR DESCRIPTION
Fix #458

I found `SDescAvatar` shows avatar only when it's truthy, which is different from how `SAvatar` works.
So I removed if-condition for `SAvatar` to have a control on what to show: image or initial of name.

@kiaking 

If this is intended, please let me know and close this PR.