### PR TITLE
feat(indicator): add `<SIndicator>` component

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -83,6 +83,7 @@ function sidebar(): DefaultTheme.SidebarItem[] {
         { text: 'SFragment', link: '/components/fragment' },
         { text: 'SGrid', link: '/components/grid' },
         { text: 'SHead', link: '/components/head' },
+        { text: 'SIndicator', link: '/components/indicator' },
         { text: 'SInputAddon', link: '/components/input-addon' },
         { text: 'SInputCheckbox', link: '/components/input-checkbox' },
         { text: 'SInputCheckboxes', link: '/components/input-checkboxes' },

--- a/docs/components/indicator.md
+++ b/docs/components/indicator.md
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import SIndicator from 'sefirot/components/SIndicator.vue'
+
+const states = ['pending', 'ready', 'queued', 'running', 'completed', 'failed']
+</script>
+
+# SIndicator
+
+`<SIndicator>` is used to display status or progress of an item or a task.
+
+<Showcase
+  path="/components/SIndicator.vue"
+  story="/stories-components-sindicator-01-playground-story-vue"
+>
+  <div class="flex flex-wrap gap-16">
+    <SIndicator v-for="s in states" :key="s" size="mini" :state="s" />
+  </div>
+</Showcase>
+
+## Usage
+
+Import `<SIndicator>` component and define its state.
+
+```vue
+<script setup lang="ts">
+import SIndicator from '@globalbrain/sefirot/lib/components/SIndicator.vue'
+</script>
+
+<template>
+  <SIndicator state="running" />
+</template>
+```
+
+## Props
+
+```ts
+interface Props {
+  size?: Size
+  state: State
+  mode?: Mode
+}
+
+type Size =
+  | 'nano'
+  | 'mini'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'jumbo'
+
+type State =
+  | 'pending'
+  | 'ready'
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+
+type Mode =
+  | 'colored'
+  | 'monochrome'
+```
+
+### `:size`
+
+The size of the indicator. The default is `medium`.
+
+```ts
+interface Props {
+  size?: Size
+}
+
+type State =
+  | 'pending'
+  | 'ready'
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+```
+
+```vue-html
+<SIndicator state="completed" />
+```
+
+### `:state`
+
+The state of the indicator.
+
+```ts
+interface Props {
+  mode?: 
+}
+
+type Size =
+  | 'mini'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'jumbo'
+```
+
+```vue-html
+<SIndicator state="completed" />
+```
+
+### `:mode`
+
+Whether the indicator should have colors or be monochrome. The default is `colored`.
+
+```ts
+interface Props {
+  mode?: Mode
+}
+
+type Mode =
+  | 'colored'
+  | 'monochrome'
+```
+
+```vue-html
+<SIndicator mode="monochrome" state="running" />
+```

--- a/lib/components/SIndicator.vue
+++ b/lib/components/SIndicator.vue
@@ -67,11 +67,11 @@ const stateIconDict = {
 .SIndicator.jumbo  { width: 48px; height: 48px; }
 
 .SIndicator.queued {
-  animation: indicator-blink 1s linear infinite;
+  animation: indicator-blink 1.5s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite;
 }
 
 .SIndicator.running {
-  animation: indicator-spin 1s linear infinite;
+  animation: indicator-spin 1.5s linear infinite;
 }
 
 .SIndicator.colored {

--- a/lib/components/SIndicator.vue
+++ b/lib/components/SIndicator.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import IconCheckCircleFill from '@iconify-icons/ph/check-circle-fill'
+import IconCircle from '@iconify-icons/ph/circle-bold'
+import IconCircleDashed from '@iconify-icons/ph/circle-dashed-bold'
+import IconCircleNotch from '@iconify-icons/ph/circle-notch-bold'
+import IconXCircle from '@iconify-icons/ph/x-circle-bold'
+import { computed } from 'vue'
+import SIcon from './SIcon.vue'
+
+export type Size = 'nano' | 'mini' | 'small' | 'medium' | 'large' | 'jumbo'
+export type State = 'pending' | 'ready' | 'queued' | 'running' | 'completed' | 'failed'
+export type Mode = 'colored' | 'monochrome'
+
+const props = withDefaults(defineProps<{
+  size?: Size
+  state: State
+  mode?: Mode
+}>(), {
+  size: 'medium',
+  mode: 'colored'
+})
+
+const classes = computed(() => [
+  props.size,
+  props.state,
+  props.mode
+])
+
+const stateIconDict = {
+  pending: IconCircle,
+  ready: IconCircle,
+  queued: IconCircleDashed,
+  running: IconCircleNotch,
+  completed: IconCheckCircleFill,
+  failed: IconXCircle
+}
+</script>
+
+<template>
+  <div class="SIndicator" :class="classes">
+    <SIcon class="icon" :icon="stateIconDict[state]" />
+  </div>
+</template>
+
+<style scoped lang="postcss">
+@keyframes indicator-blink {
+  0%   { opacity: 1; }
+  50%  { opacity: 0.5; }
+  100% { opacity: 1; }
+}
+
+@keyframes indicator-spin {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.icon {
+  width: 100%;
+  height: 100%;
+}
+
+.SIndicator.nano   { width: 20px; height: 20px; }
+.SIndicator.mini   { width: 24px; height: 24px; }
+.SIndicator.small  { width: 28px; height: 28px; }
+.SIndicator.medium { width: 32px; height: 32px; }
+.SIndicator.large  { width: 40px; height: 40px; }
+.SIndicator.jumbo  { width: 48px; height: 48px; }
+
+.SIndicator.queued {
+  animation: indicator-blink 1s linear infinite;
+}
+
+.SIndicator.running {
+  animation: indicator-spin 1s linear infinite;
+}
+
+.SIndicator.colored {
+  &.pending   { color: var(--c-fg-gray-1); }
+  &.ready     { color: var(--c-fg-info-1); }
+  &.queued    { color: var(--c-fg-info-1); }
+  &.running   { color: var(--c-fg-info-1); }
+  &.completed { color: var(--c-fg-success-1); }
+  &.failed    { color: var(--c-fg-danger-1); }
+}
+
+.SIndicator.monochrome {
+  color: var(--c-fg-gray-1);
+}
+</style>

--- a/stories/components/SIndicator.01_Playground.story.vue
+++ b/stories/components/SIndicator.01_Playground.story.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import SIndicator from 'sefirot/components/SIndicator.vue'
+
+const title = 'Components / SIndicator / 01. Playground'
+const docs = '/components/indicator'
+
+function state() {
+  return {
+    size: 'medium',
+    state: 'pending',
+    mode: 'colored'
+  }
+}
+</script>
+
+<template>
+  <Story :title="title" :init-state="state" source="Not available" auto-props-disabled>
+    <template #controls="{ state }">
+      <HstSelect
+        title="size"
+        :options="{
+          nano: 'nano',
+          mini: 'mini',
+          small: 'small',
+          medium: 'medium',
+          large: 'large',
+          jumbo: 'jumbo'
+        }"
+        v-model="state.size"
+      />
+      <HstSelect
+        title="state"
+        :options="{
+          pending: 'pending',
+          ready: 'ready',
+          queued: 'queued',
+          running: 'running',
+          completed: 'completed',
+          failed: 'failed'
+        }"
+        v-model="state.state"
+      />
+      <HstSelect
+        title="mode"
+        :options="{
+          colored: 'colored',
+          monochrome: 'monochrome'
+        }"
+        v-model="state.mode"
+      />
+    </template>
+
+    <template #default="{ state }">
+      <Board :title="title" :docs="docs">
+        <SIndicator
+          :size="state.size"
+          :state="state.state"
+          :mode="state.mode"
+        />
+      </Board>
+    </template>
+  </Story>
+</template>

--- a/stories/components/SIndicator.02_States.story.vue
+++ b/stories/components/SIndicator.02_States.story.vue
@@ -11,7 +11,7 @@ const states = [
   'running',
   'completed',
   'failed'
-]
+] as const
 
 function state() {
   return {

--- a/stories/components/SIndicator.02_States.story.vue
+++ b/stories/components/SIndicator.02_States.story.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import SIndicator from 'sefirot/components/SIndicator.vue'
+
+const title = 'Components / SIndicator / 02. States'
+const docs = '/components/indicator'
+
+const states = [
+  'pending',
+  'ready',
+  'queued',
+  'running',
+  'completed',
+  'failed'
+]
+
+function state() {
+  return {
+    size: 'medium',
+    mode: 'colored'
+  }
+}
+</script>
+
+<template>
+  <Story :title="title" :init-state="state" source="Not available" auto-props-disabled>
+    <template #controls="{ state }">
+      <HstSelect
+        title="size"
+        :options="{
+          nano: 'nano',
+          mini: 'mini',
+          small: 'small',
+          medium: 'medium',
+          large: 'large',
+          jumbo: 'jumbo'
+        }"
+        v-model="state.size"
+      />
+      <HstSelect
+        title="mode"
+        :options="{
+          colored: 'colored',
+          monochrome: 'monochrome'
+        }"
+        v-model="state.mode"
+      />
+    </template>
+
+    <template #default="{ state }">
+      <Board :title="title" :docs="docs">
+        <div class="s-flex s-gap-16">
+          <SIndicator
+            v-for="s in states"
+            :key="s"
+            :size="state.size"
+            :state="s"
+            :mode="state.mode"
+          />
+        </div>
+      </Board>
+    </template>
+  </Story>
+</template>


### PR DESCRIPTION
I've changed props a bit from the issue.

```vue
<SIndicator state="running" />
```

```ts
interface Props {
  size?: Size
  state: State
  mode?: Mode
}

type Size =
  | 'nano'
  | 'mini'
  | 'small'
  | 'medium'
  | 'large'
  | 'jumbo'

type State =
  | 'pending'
  | 'ready'
  | 'queued'
  | 'running'
  | 'completed'
  | 'failed'

type Mode =
  | 'colored'
  | 'monochrome'
```

<img width="1392" alt="Screenshot 2024-06-03 at 17 50 03" src="https://github.com/globalbrain/sefirot/assets/3753672/e0816f59-7f1a-40b2-828d-4b252a11ebc1">
