### PR TITLE
feat(input-file-upload): add droppable and indicator support

### DIFF
--- a/lib/components/SIndicator.vue
+++ b/lib/components/SIndicator.vue
@@ -7,7 +7,7 @@ import IconMinusCircle from '~icons/ph/minus-circle'
 import IconXCircle from '~icons/ph/x-circle'
 import { computed } from 'vue'
 
-export type Size = 'nano' | 'mini' | 'small' | 'medium' | 'large' | 'jumbo'
+export type Size = 'nano' | 'mini' | 'small' | 'medium' | 'large' | 'jumbo' | 'fill'
 export type State = 'pending' | 'ready' | 'queued' | 'running' | 'completed' | 'failed' | 'aborted'
 export type Mode = 'colored' | 'monochrome'
 
@@ -65,6 +65,7 @@ const classes = computed(() => [
 .SIndicator.medium { width: 32px; height: 32px; }
 .SIndicator.large  { width: 40px; height: 40px; }
 .SIndicator.jumbo  { width: 48px; height: 48px; }
+.SIndicator.fill   { width: 100%; height: 100%; }
 
 .SIndicator.queued {
   animation: indicator-blink 1.5s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite;

--- a/lib/components/SInputFileUpload.vue
+++ b/lib/components/SInputFileUpload.vue
@@ -89,7 +89,7 @@ const { isOverDropZone } = useDropZone(dropZoneEl, {
 const _value = computed(() => {
   return props.modelValue !== undefined
     ? props.modelValue
-    : props.value !== undefined ? props.value : [] as unknown as ModelValue<T>[]
+    : props.value !== undefined ? props.value : [] as ModelValue<T>[]
 })
 
 const input = ref<HTMLInputElement | null>(null)

--- a/lib/components/SInputFileUpload.vue
+++ b/lib/components/SInputFileUpload.vue
@@ -1,4 +1,6 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T extends ModelType = 'file'">
+import { type ValidationRuleWithParams } from '@vuelidate/core'
+import { useDropZone } from '@vueuse/core'
 import { type Component, computed, ref } from 'vue'
 import { useTrans } from '../composables/Lang'
 import { type Validatable } from '../composables/Validation'
@@ -6,11 +8,23 @@ import { formatSize } from '../support/File'
 import SButton from './SButton.vue'
 import SCard from './SCard.vue'
 import SCardBlock from './SCardBlock.vue'
+import { type State as IndicatorState } from './SIndicator.vue'
 import SInputBase from './SInputBase.vue'
 import SInputFileUploadItem from './SInputFileUploadItem.vue'
+import STrans from './STrans.vue'
 
 export type Size = 'mini' | 'small' | 'medium'
 export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
+
+export type ModelType = 'file' | 'object'
+export type ModelValue<T extends ModelType> = T extends 'file' ? File : FileObject
+
+export interface FileObject {
+  file: File
+  indicatorState?: IndicatorState | null
+  canRemove?: boolean
+  errorMessage?: string | null
+}
 
 const props = defineProps<{
   size?: Size
@@ -26,15 +40,18 @@ const props = defineProps<{
   checkIcon?: Component
   checkText?: string
   checkColor?: Color
-  value?: File[]
-  modelValue?: File[]
-  hideError?: boolean
+  droppable?: boolean
+  value?: ModelValue<T>[]
+  modelType?: T
+  modelValue?: ModelValue<T>[]
+  rules?: Record<string, ValidationRuleWithParams>
   validation?: Validatable
+  hideError?: boolean
 }>()
 
 const emit = defineEmits<{
-  'update:model-value': [files: File[]]
-  'change': [files: File[]]
+  'update:model-value': [files: ModelValue<T>[]]
+  'change': [files: ModelValue<T>[]]
 }>()
 
 const { t } = useTrans({
@@ -50,26 +67,44 @@ const { t } = useTrans({
   }
 })
 
+const dropZoneEl = ref<HTMLDivElement | null>(null)
+
+const { isOverDropZone } = useDropZone(dropZoneEl, {
+  multiple: true,
+  onDrop: (files) => onDrop(files)
+})
+
 const _value = computed(() => {
   return props.modelValue !== undefined
     ? props.modelValue
-    : props.value !== undefined ? props.value : []
+    : props.value !== undefined ? props.value : [] as unknown as ModelValue<T>[]
 })
 
 const input = ref<HTMLInputElement | null>(null)
 
-const classes = computed(() => [props.size ?? 'small'])
+const classes = computed(() => [
+  props.size ?? 'small',
+  { droppable: props.droppable },
+  { 'is-over-drop-zone': isOverDropZone.value }
+])
 
 const totalFileCountText = computed(() => {
   return t.selected_files(_value.value.length)
 })
 
 const totalFileSizeText = computed(() => {
-  return formatSize(_value.value)
+  const files = _value.value.map((file) => file instanceof File ? file : file.file)
+  return formatSize(files)
 })
 
 function open() {
   input.value!.click()
+}
+
+function onDrop(files: File[] | null) {
+  if (files !== null && files.length > 0) {
+    emitChange(append(files))
+  }
 }
 
 function onChange(e: Event) {
@@ -81,25 +116,35 @@ function onChange(e: Event) {
     return
   }
 
-  const newFiles = [..._value.value, ...files]
-
-  emit('update:model-value', newFiles)
-  emit('change', newFiles)
-
-  props.validation?.$touch()
+  emitChange(append(files))
 }
 
 function onRemove(index: number) {
   const files = _value.value.filter((_, i) => i !== index)
+  emitChange(files)
+}
 
+function emitChange(files: ModelValue<T>[]) {
   emit('update:model-value', files)
   emit('change', files)
+  props.validation?.$touch()
+}
+
+function append(files: File[]) {
+  return [
+    ..._value.value,
+    ...(props.modelType === 'file' ? files : toFileObjects(files))
+  ] as ModelValue<T>[]
+}
+
+function toFileObjects(files: File[]) {
+  return files.map((file) => ({ file } as ModelValue<T>))
 }
 </script>
 
 <template>
   <SInputBase
-    class="SInputFile"
+    class="SInputFileUpload"
     :class="classes"
     :label="label"
     :note="note"
@@ -121,8 +166,31 @@ function onRemove(index: number) {
         @change="onChange"
       >
       <SCard :mode="hasError ? 'danger' : undefined">
-        <SCardBlock class="header">
+        <SCardBlock v-if="droppable" class="drop-zone" ref="dropZoneEl">
+          <div class="drop-zone-box">
+            <STrans lang="en">
+              <div class="drop-zone-text">
+                <div>Drag & Drop files here</div>
+                <div>Or</div>
+              </div>
+              <div class="drop-zone-action">
+                <SButton size="mini" label="Select files" />
+              </div>
+            </STrans>
+            <STrans lang="ja">
+              <div class="drop-zone-text">
+                <div>ファイルをドラック＆ドロップ</div>
+                <div>もしくは</div>
+              </div>
+              <div class="drop-zone-action">
+                <SButton size="small" label="ファイルを選択" />
+              </div>
+            </STrans>
+          </div>
+        </SCardBlock>
+        <SCardBlock v-if="!droppable || placeholder" class="header">
           <SButton
+            v-if="!droppable"
             size="small"
             :label="text ?? t.button_text"
             @click="open"
@@ -134,8 +202,9 @@ function onRemove(index: number) {
         <template v-if="_value.length">
           <SInputFileUploadItem
             v-for="file, i in _value"
-            :key="file.name"
+            :key="i"
             :file="file"
+            :rules="rules"
             @remove="() => { onRemove(i) }"
           />
         </template>
@@ -170,6 +239,38 @@ function onRemove(index: number) {
 <style lang="postcss" scoped>
 .input {
   display: none;
+}
+
+.drop-zone {
+  padding: 12px;
+
+  &:hover .drop-zone-box {
+    border-color: var(--c-border-info-1);
+    cursor: pointer;
+  }
+}
+
+.drop-zone-box {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  border: 1px dashed var(--c-border-mute-1);
+  border-radius: 3px;
+  padding: 24px 0;
+  min-height: 192px;
+  text-align: center;
+  transition: border-color 0.25s;
+}
+
+.drop-zone-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: center;
+  font-size: 14px;
+  color: var(--c-text-2);
 }
 
 .header {
@@ -225,5 +326,17 @@ function onRemove(index: number) {
   flex-shrink: 0;
   width: 32px;
   height: 32px;
+}
+
+.SInputFileUpload.droppable {
+  .header {
+    padding-left: 16px;
+  }
+}
+
+.SInputFileUpload.is-over-drop-zone {
+  .drop-zone-box {
+    border-color: var(--c-border-info-1);
+  }
 }
 </style>

--- a/lib/components/SInputFileUpload.vue
+++ b/lib/components/SInputFileUpload.vue
@@ -5,7 +5,7 @@ import { type Component, computed, ref } from 'vue'
 import { useTrans } from '../composables/Lang'
 import { type Validatable } from '../composables/Validation'
 import { formatSize } from '../support/File'
-import SButton from './SButton.vue'
+import SButton, { type Mode as ButtonMode } from './SButton.vue'
 import SCard from './SCard.vue'
 import SCardBlock from './SCardBlock.vue'
 import { type State as IndicatorState } from './SIndicator.vue'
@@ -23,10 +23,20 @@ export interface FileObject {
   file: File
   indicatorState?: IndicatorState | null
   canRemove?: boolean
+  action?: Action
   errorMessage?: string | null
 }
 
-const props = defineProps<{
+export interface Action {
+  mode?: ButtonMode
+  icon?: Component
+  leadIcon?: Component
+  trailIcon?: Component
+  label?: string
+  onClick(): void
+}
+
+const props = withDefaults(defineProps<{
   size?: Size
   label?: string
   info?: string
@@ -47,7 +57,9 @@ const props = defineProps<{
   rules?: Record<string, ValidationRuleWithParams>
   validation?: Validatable
   hideError?: boolean
-}>()
+}>(), {
+  modelType: 'file' as any // `ModelType` doesn't work so stubbing it.
+})
 
 const emit = defineEmits<{
   'update:model-value': [files: ModelValue<T>[]]
@@ -166,7 +178,7 @@ function toFileObjects(files: File[]) {
         @change="onChange"
       >
       <SCard :mode="hasError ? 'danger' : undefined">
-        <SCardBlock v-if="droppable" class="drop-zone" ref="dropZoneEl">
+        <SCardBlock v-if="droppable" class="drop-zone" ref="dropZoneEl" @click="open">
           <div class="drop-zone-box">
             <STrans lang="en">
               <div class="drop-zone-text">

--- a/lib/components/SInputFileUpload.vue
+++ b/lib/components/SInputFileUpload.vue
@@ -182,8 +182,7 @@ function toFileObjects(files: File[]) {
           <div class="drop-zone-box">
             <STrans lang="en">
               <div class="drop-zone-text">
-                <div>Drag & Drop files here</div>
-                <div>Or</div>
+                Drag and drop files here, or
               </div>
               <div class="drop-zone-action">
                 <SButton size="mini" label="Select files" />
@@ -191,11 +190,10 @@ function toFileObjects(files: File[]) {
             </STrans>
             <STrans lang="ja">
               <div class="drop-zone-text">
-                <div>ファイルをドラック＆ドロップ</div>
-                <div>もしくは</div>
+                ファイルをドラック＆ドロップ、または
               </div>
               <div class="drop-zone-action">
-                <SButton size="small" label="ファイルを選択" />
+                <SButton size="mini" label="ファイルを選択" />
               </div>
             </STrans>
           </div>
@@ -267,7 +265,7 @@ function toFileObjects(files: File[]) {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+  gap: 16px;
   border: 1px dashed var(--c-border-mute-1);
   border-radius: 3px;
   padding: 24px 0;
@@ -277,9 +275,6 @@ function toFileObjects(files: File[]) {
 }
 
 .drop-zone-text {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
   text-align: center;
   font-size: 14px;
   color: var(--c-text-2);

--- a/lib/components/SInputFileUploadItem.vue
+++ b/lib/components/SInputFileUploadItem.vue
@@ -1,38 +1,76 @@
 <script setup lang="ts">
 import IconFileText from '~icons/ph/file-text'
 import IconTrash from '~icons/ph/trash'
+import { type ValidationRuleWithParams } from '@vuelidate/core'
 import { computed } from 'vue'
+import { useValidation } from '../composables/Validation'
 import { formatSize } from '../support/File'
 import SButton from './SButton.vue'
 import SCardBlock from './SCardBlock.vue'
+import SIndicator, { type State as IndicatorState } from './SIndicator.vue'
+
+export interface FileObject {
+  file: File
+  indicatorState?: IndicatorState | null
+  canRemove?: boolean
+  errorMessage?: string | null
+}
 
 const props = defineProps<{
-  file: File
+  file: File | FileObject
+  rules?: Record<string, ValidationRuleWithParams>
 }>()
 
 defineEmits<{
   'remove': []
 }>()
 
-const fileSize = computed(() => {
-  return formatSize(props.file)
+const _file = computed(() => ({
+  name: props.file instanceof File ? props.file.name : props.file.file.name,
+  file: props.file instanceof File ? props.file : props.file.file,
+  size: formatSize(props.file instanceof File ? props.file : props.file.file),
+  indicatorState: props.file instanceof File ? null : props.file.indicatorState,
+  canRemove: props.file instanceof File ? true : props.file.canRemove ?? true,
+  errorMessage: props.file instanceof File ? null : props.file.errorMessage
+}))
+
+const { validation } = useValidation(() => ({
+  file: _file.value.file
+}), {
+  file: props.rules ?? {}
 })
+
+validation.value.$touch()
 </script>
 
 <template>
   <SCardBlock class="SInputFileUploadItem">
-    <p class="name">
-      <IconFileText class="name-icon" />
-      <span class="name-text">{{ file.name }}</span>
-    </p>
-    <div class="size">{{ fileSize }}</div>
-    <SButton
-      size="small"
-      type="text"
-      mode="mute"
-      :icon="IconTrash"
-      @click="$emit('remove')"
-    />
+    <div class="name">
+      <div class="name-label">
+        <div class="name-icon">
+          <IconFileText v-if="_file.indicatorState == null" class="name-icon-svg" />
+          <SIndicator size="fill" v-else :state="_file.indicatorState" />
+        </div>
+        <p class="name-text">{{ _file.name }}</p>
+      </div>
+      <p v-if="_file.errorMessage" class="error">{{ _file.errorMessage }}</p>
+      <p v-else-if="validation.$errors.length" class="error">{{ validation.$errors[0]?.$message }}</p>
+    </div>
+    <div class="meta">
+      <div class="size">
+        {{ _file.size }}
+      </div>
+      <div class="delete">
+        <SButton
+          size="small"
+          type="text"
+          mode="mute"
+          :icon="IconTrash"
+          :disabled="!_file.canRemove"
+          @click="$emit('remove')"
+        />
+      </div>
+    </div>
   </SCardBlock>
 </template>
 
@@ -40,12 +78,20 @@ const fileSize = computed(() => {
 .SInputFileUploadItem {
   display: flex;
   align-items: center;
-  gap: 8px;
-  height: 48px;
-  padding: 0 8px 0 16px;
+  gap: 16px;
+  padding: 8px 8px 8px 16px;
 }
 
 .name {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.name-label {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -56,6 +102,12 @@ const fileSize = computed(() => {
 }
 
 .name-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+}
+
+.name-icon-svg {
   width: 16px;
   height: 16px;
   color: var(--c-text-2);
@@ -70,9 +122,31 @@ const fileSize = computed(() => {
   text-overflow: ellipsis;
 }
 
+.error {
+  padding-left: 24px;
+  line-height: 20px;
+  font-size: 12px;
+  color: var(--c-text-danger-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 8px;
+}
+
 .size {
+  flex-shrink: 0;
   line-height: 24px;
   font-size: 12px;
   color: var(--c-text-2);
+}
+
+.delete {
+  flex-shrink: 0;
 }
 </style>

--- a/lib/components/SInputFileUploadItem.vue
+++ b/lib/components/SInputFileUploadItem.vue
@@ -2,10 +2,10 @@
 import IconFileText from '~icons/ph/file-text'
 import IconTrash from '~icons/ph/trash'
 import { type ValidationRuleWithParams } from '@vuelidate/core'
-import { computed } from 'vue'
+import { type Component, computed } from 'vue'
 import { useValidation } from '../composables/Validation'
 import { formatSize } from '../support/File'
-import SButton from './SButton.vue'
+import SButton, { type Mode as ButtonMode } from './SButton.vue'
 import SCardBlock from './SCardBlock.vue'
 import SIndicator, { type State as IndicatorState } from './SIndicator.vue'
 
@@ -13,7 +13,17 @@ export interface FileObject {
   file: File
   indicatorState?: IndicatorState | null
   canRemove?: boolean
+  action?: Action | null
   errorMessage?: string | null
+}
+
+export interface Action {
+  mode?: ButtonMode
+  icon?: Component
+  leadIcon?: Component
+  trailIcon?: Component
+  label?: string
+  onClick(): void
 }
 
 const props = defineProps<{
@@ -31,6 +41,7 @@ const _file = computed(() => ({
   size: formatSize(props.file instanceof File ? props.file : props.file.file),
   indicatorState: props.file instanceof File ? null : props.file.indicatorState,
   canRemove: props.file instanceof File ? true : props.file.canRemove ?? true,
+  action: props.file instanceof File ? null : props.file.action,
   errorMessage: props.file instanceof File ? null : props.file.errorMessage
 }))
 
@@ -55,6 +66,18 @@ validation.value.$touch()
       </div>
       <p v-if="_file.errorMessage" class="error">{{ _file.errorMessage }}</p>
       <p v-else-if="validation.$errors.length" class="error">{{ validation.$errors[0]?.$message }}</p>
+    </div>
+    <div v-if="_file.action" class="action">
+      <SButton
+        type="text"
+        size="small"
+        :mode="_file.action.mode"
+        :icon="_file.action.icon"
+        :lead-icon="_file.action.leadIcon"
+        :trail-icon="_file.action.trailIcon"
+        :label="_file.action.label"
+        @click="_file.action.onClick"
+      />
     </div>
     <div class="meta">
       <div class="size">
@@ -130,6 +153,10 @@ validation.value.$touch()
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.action {
+  flex-shrink: 0;
 }
 
 .meta {

--- a/stories/components/SInputFileUpload.01_Playground.story.vue
+++ b/stories/components/SInputFileUpload.01_Playground.story.vue
@@ -21,7 +21,7 @@ function state() {
     info: null,
     note: null,
     text: undefined,
-    placeholder: 'Total 10MB max.',
+    placeholder: '1MB max per file.',
     emptyText: null,
     help: null,
     accept: null,

--- a/stories/components/SInputFileUpload.01_Playground.story.vue
+++ b/stories/components/SInputFileUpload.01_Playground.story.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import SInputFileUpload from 'sefirot/components/SInputFileUpload.vue'
 import { useData } from 'sefirot/composables/Data'
-import { useValidation } from 'sefirot/composables/Validation'
-import { maxTotalFileSize } from 'sefirot/validation/rules'
+import { maxFileSize } from 'sefirot/validation/rules'
 
 const title = 'Components / SInputFileUpload / 01. Playground'
 const docs = '/components/input-file-upload'
@@ -11,11 +10,9 @@ const { data } = useData({
   files: [] as File[]
 })
 
-const { validation } = useValidation(data, {
-  files: {
-    maxTotalFileSize: maxTotalFileSize('10MB')
-  }
-})
+const rules = {
+  maxFileSize: maxFileSize('1MB')
+}
 
 function state() {
   return {
@@ -27,7 +24,8 @@ function state() {
     placeholder: 'Total 10MB max.',
     emptyText: null,
     help: null,
-    accept: null
+    accept: null,
+    droppable: true
   } as const
 }
 </script>
@@ -76,6 +74,10 @@ function state() {
         title="accept"
         v-model="state.accept"
       />
+      <HstCheckbox
+        title="droppable"
+        v-model="state.droppable"
+      />
     </template>
 
     <template #default="{ state }">
@@ -90,8 +92,9 @@ function state() {
           :placeholder="state.placeholder"
           :empty-text="state.emptyText"
           :accept="state.accept"
+          :droppable="state.droppable"
           v-model="data.files"
-          :validation="validation.files"
+          :rules="rules"
         />
       </Board>
     </template>


### PR DESCRIPTION
Add droppable file selection and individual item state support to `<SinputFileUpload>`.

In order to keep the backward compatibility, the model value accepts both `File[]` and the new `FileObject[]`, and must define `:model-type="object"` when using `FileObject[]` as model value.

```vue
<script setup lang="ts>
const { data } = useData({
  files: [
    { file: File, indicatorType: 'running', canRemove: false }
  ]
})

const rules = {
  maxFileSize: maxFileSize('1mb')
}
</script>

<template>
  <SInputFIleUpload
    model-type="object"
    :v-model="data.files"
    :rules="rules"
  />
</template>
```

---

<img width="676" alt="Screenshot 2025-01-27 at 16 46 00" src="https://github.com/user-attachments/assets/00af4d6f-236e-431e-8bc5-2bd72a9d7cb3" />