### PR TITLE
feat(style): set font antialias

### DIFF
--- a/lib/styles/base.css
+++ b/lib/styles/base.css
@@ -14,6 +14,9 @@ body {
   font-weight: 400;
   color: var(--c-text-1);
   background-color: var(--c-bg-elv-1);
+  font-synthesis: none;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 blockquote,

--- a/stories/styles.css
+++ b/stories/styles.css
@@ -1,6 +1,9 @@
 body {
   line-height: 20px;
   font-size: 14px;
+  font-synthesis: none;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 #app {


### PR DESCRIPTION
Mainly to make font looks as close to Figma. We don't need to add this to VitePress since it already does it in the theme.