### PR TITLE
feat(avatar): add more size option

### DIFF
--- a/lib/components/SAvatar.vue
+++ b/lib/components/SAvatar.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-export type Size = 'nano' | 'mini' | 'small' | 'medium' | 'large'
+export type Size =
+  | 'nano'
+  | 'mini'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'jumbo'
+  | 'mega'
+  | 'fill'
 
 const props = defineProps<{
   size?: Size
@@ -34,6 +42,14 @@ const initial = computed(() => props.name?.charAt(0).toUpperCase())
   overflow: hidden;
 }
 
+.img {
+  object-fit: cover;
+}
+
+.initial {
+  font-weight: 500;
+}
+
 .SAvatar.nano {
   width: 20px;
   height: 20px;
@@ -64,15 +80,19 @@ const initial = computed(() => props.name?.charAt(0).toUpperCase())
   .initial { font-size: 16px; }
 }
 
+.SAvatar.jumbo {
+  width: 48px;
+  height: 48px;
+  .initial { font-size: 16px; }
+}
+
+.SAvatar.fill {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  .initial { font-size: 20px; }
+}
+
 .SAvatar.no-image {
   border: 1px solid var(--c-border-mute-1);
-}
-
-.img {
-  object-fit: cover;
-}
-
-.initial {
-  font-weight: 500;
 }
 </style>

--- a/stories/components/SAvatar.01_Playground.story.vue
+++ b/stories/components/SAvatar.01_Playground.story.vue
@@ -9,7 +9,8 @@ const variants = [
   { title: 'Mini', size: 'mini' },
   { title: 'Small', size: 'small' },
   { title: 'Medium', size: 'medium' },
-  { title: 'Large', size: 'large' }
+  { title: 'Large', size: 'large' },
+  { title: 'Jumbo', size: 'jumbo' }
 ] as const
 </script>
 


### PR DESCRIPTION
Add more size option to `<SAvatar>`.

- `jumbo` - `48px` big. Adding this to be more consistent with `<SButton>` sizing.
- `fill` - Custom size that fills the parent container. When we want avatar bigger than 48px, use this.

One issue with `fill` option is that it's hard to set `font-size` for name initial when the user don't have avatar image.

@brc-dd 
Do you know any tricks to like set font size dynamically based on parent container? If not, I think we can stick to `font-size: 20px` I've set. We should only use `fill` when we need big avatar and that's quite rare case so 👀 