### PR TITLE
fix(alert): use `:deep` instead of `:slotted` to style elements

### DIFF
--- a/lib/components/SAlert.vue
+++ b/lib/components/SAlert.vue
@@ -55,14 +55,14 @@ withDefaults(defineProps<{
   gap: 16px;
 }
 
-.content :slotted(p) {
+.content :deep(p) {
   margin: 0;
   max-width: 65ch;
   line-height: 24px;
   font-size: 14px;
 }
 
-.content :slotted(a) {
+.content :deep(a) {
   font-weight: 500;
   text-decoration: underline;
   transition: color 0.25s;


### PR DESCRIPTION
Because seems like `:slotted` will stop working if we have nested component which very often happens with `<STrans>`.

```html
<SAlert>
  <!-- This `<p>` becomes font size 16px with `:slotted`. -->
  <STrans lang="en"><p>Lorem ipsum...</p></STrans>
</SAlert>
```