### PR TITLE
feat(table): add cell type "Path"

### DIFF
--- a/lib/components/STableCell.vue
+++ b/lib/components/STableCell.vue
@@ -59,7 +59,7 @@ const computedCell = computed<TableCell | undefined>(() =>
     />
     <STableCellPath
       v-else-if="computedCell.type === 'path'"
-      :items="computedCell.items"
+      :segments="computedCell.segments"
     />
     <STableCellDay
       v-else-if="computedCell.type === 'day'"

--- a/lib/components/STableCell.vue
+++ b/lib/components/STableCell.vue
@@ -8,6 +8,7 @@ import STableCellCustom from './STableCellCustom.vue'
 import STableCellDay from './STableCellDay.vue'
 import STableCellEmpty from './STableCellEmpty.vue'
 import STableCellNumber from './STableCellNumber.vue'
+import STableCellPath from './STableCellPath.vue'
 import STableCellPill from './STableCellPill.vue'
 import STableCellPills from './STableCellPills.vue'
 import STableCellState from './STableCellState.vue'
@@ -55,6 +56,10 @@ const computedCell = computed<TableCell | undefined>(() =>
       :color="computedCell.color"
       :icon-color="computedCell.iconColor"
       :on-click="computedCell.onClick"
+    />
+    <STableCellPath
+      v-else-if="computedCell.type === 'path'"
+      :items="computedCell.items"
     />
     <STableCellDay
       v-else-if="computedCell.type === 'day'"

--- a/lib/components/STableCellPath.vue
+++ b/lib/components/STableCellPath.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { type TableCellPathItem } from '../composables/Table'
+import { type TableCellPathSegment } from '../composables/Table'
 import SLink from './SLink.vue'
 
 defineProps<{
-  items: TableCellPathItem[]
+  segments: TableCellPathSegment[]
 }>()
 
-function classes(item: TableCellPathItem) {
+function classes(item: TableCellPathSegment) {
   return [
     item.color ?? 'neutral',
     { link: !!item.link || !!item.onClick }
@@ -16,15 +16,15 @@ function classes(item: TableCellPathItem) {
 
 <template>
   <div class="STableCellPath">
-    <template v-for="item, index in items" :key="index">
+    <template v-for="segment, index in segments" :key="index">
       <div v-if="index > 0" class="divider">/</div>
       <SLink
         class="text"
-        :class="classes(item)"
-        :href="item.link"
-        @click="item.onClick"
+        :class="classes(segment)"
+        :href="segment.link"
+        @click="segment.onClick"
       >
-        {{ item.text }}
+        {{ segment.text }}
       </SLink>
     </template>
   </div>

--- a/lib/components/STableCellPath.vue
+++ b/lib/components/STableCellPath.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { type TableCellPathItem } from '../composables/Table'
+import SLink from './SLink.vue'
+
+defineProps<{
+  items: TableCellPathItem[]
+}>()
+
+function classes(item: TableCellPathItem) {
+  return [
+    item.color ?? 'neutral',
+    { link: !!item.link || !!item.onClick }
+  ]
+}
+</script>
+
+<template>
+  <div class="STableCellPath">
+    <template v-for="item, index in items" :key="index">
+      <div v-if="index > 0" class="divider">/</div>
+      <SLink
+        class="text"
+        :class="classes(item)"
+        :href="item.link"
+        @click="item.onClick"
+      >
+        {{ item.text }}
+      </SLink>
+    </template>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.STableCellPath {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 16px;
+  min-height: 40px;
+}
+
+.divider {
+  color: var(--c-text-3);
+}
+
+.text {
+  line-height: 24px;
+  font-size: 14px;
+  transition: color 0.25s;
+
+  &.neutral { color: var(--c-text-1); }
+  &.soft    { color: var(--c-text-2); }
+  &.mute    { color: var(--c-text-3); }
+  &.info    { color: var(--c-text-info-1); }
+  &.success { color: var(--c-text-success-1); }
+  &.warning { color: var(--c-text-warning-1); }
+  &.danger  { color: var(--c-text-danger-1); }
+
+  &.link {
+    cursor: pointer;
+  }
+
+  &.link.neutral:hover { color: var(--c-text-info-1); }
+  &.link.soft:hover    { color: var(--c-text-info-1); }
+  &.link.mute:hover    { color: var(--c-text-info-1); }
+  &.link.info:hover    { color: var(--c-text-info-2); }
+  &.link.success:hover { color: var(--c-text-success-2); }
+  &.link.warning:hover { color: var(--c-text-warning-2); }
+  &.link.danger:hover  { color: var(--c-text-danger-2); }
+}
+</style>

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -120,10 +120,10 @@ export interface TableCellNumber<V = any, R = any> extends TableCellBase {
 
 export interface TableCellPath extends TableCellBase {
   type: 'path'
-  items: TableCellPathItem[]
+  segments: TableCellPathSegment[]
 }
 
-export interface TableCellPathItem {
+export interface TableCellPathSegment {
   text: string
   link?: string | null
   color?: TableCellValueColor

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -55,6 +55,7 @@ export type TableColumnCellFn<V, R> = (value: V, record: R) => TableCell<V, R>
 export type TableCell<V = any, R = any> =
   | TableCellText<V, R>
   | TableCellNumber<V, R>
+  | TableCellPath
   | TableCellDay
   | TableCellPill
   | TableCellPills
@@ -69,6 +70,7 @@ export type TableCell<V = any, R = any> =
 export type TableCellType =
   | 'text'
   | 'number'
+  | 'path'
   | 'day'
   | 'pill'
   | 'pills'
@@ -114,6 +116,18 @@ export interface TableCellNumber<V = any, R = any> extends TableCellBase {
   color?: TableCellValueColor
   iconColor?: TableCellValueColor
   onClick?(value: V, record: R): void
+}
+
+export interface TableCellPath extends TableCellBase {
+  type: 'path'
+  items: TableCellPathItem[]
+}
+
+export interface TableCellPathItem {
+  text: string
+  link?: string | null
+  color?: TableCellValueColor
+  onClick?(): void
 }
 
 export type TableCellValueColor = ColorModes | 'soft'


### PR DESCRIPTION
Add a cell type to display "Path" like data (directory path, breadcrumbs, etc).

```ts
const data = [
  { path: ['Folder A', 'file-a.png'] },
  { path: ['Folder B', 'file-b.png'] }
]

const table = useTable({
  records: data,
  orders: ['path'],
  columns: {
    path: {
      label: 'Path',
      cell: (_, record) => ({
        type: 'path',
        items: record.path.map((p) => ({
          label: p,
          link: `https://example.com/${p}`
        }))
      })
    }
  }
})
```

---

<img width="699" alt="Screenshot 2025-01-22 at 13 00 31" src="https://github.com/user-attachments/assets/0fbbe89b-0ec9-4f96-a338-38a14d7c62c7" />
