### PR TITLE
feat(input): add `<SInputFileUpload>`

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -86,6 +86,7 @@ function sidebar(): DefaultTheme.SidebarItem[] {
         { text: 'SInputCheckbox', link: '/components/input-checkbox' },
         { text: 'SInputCheckboxes', link: '/components/input-checkboxes' },
         { text: 'SInputFile', link: '/components/input-file' },
+        { text: 'SInputFileUpload', link: '/components/input-file-upload' },
         { text: 'SInputHMS', link: '/components/input-hms' },
         { text: 'SInputImage', link: '/components/input-image' },
         { text: 'SInputNumber', link: '/components/input-number' },

--- a/docs/components/input-file-upload.md
+++ b/docs/components/input-file-upload.md
@@ -1,0 +1,379 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import SInputFileUpload from 'sefirot/components/SInputFileUpload.vue'
+
+const input = ref([])
+</script>
+
+# SInputFileUpload
+
+`<SInputFileUpload>` is a multiple file select component. It has more advanced features compared to `<SInputFile>` such as listing selected files individually, removing selected files, and more.
+
+<Showcase
+  path="/components/SInputFileUpload.vue"
+  story="/stories-components-sinputfileupload-01-playground-story-vue"
+>
+  <SInputFileUpload v-model="input" />
+</Showcase>
+
+## Import
+
+```ts
+import SInputFileUpload from '@globalbrain/sefirot/lib/components/SInputFileUpload.vue'
+```
+
+## Usage
+
+Import `<SInputFileUpload>` and pass in value as either `v-model` or `:value`. The value should be an array of `File` objects.
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import SInputFile from '@globalbrain/sefirot/lib/components/SInputFile.vue'
+
+const input = ref<File[]>([])
+</script>
+
+<template>
+  <SInputFileUpload v-model="input" />
+</template>
+```
+
+## Props
+
+```ts
+interface Props {
+  size?: Size
+  label?: string
+  info?: string
+  note?: string
+  help?: string
+  text?: string
+  placeholder?: string
+  emptyText?: string
+  accept?: string
+  multiple?: boolean
+  checkIcon?: Component
+  checkText?: string
+  checkColor?: Color
+  value?: File[]
+  modelValue?: File[]
+  hideError?: boolean
+  validation?: Validatable
+}
+
+type Size =
+  | 'mini'
+  | 'small'
+  | 'medium'
+
+type Color =
+  | 'neutral'
+  | 'mute'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+```
+
+### `:size`
+
+Defines the size of the input. This only affects the size of the label. The default is `small`.
+
+```ts
+interface Props {
+  size?: 'mini' | 'small' | 'medium'
+}
+```
+
+```vue-html
+<SInputFileUpload size="small" v-model="..." />
+```
+
+### `:label`
+
+Defines the label text of the input.
+
+```ts
+interface Props {
+  label?: string
+}
+```
+
+```vue-html
+<SInputFileUpload label="Upload file" v-model="..." />
+```
+
+### `:info`
+
+Shows help icon after the label and shows info in a tooltip when the user hovers the label.
+
+```ts
+interface Props {
+  info?: string
+}
+```
+
+```vue-html
+<SInputFileUpload
+  label="Upload image"
+  info="The files will be uploaded to the server."
+  v-model="..."
+/>
+```
+
+### `:note`
+
+Adds small help text after the label. Best used along with `label` prop.
+
+```ts
+interface Props {
+  note?: string
+}
+```
+
+```vue-html
+<SInputFileUpload
+  label="Upload file"
+  note="Optional"
+  v-model="..."
+/>
+```
+
+### `:help`
+
+Adds small help text to the bottom of the input.
+
+```ts
+interface Props {
+  help?: string
+}
+```
+
+```vue-html
+<SInputFileUpload
+  label="Upload file"
+  help="Accepts only JPG and PNG."
+  v-model="..."
+/>
+```
+
+### `:text`
+
+Defines the text of the button. Defaults to `'Choose File'`.
+
+```ts
+interface Props {
+  text?: string
+}
+```
+
+```vue-html
+<SInputFileUpload text="Select File" v-model="..." />
+```
+
+### `:placeholder`
+
+Defines the placeholder text to show right next to file select button. Use this space to describe main validation rules, such as file size limit.
+
+```ts
+interface Props {
+  placeholder?: string
+}
+```
+
+```vue-html
+<SInputFileUpload
+  placeholder="Total 10MB max."
+  v-model="..."
+/>
+```
+
+### `:accept`
+
+Defines the file types to accept.
+
+```ts
+interface Props {
+  accept?: string
+}
+```
+
+```vue-html
+<SInputFileUpload accept="image/*" v-model="..." />
+```
+
+### `:check-icon`
+
+Icon to display at corner right of label. Useful to show the status of a particular input.
+
+```ts
+interface Props {
+  checkIcon?: Component
+}
+```
+
+```vue-html
+<SInputFileUpload :check-icon="IconCheckCircle" />
+```
+
+### `:check-text`
+
+Text to display alongside `check-icon`.
+
+```ts
+interface Props {
+  checkText?: string
+}
+```
+
+```vue-html
+<SInputFileUpload :check-text="Saved" />
+```
+
+### `:check-color`
+
+Defines the color of `check-icon` and `check-text`. The default is `neutral`.
+
+```ts
+interface Props {
+  checkColor?: Color
+}
+
+type Color =
+  | 'neutral' 
+  | 'mute' 
+  | 'info' 
+  | 'success' 
+  | 'warning' 
+  | 'danger'
+```
+
+```vue-html
+<SInputFileUpload
+  :check-icon="IconCheckCircle"
+  check-text="Uploaded"
+  check-color="success"
+/>
+```
+
+### `:value`
+
+Sets the input value. When `model-value` prop is set (e.g. via `v-model` directive), this prop gets ignored.
+
+```ts
+interface Props {
+  value?: File[]
+}
+```
+
+```vue-html
+<SInputFileUpload :value="file" />
+```
+
+### `:model-value`
+
+The `v-model` binding for the input.
+
+```ts
+interface Props {
+  modelValue?: File[]
+}
+```
+
+```vue-html
+<SInputFileUpload v-model="file" />
+```
+
+### `:validation`
+
+The validation object for the input. It accepts [Vuelidate](https://vuelidate-next.netlify.app/) like validation object and displays error if there're any.
+
+```ts
+import { Ref } from 'vue'
+
+interface Props {
+  validation?: Validatable
+}
+
+export interface Validatable {
+  readonly $dirty: boolean
+  readonly $invalid: boolean
+  readonly $errors: ValidatableError[]
+  readonly $touch: () => void
+}
+
+export interface ValidatableError {
+  readonly $message: string | Ref<string>
+}
+```
+
+```vue-html
+<SInputFileUpload
+  v-model="file"
+  :validation="validation"
+/>
+```
+
+### `:hide-error`
+
+Stop showing validation error message even when there are errors. This prop will not prevent the error color from appearing.
+
+```ts
+interface Props {
+  hideError?: boolean
+}
+```
+
+```vue-html
+<SInputFileUpload
+  v-model="file"
+  :validation="validation"
+  hide-error
+/>
+```
+
+## Slots
+
+Here are the list of slots you may define within the component.
+
+### `#info` {#info-slot}
+
+Same as `info` prop. When `info` prop and this slot are defined at the same time, this slot will take precedence.
+
+```vue-html
+<SInputFileUpload label="Upload image" v-model="...">
+  <template #info>
+    Learn more about this field <SLink href="...">here</SLink>.
+  </template>
+</SInputFile>
+```
+
+## Events
+
+```ts
+interface Emits {
+  'update:model-value': [files: File[]]
+  'change': [files: File[]]
+}
+```
+
+### `@update:model-value`
+
+Emits when the user selects the item. This event is always emitted together with `change` event.
+
+```ts
+interface Emits {
+  'update:model-value': [files: File[]]
+}
+```
+
+### `@change`
+
+Emits when the user selects the item. This event is always emitted together with `update:model-value` event.
+
+```ts
+interface Emits {
+  change: [files: File[]]
+}
+```

--- a/docs/support/file.md
+++ b/docs/support/file.md
@@ -17,3 +17,18 @@ const file = new File([], 'example.txt')
 
 getExtension(file) // <- 'txt'
 ```
+
+## `formatSize`
+
+Formats the file size in bytes to a human-readable format. It also accepts array of files and returns the total size.
+
+```ts
+function formatSize(files: File | File[]): string
+```
+
+```ts
+import { formatSize } from '@globalbrain/sefirot/lib/support/File'
+
+formatSize(file)           // <- '10.00MB'
+formatSize([file1, file2]) // <- '20.00MB'
+```

--- a/lib/components/SInputBase.vue
+++ b/lib/components/SInputBase.vue
@@ -72,7 +72,7 @@ function getErrorMsg(validation: Validatable) {
       </span>
     </label>
 
-    <slot />
+    <slot :has-error="error?.has" />
 
     <div class="help">
       <slot name="before-help" />

--- a/lib/components/SInputFileUpload.vue
+++ b/lib/components/SInputFileUpload.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { type Component, computed, ref } from 'vue'
+import { useTrans } from '../composables/Lang'
+import { type Validatable } from '../composables/Validation'
+import { formatSize } from '../support/File'
+import SButton from './SButton.vue'
+import SCard from './SCard.vue'
+import SCardBlock from './SCardBlock.vue'
+import SInputBase from './SInputBase.vue'
+import SInputFileUploadItem from './SInputFileUploadItem.vue'
+
+export type Size = 'mini' | 'small' | 'medium'
+export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
+
+const props = defineProps<{
+  size?: Size
+  label?: string
+  info?: string
+  note?: string
+  help?: string
+  text?: string
+  placeholder?: string
+  emptyText?: string
+  accept?: string
+  multiple?: boolean
+  checkIcon?: Component
+  checkText?: string
+  checkColor?: Color
+  value?: File[]
+  modelValue?: File[]
+  hideError?: boolean
+  validation?: Validatable
+}>()
+
+const emit = defineEmits<{
+  'update:model-value': [files: File[]]
+  'change': [files: File[]]
+}>()
+
+const { t } = useTrans({
+  en: {
+    button_text: 'Choose File',
+    empty_text: 'No file selected',
+    selected_files: (c: number) => c === 1 ? `${c} file` : `${c} files`
+  },
+  ja: {
+    button_text: 'ファイルを選択',
+    empty_text: 'ファイルが選択されていません',
+    selected_files: (c: number) => `ファイル数: ${c}`
+  }
+})
+
+const _value = computed(() => {
+  return props.modelValue !== undefined
+    ? props.modelValue
+    : props.value !== undefined ? props.value : []
+})
+
+const input = ref<HTMLInputElement | null>(null)
+
+const classes = computed(() => [props.size ?? 'small'])
+
+const totalFileCountText = computed(() => {
+  return t.selected_files(_value.value.length)
+})
+
+const totalFileSizeText = computed(() => {
+  return formatSize(_value.value)
+})
+
+function open() {
+  input.value!.click()
+}
+
+function onChange(e: Event) {
+  const files = Array.from((e.target as HTMLInputElement).files ?? [])
+
+  // When files are empty, that means user have "canceled" the file selection
+  // so we should do nothing in this case.
+  if (files.length === 0) {
+    return
+  }
+
+  const newFiles = [..._value.value, ...files]
+
+  emit('update:model-value', newFiles)
+  emit('change', newFiles)
+
+  props.validation?.$touch()
+}
+
+function onRemove(index: number) {
+  const files = _value.value.filter((_, i) => i !== index)
+
+  emit('update:model-value', files)
+  emit('change', files)
+}
+</script>
+
+<template>
+  <SInputBase
+    class="SInputFile"
+    :class="classes"
+    :label="label"
+    :note="note"
+    :info="info"
+    :help="help"
+    :check-icon="checkIcon"
+    :check-text="checkText"
+    :check-color="checkColor"
+    :validation="validation"
+    :hide-error="hideError"
+  >
+    <template #default="{ hasError }">
+      <input
+        ref="input"
+        class="input"
+        type="file"
+        :accept="accept"
+        multiple
+        @change="onChange"
+      >
+      <SCard :mode="hasError ? 'danger' : undefined">
+        <SCardBlock class="header">
+          <SButton
+            size="small"
+            :label="text ?? t.button_text"
+            @click="open"
+          />
+          <p v-if="placeholder" class="placeholder">
+            {{ placeholder }}
+          </p>
+        </SCardBlock>
+        <template v-if="_value.length">
+          <SInputFileUploadItem
+            v-for="file, i in _value"
+            :key="file.name"
+            :file="file"
+            @remove="() => { onRemove(i) }"
+          />
+        </template>
+        <template v-else>
+          <SCardBlock class="empty">
+            <p class="empty-text">
+              {{ emptyText ?? t.empty_text }}
+            </p>
+          </SCardBlock>
+        </template>
+        <SCardBlock class="footer">
+          <div class="footer-left">
+            <p class="footer-file-count">
+              {{ totalFileCountText }}
+            </p>
+          </div>
+          <div class="footer-right">
+            <p class="footer-file-size">
+              {{ totalFileSizeText }}
+            </p>
+            <div class="footer-spacer" />
+          </div>
+        </SCardBlock>
+      </SCard>
+    </template>
+    <template v-if="$slots.info" #info>
+      <slot name="info" />
+    </template>
+  </SInputBase>
+</template>
+
+<style lang="postcss" scoped>
+.input {
+  display: none;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 48px;
+  padding: 0 8px;
+}
+
+.placeholder {
+  line-height: 24px;
+  font-size: 12px;
+  color: var(--c-text-2);
+}
+
+.empty {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 48px;
+  padding: 0 16px;
+}
+
+.empty-text {
+  line-height: 20px;
+  font-size: 12px;
+  color: var(--c-text-2);
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 48px;
+  padding: 0 8px 0 16px;
+}
+
+.footer-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.footer-file-count,
+.footer-file-size {
+  line-height: 24px;
+  font-size: 12px;
+  color: var(--c-text-2);
+}
+
+.footer-spacer {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+}
+</style>

--- a/lib/components/SInputFileUploadItem.vue
+++ b/lib/components/SInputFileUploadItem.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { formatSize } from '../support/File'
+import SButton from './SButton.vue'
+import SCardBlock from './SCardBlock.vue'
+import IconFileText from '~icons/ph/file-text'
+import IconTrash from '~icons/ph/trash'
+
+const props = defineProps<{
+  file: File
+}>()
+
+defineEmits<{
+  'remove': []
+}>()
+
+const fileSize = computed(() => {
+  return formatSize(props.file)
+})
+</script>
+
+<template>
+  <SCardBlock class="SInputFileUploadItem">
+    <p class="name">
+      <IconFileText class="name-icon" />
+      <span class="name-text">{{ file.name }}</span>
+    </p>
+    <div class="size">{{ fileSize }}</div>
+    <SButton
+      size="small"
+      type="text"
+      mode="mute"
+      :icon="IconTrash"
+      @click="$emit('remove')"
+    />
+  </SCardBlock>
+</template>
+
+<style lang="postcss" scoped>
+.SInputFileUploadItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 48px;
+  padding: 0 8px 0 16px;
+}
+
+.name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-grow: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.name-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--c-text-2);
+}
+
+.name-text {
+  line-height: 24px;
+  font-size: 14px;
+  color: var(--c-text-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.size {
+  line-height: 24px;
+  font-size: 12px;
+  color: var(--c-text-2);
+}
+</style>

--- a/lib/support/File.ts
+++ b/lib/support/File.ts
@@ -6,3 +6,19 @@ export function getExtension(file: File): string {
 
   return name.slice((name.lastIndexOf('.') - 1 >>> 0) + 2)
 }
+
+/**
+ * Formats the file size in bytes to a human-readable format. It also accepts
+ * array of files and returns the total size.
+ */
+export function formatSize(files: File | File[]): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+  files = Array.isArray(files) ? files : [files]
+  let size = files.reduce((previous, file) => previous + file.size, 0)
+  let index = 0
+  while (size >= 1024 && index < units.length) {
+    size /= 1024
+    index++
+  }
+  return `${size.toFixed(2)}${units[index]}`
+}

--- a/stories/components/SInputFileUpload.01_Playground.story.vue
+++ b/stories/components/SInputFileUpload.01_Playground.story.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import SInputFileUpload from 'sefirot/components/SInputFileUpload.vue'
+import { useData } from 'sefirot/composables/Data'
+import { useValidation } from 'sefirot/composables/Validation'
+import { maxTotalFileSize } from 'sefirot/validation/rules'
+
+const title = 'Components / SInputFileUpload / 01. Playground'
+const docs = '/components/input-file-upload'
+
+const { data } = useData({
+  files: [] as File[]
+})
+
+const { validation } = useValidation(data, {
+  files: {
+    maxTotalFileSize: maxTotalFileSize('10MB')
+  }
+})
+
+function state() {
+  return {
+    size: 'small',
+    label: 'Label',
+    info: null,
+    note: null,
+    text: undefined,
+    placeholder: 'Total 10MB max.',
+    emptyText: null,
+    help: null,
+    accept: null
+  } as const
+}
+</script>
+
+<template>
+  <Story :title="title" :init-state="state" source="Not available" auto-props-disabled>
+    <template #controls="{ state }">
+      <HstSelect
+        title="size"
+        :options="{
+          mini: 'mini',
+          small: 'small',
+          medium: 'medium'
+        }"
+        v-model="state.size"
+      />
+      <HstText
+        title="label"
+        v-model="state.label"
+      />
+      <HstText
+        title="info"
+        v-model="state.info"
+      />
+      <HstText
+        title="note"
+        v-model="state.note"
+      />
+      <HstText
+        title="help"
+        v-model="state.help"
+      />
+      <HstText
+        title="text"
+        v-model="state.text"
+      />
+      <HstText
+        title="placeholder"
+        v-model="state.placeholder"
+      />
+      <HstText
+        title="empty-text"
+        v-model="state.emptyText"
+      />
+      <HstText
+        title="accept"
+        v-model="state.accept"
+      />
+    </template>
+
+    <template #default="{ state }">
+      <Board :title="title" :docs="docs">
+        <SInputFileUpload
+          :size="state.size"
+          :label="state.label"
+          :info="state.info"
+          :note="state.note"
+          :help="state.help"
+          :text="state.text"
+          :placeholder="state.placeholder"
+          :empty-text="state.emptyText"
+          :accept="state.accept"
+          v-model="data.files"
+          :validation="validation.files"
+        />
+      </Board>
+    </template>
+  </Story>
+</template>


### PR DESCRIPTION
- close #544 

I've also:

- Add new helper function `formatSize` to get total file size text like `12.32MB`.
- Add new scoped slot to `<SInputBase>` to get whether the input has error or not. Bacause it is easier to apply `mode` option to `SCard`.

I haven't added validation feature for each item. It is not required at the moment, and I wasn't still not sure what was the best way to go about it 🤔 

---

<img width="708" alt="Screenshot 2024-08-05 at 12 08 29" src="https://github.com/user-attachments/assets/d147b40e-caf8-445c-b0cb-02fcff3b3f51">

<img width="708" alt="Screenshot 2024-08-05 at 12 08 37" src="https://github.com/user-attachments/assets/dcb00cdb-08e9-4bcf-9efc-2ca26b5174c2">

<img width="708" alt="Screenshot 2024-08-05 at 12 08 46" src="https://github.com/user-attachments/assets/cd99af78-fef6-4855-bae1-96ff99f28b02">
