### PR TITLE
feat(login-page): add password action

### DIFF
--- a/docs/components/login-page.md
+++ b/docs/components/login-page.md
@@ -124,7 +124,9 @@ interface ActionSocial {
 }
 ```
 
-When selecting `type: 'password'`, it will open a email/password form modal when a user clicks the action button, and `onSubmit` will be called when the user submits the form. You can await for a promise to show a loading spinner while the form is being submitted.
+When selecting `type: 'password'`, it will open a email/password form modal when a user clicks the action button, and `onSubmit` will be called when the user submits the form.
+
+You can await for a promise to show a loading spinner while the form is being submitted. If you return `false`, the form will not close and the error message will be shown.
 
 ```ts
 const actions = [
@@ -133,7 +135,11 @@ const actions = [
     async onSubmit(email, password) {
       // The email/password dialog will show loading spinner
       // while this promise is being awaited
-      await login(email, password)
+      const result = await login(email, password)
+
+      // If the promise returns false, the dialog will not close
+      // and the error message will be shown.
+      return result
     }
   }
 ]

--- a/docs/components/login-page.md
+++ b/docs/components/login-page.md
@@ -49,9 +49,16 @@ interface CoverPhotographer {
   link: string
 }
 
-interface Action {
+type Action = ActionPassword | ActionSocial
+
+interface ActionPassword {
+  type: 'password'
+  onSubmit(email: string, password: string): Promise<void>
+}
+
+interface ActionSocial {
   type: 'google'
-  onClick: () => Promise<void>
+  onClick(): Promise<void>
 }
 ```
 
@@ -97,15 +104,37 @@ interface CoverPhotographer {
 
 ### `:actions`
 
-This prop is an array of login buttons, where `type` is auth provider, and `onClick` is a function to log in.
+This prop is an array of login buttons, where `type` is auth provider.
 
 ```ts
 interface Props {
   actions: Action[]
 }
 
-interface Action {
-  type: 'google'
-  onClick: () => Promise<void>
+type Action = ActionPassword | ActionSocial
+
+interface ActionPassword {
+  type: 'password'
+  onSubmit(email: string, password: string): Promise<void>
 }
+
+interface ActionSocial {
+  type: 'google'
+  onClick(): Promise<void>
+}
+```
+
+When selecting `type: 'password'`, it will open a email/password form modal when a user clicks the action button, and `onSubmit` will be called when the user submits the form. You can await for a promise to show a loading spinner while the form is being submitted.
+
+```ts
+const actions = [
+  {
+    type: 'password',
+    async onSubmit(email, password) {
+      // The email/password dialog will show loading spinner
+      // while this promise is being awaited
+      await login(email, password)
+    }
+  }
+]
 ```

--- a/lib/components/SLoginPage.vue
+++ b/lib/components/SLoginPage.vue
@@ -23,7 +23,7 @@ export type Action = ActionPassword | ActionSocial
 
 export interface ActionPassword {
   type: 'password'
-  onSubmit(email: string, password: string): Promise<void>
+  onSubmit(email: string, password: string): Promise<boolean>
 }
 
 export interface ActionSocial {
@@ -44,6 +44,7 @@ const passwordDialog = usePower()
 
 const selectedPasswordAction = ref<ActionPassword | null>(null)
 const actionInProgress = ref(false)
+const actionError = ref(false)
 
 const coverBgImageStyle = computed(() => `url(${props.cover})`)
 
@@ -77,9 +78,14 @@ function onAction(action: Action) {
 
 async function onSubmit(email: string, password: string) {
   actionInProgress.value = true
-  await selectedPasswordAction.value!.onSubmit(email, password)
+
+  actionError.value = !(await selectedPasswordAction.value!.onSubmit(email, password))
+
   actionInProgress.value = false
-  passwordDialog.off()
+
+  if (!actionError.value) {
+    passwordDialog.off()
+  }
 }
 </script>
 
@@ -128,6 +134,7 @@ async function onSubmit(email: string, password: string) {
     <SModal :open="passwordDialog.state.value" @close="passwordDialog.off">
       <SLoginPagePasswordDialog
         :loading="actionInProgress"
+        :error="actionError"
         @cancel="passwordDialog.off"
         @submit="onSubmit"
       />

--- a/lib/components/SLoginPagePasswordDialog.vue
+++ b/lib/components/SLoginPagePasswordDialog.vue
@@ -2,6 +2,7 @@
 import { useD } from '../composables/D'
 import { useV } from '../composables/V'
 import { email, maxLength, required } from '../validation/rules'
+import SAlert from './SAlert.vue'
 import SCard from './SCard.vue'
 import SCardBlock from './SCardBlock.vue'
 import SContent from './SContent.vue'
@@ -13,6 +14,7 @@ import SInputText from './SInputText.vue'
 
 defineProps<{
   loading: boolean
+  error: boolean
 }>()
 
 const emit = defineEmits<{
@@ -51,6 +53,9 @@ async function onSubmit() {
         <SContent>
           <h2>Sign in to account</h2>
         </SContent>
+        <SAlert v-if="error" mode="danger">
+          <p>Invalid email or password.</p>
+        </SAlert>
         <SInputText
           name="email"
           type="email"

--- a/lib/components/SLoginPagePasswordDialog.vue
+++ b/lib/components/SLoginPagePasswordDialog.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { useD } from '../composables/D'
+import { useV } from '../composables/V'
+import { email, maxLength, required } from '../validation/rules'
+import SCard from './SCard.vue'
+import SCardBlock from './SCardBlock.vue'
+import SContent from './SContent.vue'
+import SControl from './SControl.vue'
+import SControlButton from './SControlButton.vue'
+import SControlRight from './SControlRight.vue'
+import SDoc from './SDoc.vue'
+import SInputText from './SInputText.vue'
+
+defineProps<{
+  loading: boolean
+}>()
+
+const emit = defineEmits<{
+  cancel: []
+  submit: [email: string, password: string]
+}>()
+
+const { data } = useD({
+  email: null as string | null,
+  password: null as string | null
+})
+
+const { validation, validateAndNotify } = useV(data, {
+  email: {
+    required: required(),
+    maxLength: maxLength(255),
+    email: email()
+  },
+  password: {
+    required: required(),
+    maxLength: maxLength(255)
+  }
+})
+
+async function onSubmit() {
+  if (await validateAndNotify()) {
+    emit('submit', data.value.email!, data.value.password!)
+  }
+}
+</script>
+
+<template>
+  <SCard size="small">
+    <SCardBlock class="s-p-24">
+      <SDoc>
+        <SContent>
+          <h2>Sign in to account</h2>
+        </SContent>
+        <SInputText
+          name="email"
+          type="email"
+          label="Email"
+          placeholder="john.doe@example.com"
+          v-model="data.email"
+          :validation="validation.email"
+        />
+        <SInputText
+          name="password"
+          type="password"
+          label="Password"
+          placeholder="Password"
+          v-model="data.password"
+          :validation="validation.password"
+        />
+      </SDoc>
+    </SCardBlock>
+    <SCardBlock size="xlarge" class="s-px-24">
+      <SControl>
+        <SControlRight>
+          <SControlButton
+            label="Cancel"
+            :disabled="loading"
+            @click="$emit('cancel')"
+          />
+          <SControlButton
+            mode="info"
+            label="Sign in"
+            :loading="loading"
+            @click="onSubmit"
+          />
+        </SControlRight>
+      </SControl>
+    </SCardBlock>
+  </SCard>
+</template>

--- a/stories/components/SLoginPage.01_Playground.story.vue
+++ b/stories/components/SLoginPage.01_Playground.story.vue
@@ -1,59 +1,37 @@
 <script setup lang="ts">
-import SLoginPage from 'sefirot/components/SLoginPage.vue'
+import SLoginPage, { type Action } from 'sefirot/components/SLoginPage.vue'
+import { sleep } from 'sefirot/support/Time'
 
 const title = 'Components / SLoginPage / 01. Playground'
 const docs = '/components/login-page'
 
-function state() {
-  const state: InstanceType<typeof SLoginPage>['$props'] = {
-    cover: 'https://images.unsplash.com/photo-1526783166374-1239abde1c20?q=80&w=3008&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-    coverTitle: {
-      text: 'Golden Gate Bridge',
-      link: 'https://unsplash.com/photos/bottom-view-of-orange-building-LjE32XEW01g'
-    },
-    coverPhotographer: {
-      text: 'Keegan Houser',
-      link: 'https://unsplash.com/@khouser01'
-    },
-    actions: [
-      { type: 'google', onClick: async () => {} }
-    ]
-  }
+const cover = 'https://images.unsplash.com/photo-1526783166374-1239abde1c20?q=80&w=3008&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
 
-  return state
+const coverTitle = {
+  text: 'Golden Gate Bridge',
+  link: 'https://unsplash.com/photos/bottom-view-of-orange-building-LjE32XEW01g'
 }
+
+const coverPhotographer = {
+  text: 'Keegan Houser',
+  link: 'https://unsplash.com/@khouser01'
+}
+
+const actions: Action[] = [
+  { type: 'password', onSubmit: async () => { await sleep(1000) } },
+  { type: 'google', onClick: async () => {} }
+]
 </script>
 
 <template>
-  <Story :title="title" :init-state="state" source="Not available" auto-props-disabled>
-    <template #controls="{ state }">
-      <HstText
-        title="cover"
-        v-model="state.cover"
+  <Story :title="title" source="Not available" auto-props-disabled>
+    <Board :title="title" :docs="docs">
+      <SLoginPage
+        :cover="cover"
+        :cover-title="coverTitle"
+        :cover-photographer="coverPhotographer"
+        :actions="actions"
       />
-      <HstJson
-        title="coverTitle"
-        v-model="state.coverTitle"
-      />
-      <HstJson
-        title="coverPhotographer"
-        v-model="state.coverPhotographer"
-      />
-      <HstJson
-        title="actions"
-        v-model="state.actions"
-      />
-    </template>
-
-    <template #default="{ state }">
-      <Board :title="title" :docs="docs">
-        <SLoginPage
-          :cover="state.cover"
-          :cover-title="state.coverTitle"
-          :cover-photographer="state.coverPhotographer"
-          :actions="state.actions"
-        />
-      </Board>
-    </template>
+    </Board>
   </Story>
 </template>

--- a/stories/components/SLoginPage.01_Playground.story.vue
+++ b/stories/components/SLoginPage.01_Playground.story.vue
@@ -18,7 +18,7 @@ const coverPhotographer = {
 }
 
 const actions: Action[] = [
-  { type: 'password', onSubmit: async () => { await sleep(1000) } },
+  { type: 'password', onSubmit: async () => { await sleep(1000); return true } },
   { type: 'google', onClick: async () => {} }
 ]
 </script>


### PR DESCRIPTION
Add password action to the `<SLoginPage>`.

It will also show email/password dialog and handle validations. We can await inside `onSubmit` function to show loading spinner on the form.

```ts
const actions = [
  {
    type: 'password',
    async onSubmit(email, password) {
      // The email/password dialog will show loading spinner
      // while this promise is being awaited
      await login(email, password)
    }
  }
]
```

---
<img width="1438" alt="Screenshot 2024-07-18 at 13 20 42" src="https://github.com/user-attachments/assets/a8ef758c-2154-4798-a5ae-a185a4bd274d">

<img width="1435" alt="Screenshot 2024-07-18 at 13 20 49" src="https://github.com/user-attachments/assets/310d5b0b-e73a-4294-a7fc-a3d8e05e9408">

