### PR TITLE
feat(api): allow executing queries without assigning result to data

### DIFF
--- a/docs/composables/api.md
+++ b/docs/composables/api.md
@@ -10,7 +10,18 @@ Executes given promise function immediately and set the result to `data` ref.
 interface Query<Data = any> {
   loading: Ref<boolean>
   data: Ref<Data | undefined>
-  execute(options?: { assign?: boolean }): Promise<Data>
+  execute(options?: {
+    /**
+     * controls whether the response should be assigned to the data ref
+     * @default true
+     */
+    assign?: boolean
+    /**
+     * controls whether the loading state should not be set before fetching
+     * @default false
+     */
+    silent?: boolean
+  }): Promise<Data>
 }
 
 interface UseQueryOptions {

--- a/docs/composables/api.md
+++ b/docs/composables/api.md
@@ -10,16 +10,19 @@ Executes given promise function immediately and set the result to `data` ref.
 interface Query<Data = any> {
   loading: Ref<boolean>
   data: Ref<Data | undefined>
-  execute(): Promise<Data>
+  execute(options?: { assign?: boolean }): Promise<Data>
 }
 
 interface UseQueryOptions {
   /**
-   * controls whether the query should execute immediately.
-   * 
+   * controls whether the query should execute immediately
    * @default true
    */
   immediate?: boolean
+  /**
+   * watch the given source(s) and re-execute the query
+   */
+  watch?: WatchSource | WatchSource[]
 }
 
 function useQuery<Data = any>(

--- a/lib/composables/Api.ts
+++ b/lib/composables/Api.ts
@@ -5,7 +5,7 @@ import { tryOnMounted } from './Utils'
 export interface Query<Data = any> {
   loading: Ref<boolean>
   data: Ref<Data | undefined>
-  execute(): Promise<Data>
+  execute(options?: { assign?: boolean }): Promise<Data>
 }
 
 export interface UseQueryOptions {
@@ -40,14 +40,15 @@ export function useQuery<Data = any>(
   }
 
   if (options.watch) {
-    watch(options.watch, execute, { deep: true })
+    watch(options.watch, () => { execute() }, { deep: true })
   }
 
-  async function execute(): Promise<Data> {
+  async function execute({ assign = true } = {}): Promise<Data> {
     loading.value = true
 
     const res: Data = await req(new Http())
-    data.value = res
+
+    if (assign) { data.value = res }
 
     loading.value = false
     return res

--- a/lib/composables/Api.ts
+++ b/lib/composables/Api.ts
@@ -44,10 +44,9 @@ export function useQuery<Data = any>(
   }
 
   async function execute({ assign = true } = {}): Promise<Data> {
-    loading.value = true
+    if (assign) { loading.value = true }
 
     const res: Data = await req(new Http())
-
     if (assign) { data.value = res }
 
     loading.value = false

--- a/lib/composables/Api.ts
+++ b/lib/composables/Api.ts
@@ -5,7 +5,18 @@ import { tryOnMounted } from './Utils'
 export interface Query<Data = any> {
   loading: Ref<boolean>
   data: Ref<Data | undefined>
-  execute(options?: { assign?: boolean }): Promise<Data>
+  execute(options?: {
+    /**
+     * controls whether the response should be assigned to the data ref
+     * @default true
+     */
+    assign?: boolean
+    /**
+     * controls whether the loading state should not be set before fetching
+     * @default false
+     */
+    silent?: boolean
+  }): Promise<Data>
 }
 
 export interface UseQueryOptions {
@@ -43,8 +54,8 @@ export function useQuery<Data = any>(
     watch(options.watch, () => { execute() }, { deep: true })
   }
 
-  async function execute({ assign = true } = {}): Promise<Data> {
-    if (assign) { loading.value = true }
+  async function execute({ assign = true, silent = false } = {}): Promise<Data> {
+    if (!silent) { loading.value = true }
 
     const res: Data = await req(new Http())
     if (assign) { data.value = res }


### PR DESCRIPTION
Adds `assign` option to `useQuery.execute`. It's helpful while implementing functionality like "load more".

When assign is false, `loading.value` will not be set to `true` before fetching - this is to avoid showing spinner - and calling execute won't update `query.data` - one would need to manually merge the returned data with existing one.

Example:

```ts
const query = useQuery(...)

async function loadMore(): Promise<void> {
    const res = await query.execute({ assign: false })
    ;(query.data.value ??= {}).push(...res)
  }
}
```