### PR TITLE
fix(table): correct wrong types and make pills accept array

### DIFF
--- a/lib/components/STableCellDay.vue
+++ b/lib/components/STableCellDay.vue
@@ -4,7 +4,7 @@ import { type Day } from '../support/Day'
 
 const props = defineProps<{
   value?: Day | null
-  record: any
+  record?: any
   align?: 'left' | 'center' | 'right'
   getter?: Day | null
   format?: string

--- a/lib/components/STableCellNumber.vue
+++ b/lib/components/STableCellNumber.vue
@@ -7,7 +7,7 @@ import SLink from './SLink.vue'
 
 const props = defineProps<{
   value?: any
-  record: any
+  record?: any
   align?: 'left' | 'center' | 'right'
   icon?: any
   getter?: number | null

--- a/lib/components/STableCellPill.vue
+++ b/lib/components/STableCellPill.vue
@@ -4,7 +4,7 @@ import SPill, { type Mode } from './SPill.vue'
 
 const props = defineProps<{
   value?: any
-  record: any
+  record?: any
   getter?: string | ((value: any, record: any) => string)
   color?: Mode | ((value: any, record: any) => Mode)
 }>()

--- a/lib/components/STableCellPills.vue
+++ b/lib/components/STableCellPills.vue
@@ -4,12 +4,16 @@ import { type TableCellPillItem } from '../composables/Table'
 import STableCellPill from './STableCellPill.vue'
 
 const props = defineProps<{
-  value: string[]
-  record: any
-  pills(value: string[], record: any): TableCellPillItem[]
+  value?: any
+  record?: any
+  pills: TableCellPillItem[] | ((value: any, record: any) => TableCellPillItem[])
 }>()
 
-const items = computed(() => props.pills(props.value, props.record))
+const items = computed(() => {
+  return Array.isArray(props.pills)
+    ? props.pills
+    : props.pills(props.value, props.record)
+})
 </script>
 
 <template>

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -140,7 +140,7 @@ export type TableCellPillColor = ColorModes
 
 export interface TableCellPills<V = any, R = any> extends TableCellBase {
   type: 'pills'
-  pills(value: V, record: R): TableCellPillItem[]
+  pills: TableCellPillItem[] | ((value: V, record: R) => TableCellPillItem[])
 }
 
 export interface TableCellPillItem {


### PR DESCRIPTION
`value` in cell components could be anything, because this is what we get when `order` name matches with record field name. And it don't even have to exist in the record.

Also, `pills` option was only taking function so fixed it.