### PR TITLE
feat(api): allow watching options in useQuery

### DIFF
--- a/lib/composables/Api.ts
+++ b/lib/composables/Api.ts
@@ -1,4 +1,4 @@
-import { type Ref, ref } from 'vue'
+import { type Ref, type WatchSource, ref, watch } from 'vue'
 import { Http } from '../http/Http'
 import { tryOnMounted } from './Utils'
 
@@ -14,6 +14,10 @@ export interface UseQueryOptions {
    * @default true
    */
   immediate?: boolean
+  /**
+   * watch the given source(s) and re-execute the query
+   */
+  watch?: WatchSource | WatchSource[]
 }
 
 export interface Mutation<Data = any, Args extends any[] = any[]> {
@@ -33,6 +37,10 @@ export function useQuery<Data = any>(
 
   if (options.immediate !== false) {
     tryOnMounted(execute)
+  }
+
+  if (options.watch) {
+    watch(options.watch, execute, { deep: true })
   }
 
   async function execute(): Promise<Data> {


### PR DESCRIPTION
Before:

```ts
export function usePostPage(options: MaybeRefOrGetter<UsePostPageOptions>) {
  const query = useQuery(async (http) => {...})

  watch(() => toValue(options), query.execute, { deep: true })

  return query
}
```

After:

```ts
export function usePostPage(options: MaybeRefOrGetter<UsePostPageOptions>) {
  return useQuery(async (http) => {...}, { watch: () => toValue(options) })
}
```

Nuxt's `useAsyncData` also supports passing watch sources, so `useQuerySsr` already supports this.