### PR TITLE
fix(table): use `mini` size for state cell

### DIFF
--- a/lib/components/STableCellState.vue
+++ b/lib/components/STableCellState.vue
@@ -11,6 +11,7 @@ defineProps<{
   <div class="STableCellState" :class="[mode ?? 'neutral']">
     <SState
       v-if="value"
+      size="mini"
       :mode="mode"
       :label="value"
     />


### PR DESCRIPTION
This should have been like this from beginning to align the size with pill.

<img width="1280" alt="Screenshot 2024-03-05 at 9 44 29" src="https://github.com/globalbrain/sefirot/assets/3753672/06228084-bf45-461c-abbf-466ef3b5ed02">
