### PR TITLE
fix(validation): support reactivity for properties

### DIFF
--- a/lib/validation/Rule.ts
+++ b/lib/validation/Rule.ts
@@ -1,6 +1,5 @@
 import { type ValidationRuleWithParams } from '@vuelidate/core'
 import { type MessageProps as VMessageProps, helpers } from '@vuelidate/validators'
-import { computed } from 'vue'
 import { type Lang, useLang } from '../composables/Lang'
 import { _required } from './validators'
 

--- a/lib/validation/Rule.ts
+++ b/lib/validation/Rule.ts
@@ -42,6 +42,6 @@ export function createRule(
 
 function createParamsForAsyncValidator(params: Record<string, any>) {
   return Object.keys(params).map((key) => {
-    return computed(() => params[key]())
+    return params[key]
   })
 }

--- a/lib/validation/Rule.ts
+++ b/lib/validation/Rule.ts
@@ -1,11 +1,13 @@
 import { type ValidationRuleWithParams } from '@vuelidate/core'
 import { type MessageProps as VMessageProps, helpers } from '@vuelidate/validators'
+import { computed } from 'vue'
 import { type Lang, useLang } from '../composables/Lang'
 import { _required } from './validators'
 
 export interface RuleOptions {
   optional?: boolean
   async?: boolean
+  params?: Record<string, any>
   message(params: MessageProps): string
   validation(value: unknown): boolean | Promise<boolean>
 }
@@ -19,14 +21,27 @@ export function createRule(
 ): ValidationRuleWithParams {
   const lang = useLang()
 
-  function validation(value: unknown) {
-    return options.optional && !_required(value)
-      ? true
-      : options.validation(value)
-  }
+  const params = options.params ?? {}
+
+  const validator = helpers.withParams(
+    params,
+    (value: unknown) => {
+      return options.optional && !_required(value)
+        ? true
+        : options.validation(value)
+    }
+  )
 
   return helpers.withMessage(
     (params) => options.message({ ...params, lang }),
-    options.async ? helpers.withAsync(validation) : validation
+    options.async
+      ? helpers.withAsync(validator, createParamsForAsyncValidator(params))
+      : validator
   )
+}
+
+function createParamsForAsyncValidator(params: Record<string, any>) {
+  return Object.keys(params).map((key) => {
+    return computed(() => params[key]())
+  })
 }

--- a/lib/validation/rules/requiredHmsIf.ts
+++ b/lib/validation/rules/requiredHmsIf.ts
@@ -10,6 +10,7 @@ export const message = {
 export function requiredHmsIf(condition: RequiredIfCondition, required?: HmsType[], msg?: string) {
   return createRule({
     async: true,
+    params: { condition },
     message: ({ lang }) => msg ?? message[lang],
     validation: (value) => baseRequiredHmsIf(value, condition, required)
   })

--- a/lib/validation/rules/requiredIf.ts
+++ b/lib/validation/rules/requiredIf.ts
@@ -12,6 +12,7 @@ export function requiredIf(
 ) {
   return createRule({
     async: true,
+    params: { condition },
     message: ({ lang }) => msg ?? message[lang],
     validation: (value) => baseRequiredIf(value, condition)
   })

--- a/lib/validation/rules/requiredYmdIf.ts
+++ b/lib/validation/rules/requiredYmdIf.ts
@@ -10,6 +10,7 @@ export const message = {
 export function requiredYmdIf(condition: RequiredIfCondition, required?: YmdType[], msg?: string) {
   return createRule({
     async: true,
+    params: { condition },
     message: ({ lang }) => msg ?? message[lang],
     validation: (value) => baseRequiredYmdIf(value, condition, required)
   })

--- a/tests/validation/rules/requiredHmsIf.spec.ts
+++ b/tests/validation/rules/requiredHmsIf.spec.ts
@@ -1,5 +1,10 @@
+import { flushPromises } from '@vue/test-utils'
+import { useD } from 'sefirot/composables/D'
+import { useV } from 'sefirot/composables/V'
+import { type Hms } from 'sefirot/support/Day'
 import { requiredHmsIf } from 'sefirot/validation/rules'
 import { type RequiredIfCondition } from 'sefirot/validation/validators'
+import { ref } from 'vue'
 
 describe('validation/rules/requiredHmsIf', () => {
   function getTestCasesForAllTypes() {
@@ -77,6 +82,27 @@ describe('validation/rules/requiredHmsIf', () => {
   )('validates only given types: $value is true if condition is $condition', async ({ value, condition }) => {
     const rule = requiredHmsIf(condition, ['h', 'm'])
     expect(await rule.$validator(value, null, null)).toBe(true)
+  })
+
+  test('condition can be reactive', async () => {
+    const condition = ref(false)
+
+    const { data } = useD({
+      v: {} as Hms
+    })
+
+    const { validation } = useV(data, {
+      v: { required: requiredHmsIf(() => condition.value) }
+    })
+
+    expect(validation.value.$invalid).toBe(false)
+
+    condition.value = true
+
+    // Await since this is async validator.
+    await flushPromises()
+
+    expect(validation.value.$invalid).toBe(true)
   })
 
   test('default error message', () => {

--- a/tests/validation/rules/requiredIf.spec.ts
+++ b/tests/validation/rules/requiredIf.spec.ts
@@ -48,7 +48,7 @@ describe('validation/rules/requiredIf', () => {
     })
 
     const { validation } = useV(data, {
-      v: { requiredIf: requiredIf(() => condition.value) }
+      v: { required: requiredIf(() => condition.value) }
     })
 
     expect(validation.value.$invalid).toBe(false)

--- a/tests/validation/rules/requiredIf.spec.ts
+++ b/tests/validation/rules/requiredIf.spec.ts
@@ -1,4 +1,8 @@
+import { useD } from 'sefirot/composables/D'
+import { useV } from 'sefirot/composables/V'
+import { sleep } from 'sefirot/support/Time'
 import { requiredIf } from 'sefirot/validation/rules'
+import { ref } from 'vue'
 
 describe('validation/rules/requiredIf', () => {
   test('validates if the value is valid', () => {
@@ -34,6 +38,27 @@ describe('validation/rules/requiredIf', () => {
       expect(rule.$validator('  ', null, null)).toStrictEqual(expected)
       expect(rule.$validator(new Date('a'), null, null)).toStrictEqual(expected)
     })
+  })
+
+  test('condition can be reactive', async () => {
+    const condition = ref(false)
+
+    const { data } = useD({
+      v: null as string | null
+    })
+
+    const { validation } = useV(data, {
+      v: { requiredIf: requiredIf(() => condition.value) }
+    })
+
+    expect(validation.value.$invalid).toBe(false)
+
+    condition.value = true
+
+    // Await since this is async validator.
+    await sleep(0)
+
+    expect(validation.value.$invalid).toBe(true)
   })
 
   test('default error message', () => {

--- a/tests/validation/rules/requiredIf.spec.ts
+++ b/tests/validation/rules/requiredIf.spec.ts
@@ -1,6 +1,6 @@
+import { flushPromises } from '@vue/test-utils'
 import { useD } from 'sefirot/composables/D'
 import { useV } from 'sefirot/composables/V'
-import { sleep } from 'sefirot/support/Time'
 import { requiredIf } from 'sefirot/validation/rules'
 import { ref } from 'vue'
 
@@ -56,7 +56,7 @@ describe('validation/rules/requiredIf', () => {
     condition.value = true
 
     // Await since this is async validator.
-    await sleep(0)
+    await flushPromises()
 
     expect(validation.value.$invalid).toBe(true)
   })

--- a/tests/validation/rules/requiredYmdIf.spec.ts
+++ b/tests/validation/rules/requiredYmdIf.spec.ts
@@ -1,5 +1,10 @@
+import { flushPromises } from '@vue/test-utils'
+import { useD } from 'sefirot/composables/D'
+import { useV } from 'sefirot/composables/V'
+import { type Ymd } from 'sefirot/support/Day'
 import { requiredYmdIf } from 'sefirot/validation/rules'
 import { type RequiredIfCondition } from 'sefirot/validation/validators'
+import { ref } from 'vue'
 
 describe('validation/rules/requiredYmdIf', () => {
   function getTestCasesForAllTypes() {
@@ -74,6 +79,27 @@ describe('validation/rules/requiredYmdIf', () => {
   )('validates only given types: $value is true if condition is $condition', async ({ value, condition }) => {
     const rule = requiredYmdIf(condition, ['y', 'm'])
     expect(await rule.$validator(value, null, null)).toBe(true)
+  })
+
+  test('condition can be reactive', async () => {
+    const condition = ref(false)
+
+    const { data } = useD({
+      v: {} as Ymd
+    })
+
+    const { validation } = useV(data, {
+      v: { required: requiredYmdIf(() => condition.value) }
+    })
+
+    expect(validation.value.$invalid).toBe(false)
+
+    condition.value = true
+
+    // Await since this is async validator.
+    await flushPromises()
+
+    expect(validation.value.$invalid).toBe(true)
   })
 
   test('default error message', () => {


### PR DESCRIPTION
Reactivity in rules were not working. Seems like we need explicitly pass in reactive props into `params`.

```ts
export function requiredIf(
  condition: RequiredIfCondition,
  msg?: string
) {
  return createRule({
    async: true,
    params: { condition }, // <- This one!
    message: ({ lang }) => msg ?? message[lang],
    validation: (value) => baseRequiredIf(value, condition)
  })
}
```