### PR TITLE
feat(card): support action bar button as link

### DIFF
--- a/lib/components/SControlActionBarButton.vue
+++ b/lib/components/SControlActionBarButton.vue
@@ -5,6 +5,7 @@ import SButton from './SButton.vue'
 defineProps<{
   as?: string
   icon?: any
+  href?: string
 }>()
 
 defineEmits<{
@@ -22,6 +23,7 @@ const size = useControlSize()
       mode="mute"
       :size="size"
       :icon="icon"
+      :href="href"
       block
       @click="$emit('click')"
     />

--- a/stories/components/SCard.01_Playground.story.vue
+++ b/stories/components/SCard.01_Playground.story.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
+import IconLink from '@iconify-icons/ph/arrow-square-out-bold'
+import IconPlus from '@iconify-icons/ph/plus-bold'
 import SCard from 'sefirot/components/SCard.vue'
 import SCardBlock from 'sefirot/components/SCardBlock.vue'
 import SControl from 'sefirot/components/SControl.vue'
 import SControlActionBar from 'sefirot/components/SControlActionBar.vue'
+import SControlActionBarButton from 'sefirot/components/SControlActionBarButton.vue'
 import SControlActionBarCollapse from 'sefirot/components/SControlActionBarCollapse.vue'
 import SControlButton from 'sefirot/components/SControlButton.vue'
 import SControlLeft from 'sefirot/components/SControlLeft.vue'
@@ -49,6 +52,8 @@ function state() {
                 </SControlLeft>
                 <SControlRight>
                   <SControlActionBar>
+                    <SControlActionBarButton :icon="IconPlus" />
+                    <SControlActionBarButton :icon="IconLink" href="https://sefirot.globalbrains.com/" />
                     <SControlActionBarCollapse />
                   </SControlActionBar>
                 </SControlRight>


### PR DESCRIPTION
No related issues.

I added a way to render `SControlActionBarButton` as a link just because we came to need it in our products.