### PR TITLE
fix: set `dayjs` as peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@vuelidate/validators": "^2.0.4",
     "@vueuse/core": "^10.9.0",
     "body-scroll-lock": "4.0.0-beta.0",
+    "dayjs": "^1.11.11",
     "fuse.js": "^7.0.0",
     "lodash-es": "^4.17.21",
     "markdown-it": "^14.1.0",
@@ -70,7 +71,6 @@
     "@tinyhttp/cookie": "^2.1.0",
     "@types/file-saver": "^2.0.7",
     "@types/qs": "^6.9.15",
-    "dayjs": "^1.11.11",
     "file-saver": "^2.0.5",
     "ofetch": "^1.3.4",
     "qs": "^6.12.1"
@@ -95,6 +95,7 @@
     "@vuelidate/validators": "^2.0.4",
     "@vueuse/core": "^10.9.0",
     "body-scroll-lock": "4.0.0-beta.0",
+    "dayjs": "^1.11.11",
     "eslint": "^8.57.0",
     "fuse.js": "^7.0.0",
     "happy-dom": "^14.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@types/qs':
         specifier: ^6.9.15
         version: 6.9.15
-      dayjs:
-        specifier: ^1.11.11
-        version: 1.11.11
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -96,6 +93,9 @@ importers:
       body-scroll-lock:
         specifier: 4.0.0-beta.0
         version: 4.0.0-beta.0
+      dayjs:
+        specifier: ^1.11.11
+        version: 1.11.11
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -8400,7 +8400,7 @@ snapshots:
 
   semver-diff@4.0.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   semver@5.7.2: {}
 


### PR DESCRIPTION
No related issues.

Some products install `dayjs` as their own dependency whose version is different from Sefirot's dependency version.
I got a type error during development.

This PR is to make `dayjs` a peer-dependency so that its version can be automatically checked in Sefirot user products.