### PR TITLE
feat: add policy composable

### DIFF
--- a/lib/composables/Policy.ts
+++ b/lib/composables/Policy.ts
@@ -1,0 +1,26 @@
+import { type ComputedRef, computed } from 'vue'
+
+export type Policy<Code extends string | undefined = undefined> = ComputedRef<PolicyResponse<Code>>
+
+export interface PolicyResponse<Code extends string | undefined = undefined> {
+  ok: boolean | null
+  code?: Code
+  message?: string
+  is(code: Code): boolean
+}
+
+export interface PolicyHelpers<Code extends string | undefined = undefined> {
+  allow: (code?: Code, message?: string) => PolicyResponse<Code>
+  deny: (code?: Code, message?: string) => PolicyResponse<Code>
+  pending: (code?: Code, message?: string) => PolicyResponse<Code>
+}
+
+export function usePolicy<Code extends string | undefined = undefined>(
+  fn: (helpers: PolicyHelpers<Code>) => PolicyResponse<Code>
+): Policy<Code> {
+  return computed(() => fn({
+    allow: (code, message) => ({ ok: true, code, message, is: (c) => c === code }),
+    deny: (code, message) => ({ ok: false, code, message, is: (c) => c === code }),
+    pending: (code, message) => ({ ok: null, code, message, is: (c) => c === code })
+  }))
+}


### PR DESCRIPTION
closes #419

Usage:

```ts
import {
  type Policy,
  type PolicyResponse,
  type PolicyHelpers as SefirotPolicyHelpers,
  usePolicy as sefirotUsePolicy
} from 'sefirot/composables/Policy'

interface PolicyHelpers<Code extends string | undefined = undefined>
  extends SefirotPolicyHelpers<Code> {
  user: { admin: boolean }
}

function usePolicy<Code extends string | undefined = undefined>(
  fn: (helpers: PolicyHelpers<Code>) => PolicyResponse<Code>
): Policy<Code> {
  const user = { admin: true }

  return sefirotUsePolicy((helpers) => {
    return fn({ ...helpers, user })
  })
}


// ...

import { type Policy, usePolicy } from './Policy'

function canDoFoo(): Policy<'foo' | 'bar'> {
  return usePolicy(({ user, allow, deny }) => {
    return user.admin ? allow('foo') : deny('bar')
  })
}

function canDoBar(): Policy {
  return usePolicy(({ user, allow, deny }) => {
    return user.admin ? allow() : deny()
  })
}

// alternatively

import { usePolicy } from './Policy'

export function canDoFoo() {
  return usePolicy<'foo' | 'bar'>(({ user, allow, deny }) => {
    return user.admin ? allow('foo') : deny('bar')
  })
}

export function canDoBar() {
  return usePolicy(({ user, allow, deny }) => {
    return user.admin ? allow() : deny()
  })
}
```