### PR TITLE
fix(url): handle array value when corresponding target is non-array

### DIFF
--- a/lib/composables/Url.ts
+++ b/lib/composables/Url.ts
@@ -131,7 +131,11 @@ function deepAssign(target: Record<string, any>, source: Record<string, any>) {
     const value = source[key]
 
     if (Array.isArray(value)) {
-      target[key].splice(0, target[key].length, ...value)
+      if (Array.isArray(target[key])) {
+        target[key].splice(0, target[key].length, ...value)
+      } else {
+        target[key] = value
+      }
     } else if (value && typeof value === 'object') {
       target[key] = deepAssign(target[key] || {}, value)
     } else {


### PR DESCRIPTION
resolves sentry#5090679546

target[key] can be undefined in certain cases in those cases calling splice will throw error. splice call is there to maintain reactivity in array but if there is nothing by default there is no need to maintain reactivity