### PR TITLE
feat(desc): enable passing multiple avatars to `<SDescAvatar>`

### DIFF
--- a/docs/components/desc.md
+++ b/docs/components/desc.md
@@ -435,6 +435,7 @@ Use `<SDescAvatar>` component to display a value using [`<SAvatar>`](./avatar).
 ```ts
 interface Props {
   avatar?: Avatar | null
+  dir?: 'column' | 'row'
 }
 
 interface Avatar {
@@ -451,6 +452,31 @@ interface Avatar {
       avatar: "/path/to/avatar.jpg",
       name: "John Doe"
     }" />
+  </SDescItem>
+</SDesc>
+```
+
+You may also pass in multiple avatars as an array.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Status" />
+    <SDescAvatar :avatar="[
+      { avatar: "/path/to/avatar.jpg", name: "John Doe" },
+      { avatar: "/path/to/avatar.jpg", name: "Jane Doe" }
+    ]" />
+  </SDescItem>
+</SDesc>
+```
+
+When passing in multiple avatars, you may also define `:dir` to control the direction of the avatar stack. The default is set to `column` which stacks the avatars vertically. You may set it to `row` to stack them horizontally.
+
+```vue-html
+<SDesc cols="2" gap="24">
+  <SDescItem span="1">
+    <SDescLabel value="Status" />
+    <SDescAvatar dir="row" :avatar="avatars" />
   </SDescItem>
 </SDesc>
 ```

--- a/lib/components/SDescAvatar.vue
+++ b/lib/components/SDescAvatar.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { isArray } from '../support/Utils'
 import SAvatar from './SAvatar.vue'
 import SDescEmpty from './SDescEmpty.vue'
 
@@ -7,21 +9,32 @@ export interface Avatar {
   name?: string | null
 }
 
-defineProps<{
-  avatar?: Avatar | null
-}>()
+const props = withDefaults(defineProps<{
+  avatar?: Avatar | Avatar[] | null
+  dir?: 'column' | 'row'
+}>(), {
+  dir: 'column'
+})
+
+const _avatar = computed(() => {
+  if (!props.avatar) {
+    return null
+  }
+
+  return isArray(props.avatar) ? props.avatar : [props.avatar]
+})
 </script>
 
 <template>
-  <div v-if="avatar" class="SDescAvatar">
-    <div class="value">
+  <div v-if="_avatar" class="SDescAvatar" :class="[dir]">
+    <div v-for="a, i in _avatar" :key="i" class="value">
       <SAvatar
         size="nano"
-        :avatar="avatar.avatar"
-        :name="avatar.name"
+        :avatar="a.avatar"
+        :name="a.name"
       />
-      <span v-if="avatar.name" class="name">
-        {{ avatar.name }}
+      <span v-if="a.name" class="name">
+        {{ a.name }}
       </span>
     </div>
   </div>
@@ -29,6 +42,21 @@ defineProps<{
 </template>
 
 <style scoped lang="postcss">
+.SDescAvatar {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.SDescAvatar.column {
+  flex-direction: column;
+  gap: 4px;
+}
+
+.SDescAvatar.row {
+  flex-direction: row;
+  gap: 12px;
+}
+
 .value {
   display: flex;
   align-items: center;

--- a/lib/components/SDescAvatar.vue
+++ b/lib/components/SDescAvatar.vue
@@ -54,7 +54,7 @@ const _avatar = computed(() => {
 
 .SDescAvatar.row {
   flex-direction: row;
-  gap: 12px;
+  gap: 4px 12px;
 }
 
 .value {

--- a/lib/components/SDescAvatar.vue
+++ b/lib/components/SDescAvatar.vue
@@ -26,7 +26,7 @@ const _avatar = computed(() => {
 </script>
 
 <template>
-  <div v-if="_avatar" class="SDescAvatar" :class="[dir]">
+  <div v-if="_avatar?.length" class="SDescAvatar" :class="[dir]">
     <div v-for="a, i in _avatar" :key="i" class="value">
       <SAvatar
         size="nano"

--- a/stories/components/SDesc.04_Avatar_Many.story.vue
+++ b/stories/components/SDesc.04_Avatar_Many.story.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import SDesc from 'sefirot/components/SDesc.vue'
+import SDescAvatar from 'sefirot/components/SDescAvatar.vue'
+import SDescItem from 'sefirot/components/SDescItem.vue'
+import SDescLabel from 'sefirot/components/SDescLabel.vue'
+
+const title = 'Components / SDesc / 04. Avatar Many'
+const docs = '/components/desc'
+
+const avatars = [
+  { avatar: 'https://i.pravatar.cc/64?img=1', name: 'Margot Foster' },
+  { avatar: 'https://i.pravatar.cc/64?img=2', name: 'Chris Johna' },
+  { avatar: 'https://i.pravatar.cc/64?img=3', name: 'Jenny Wilson' }
+]
+</script>
+
+<template>
+  <Story :title="title" source="Not available" auto-props-disabled>
+    <Board :title="title" :docs="docs">
+      <SDesc gap="24">
+        <SDescItem>
+          <SDescLabel>Vertical stack</SDescLabel>
+          <SDescAvatar :avatar="avatars" />
+        </SDescItem>
+        <SDescItem>
+          <SDescLabel>Horizontal stack</SDescLabel>
+          <SDescAvatar dir="row" :avatar="avatars" />
+        </SDescItem>
+      </SDesc>
+    </Board>
+  </Story>
+</template>


### PR DESCRIPTION
```vue
<SDesc cols="2" gap="24">
  <SDescItem span="1">
    <SDescLabel value="Status" />
    <SDescAvatar :avatar="[
      { avatar: "/path/to/avatar.jpg", name: "John Doe" },
      { avatar: "/path/to/avatar.jpg", name: "Jane Doe" }
    ]" />
  </SDescItem>
</SDesc>
```

<img width="1280" alt="Screenshot 2024-02-27 at 19 23 05" src="https://github.com/globalbrain/sefirot/assets/3753672/011dbe4e-0c8d-4f82-b8ca-4978f5db123d">
