### PR TITLE
feat: add app setup composables

### DIFF
--- a/lib/composables/App.ts
+++ b/lib/composables/App.ts
@@ -1,0 +1,22 @@
+import { type HttpOptions } from '../http/Http'
+import { useSetupHttp } from './Http'
+import { type HasLang, useSetupLang } from './Lang'
+import { type HasTheme, useSetupTheme } from './Theme'
+
+export interface SetupAppUser extends HasLang, HasTheme {}
+
+export interface SetupAppOptions {
+  http?: HttpOptions
+}
+
+export function useSetupApp(): (user?: SetupAppUser | null, options?: SetupAppOptions) => void {
+  const setupLang = useSetupLang()
+  const setupTheme = useSetupTheme()
+  const setupHttp = useSetupHttp()
+
+  return (user, options) => {
+    setupLang(user)
+    setupTheme(user)
+    setupHttp(user, options?.http)
+  }
+}

--- a/lib/composables/Http.ts
+++ b/lib/composables/Http.ts
@@ -1,0 +1,17 @@
+import { type Lang, useBrowserLang } from 'sefirot/composables/Lang'
+import { Http, type HttpOptions } from 'sefirot/http/Http'
+
+export interface HasLang {
+  lang: Lang
+}
+
+export function useSetupHttp(): (user?: HasLang | null, options?: HttpOptions) => void {
+  const browserLang = useBrowserLang()
+
+  return (user, options = {}) => {
+    Http.config({
+      lang: user?.lang ?? browserLang,
+      ...options
+    })
+  }
+}

--- a/lib/composables/Lang.ts
+++ b/lib/composables/Lang.ts
@@ -11,7 +11,19 @@ export interface TransMessages<T> {
   ja: T
 }
 
+export interface HasLang {
+  lang: Lang
+}
+
 export const SefirotLangKey = 'sefirot-lang-key'
+
+export function useSetupLang(): (user?: HasLang | null) => void {
+  const browserLang = useBrowserLang()
+
+  return (user) => {
+    provideLang(user?.lang ?? browserLang)
+  }
+}
 
 export function provideLang(lang: Lang) {
   provide(SefirotLangKey, lang)
@@ -23,6 +35,12 @@ export function useLang(): Lang {
   return inject(SefirotLangKey, 'en') || 'en'
 }
 
+export function useBrowserLang(): Lang {
+  const lang = navigator.language
+
+  return lang.split('-')[0] === 'ja' ? 'ja' : 'en'
+}
+
 export function useTrans<T>(messages: TransMessages<T>): Trans<T> {
   const lang = useLang()
 
@@ -31,10 +49,4 @@ export function useTrans<T>(messages: TransMessages<T>): Trans<T> {
   return {
     t
   }
-}
-
-export function useBrowserLang(): Lang {
-  const lang = navigator.language
-
-  return lang.split('-')[0] === 'ja' ? 'ja' : 'en'
 }

--- a/lib/composables/Theme.ts
+++ b/lib/composables/Theme.ts
@@ -1,0 +1,25 @@
+import { useDark } from '@vueuse/core'
+import { type WritableComputedRef, computed } from 'vue'
+
+export type Theme = 'light' | 'dark'
+
+export interface HasTheme {
+  theme: Theme
+}
+
+export function useSetupTheme(): (user?: HasTheme | null) => void {
+  const theme = useTheme()
+
+  return (user) => {
+    theme.value = user?.theme ?? 'light'
+  }
+}
+
+export function useTheme(): WritableComputedRef<Theme> {
+  const _isDark = useDark()
+
+  return computed({
+    get: () => _isDark.value ? 'dark' : 'light',
+    set: (v) => { _isDark.value = v === 'dark' }
+  })
+}


### PR DESCRIPTION
So we can do this now.

```ts
import { useSetupApp } from 'sefirot/composables/App'

const setupApp = useSetupApp()

setupApp(signedInUser, {
  http: {
    baseUrl: '/backend/'
  }
})
```