### PR TITLE
fix(validation): use `withAsync` for async rule

### DIFF
--- a/lib/validation/Rule.ts
+++ b/lib/validation/Rule.ts
@@ -5,6 +5,7 @@ import { _required } from './validators'
 
 export interface RuleOptions {
   optional?: boolean
+  async?: boolean
   message(params: MessageProps): string
   validation(value: unknown): boolean | Promise<boolean>
 }
@@ -18,14 +19,14 @@ export function createRule(
 ): ValidationRuleWithParams {
   const lang = useLang()
 
+  function validation(value: unknown) {
+    return options.optional && !_required(value)
+      ? true
+      : options.validation(value)
+  }
+
   return helpers.withMessage(
-    (params) => {
-      return options.message({ ...params, lang })
-    },
-    (value) => {
-      return options.optional && !_required(value)
-        ? true
-        : options.validation(value)
-    }
+    (params) => options.message({ ...params, lang }),
+    options.async ? helpers.withAsync(validation) : validation
   )
 }

--- a/lib/validation/rules/requiredIf.ts
+++ b/lib/validation/rules/requiredIf.ts
@@ -11,6 +11,7 @@ export function requiredIf(
   msg?: string
 ) {
   return createRule({
+    async: true,
     message: ({ lang }) => msg ?? message[lang],
     validation: (value) => baseRequiredIf(value, condition)
   })


### PR DESCRIPTION
Seems like when validator is async, we need to wrap the validation with [`withAsync` helper](https://vuelidate-next.netlify.app/custom_validators.html#async-validators).

Added `async` option to `createRule`.