### PR TITLE
feat(input): add warning props to text, textarea, and number

### DIFF
--- a/lib/components/SInputNumber.vue
+++ b/lib/components/SInputNumber.vue
@@ -1,41 +1,30 @@
 <script setup lang="ts">
-import { type Component, computed } from 'vue'
-import { type Validatable } from '../composables/Validation'
+import { computed } from 'vue'
 import { isString } from '../support/Utils'
+import { type Props as BaseProps } from './SInputBase.vue'
 import SInputText from './SInputText.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
-export type Align = 'left' | 'center' | 'right'
-export type CheckColor = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
-export type TextColor = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
-
-const props = defineProps<{
-  size?: Size
-  name?: string
-  label?: string
-  info?: string
-  note?: string
-  help?: string
+export interface Props extends BaseProps {
   placeholder?: string
   unitBefore?: any
   unitAfter?: any
-  checkIcon?: Component
-  checkText?: string
-  checkColor?: CheckColor
   textColor?: TextColor | ((value: number | null) => TextColor)
-  align?: Align
   separator?: boolean
+  align?: Align
   disabled?: boolean
   value?: number | null
   modelValue?: number | null
   displayValue?: string | null
-  hideError?: boolean
-  validation?: Validatable
-}>()
+}
+
+export type Align = 'left' | 'center' | 'right'
+export type TextColor = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+
+const props = defineProps<Props>()
 
 const emit = defineEmits<{
-  (e: 'update:model-value', value: number | null): void
-  (e: 'input', value: number | null): void
+  'update:model-value': [value: number | null]
+  'input': [value: number | null]
 }>()
 
 const _value = computed(() => {
@@ -86,8 +75,8 @@ function emitUpdate(value: string | null) {
 <template>
   <SInputText
     class="SInputNumber"
-    :name="name"
     :size="size"
+    :name="name"
     type="number"
     :label="label"
     :note="note"
@@ -102,10 +91,12 @@ function emitUpdate(value: string | null) {
     :text-color="_textColor"
     :align="align"
     :disabled="disabled"
-    :hide-error="hideError"
     :display-value="displayValue"
     :model-value="_value == null ? null : String(_value)"
     :validation="validation"
+    :warning="warning"
+    :hide-error="hideError"
+    :hide-warning="hideWarning"
     @update:model-value="emitUpdate"
     @input="emitUpdate"
   >

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -1,51 +1,36 @@
 <script setup lang="ts">
 import { type Component, computed, ref } from 'vue'
-import { type Validatable } from '../composables/Validation'
 import { isString } from '../support/Utils'
-import SInputBase from './SInputBase.vue'
+import SInputBase, { type Props as BaseProps } from './SInputBase.vue'
 
-export interface Props {
-  size?: Size
-  name?: string
-  label?: string
-  info?: string
-  note?: string
-  help?: string
+export interface Props extends BaseProps {
   type?: string
   placeholder?: string
   unitBefore?: Component | string
   unitAfter?: Component | string
-  checkIcon?: Component
-  checkText?: string
-  checkColor?: CheckColor
   textColor?: TextColor | ((value: string | null) => TextColor)
   align?: Align
   disabled?: boolean
   modelValue: string | null
   displayValue?: string | null
-  hideError?: boolean
-  validation?: Validatable
 }
 
-export type Size = 'mini' | 'small' | 'medium'
 export type Align = 'left' | 'center' | 'right'
-export type CheckColor = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 export type TextColor = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
 
 const props = defineProps<Props>()
 
 const emit = defineEmits<{
-  (e: 'update:model-value', value: string | null): void
-  (e: 'input', value: string | null): void
-  (e: 'blur', value: string | null): void
-  (e: 'enter', value: string | null): void
+  'update:model-value': [value: string | null]
+  'input': [value: string | null]
+  'blur': [value: string | null]
+  'enter': [value: string | null]
 }>()
 
 const input = ref<HTMLElement | null>(null)
 const isFocused = ref(false)
 
 const classes = computed(() => [
-  props.size ?? 'small',
   props.align ?? 'left',
   { disabled: props.disabled }
 ])
@@ -116,6 +101,7 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
   <SInputBase
     class="SInputText"
     :class="classes"
+    :size="size"
     :name="name"
     :label="label"
     :note="note"
@@ -124,8 +110,10 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
     :check-icon="checkIcon"
     :check-text="checkText"
     :check-color="checkColor"
-    :hide-error="hideError"
     :validation="validation"
+    :warning="warning"
+    :hide-error="hideError"
+    :hide-warning="hideWarning"
   >
     <div class="box" :class="{ focus: isFocused }" @click="focus">
       <div v-if="$slots['addon-before']" class="addon before">
@@ -346,6 +334,14 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
   .box:hover,
   .box:focus {
     border-color: var(--input-error-border-color);
+  }
+}
+
+.SInputText.has-warning {
+  .box,
+  .box:hover,
+  .box:focus {
+    border-color: var(--input-warning-border-color);
   }
 }
 

--- a/lib/components/SInputTextarea.vue
+++ b/lib/components/SInputTextarea.vue
@@ -1,42 +1,29 @@
 <script setup lang="ts">
-import { type Component, computed, ref } from 'vue'
-import { type Validatable } from '../composables/Validation'
-import SInputBase from './SInputBase.vue'
+import { computed, ref } from 'vue'
+import SInputBase, { type Props as BaseProps } from './SInputBase.vue'
 import SInputSegments from './SInputSegments.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
-export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
-
-const props = withDefaults(defineProps<{
-  size?: Size
-  name?: string
-  label?: string
-  info?: string
-  note?: string
-  help?: string
-  checkIcon?: Component
-  checkText?: string
-  checkColor?: Color
+export interface Props extends BaseProps {
   placeholder?: string
   disabled?: boolean
   rows?: number | 'fill'
   autoResize?: boolean | number
   value?: string | null
   modelValue?: string | null
-  hideError?: boolean
-  validation?: Validatable
   preview?: (value: string | null) => string
   previewLabel?: string
   writeLabel?: string
-}>(), {
+}
+
+const props = withDefaults(defineProps<Props>(), {
   size: 'small',
   rows: 3
 })
 
 const emit = defineEmits<{
-  (e: 'update:model-value', value: string | null): void
-  (e: 'input', value: string | null): void
-  (e: 'blur', value: string | null): void
+  'update:model-value': [value: string | null]
+  'input': [value: string | null]
+  'blur': [value: string | null]
 }>()
 
 const sizePaddingYDict = {
@@ -93,6 +80,7 @@ const isPreview = ref(false)
   <SInputBase
     class="SInputTextarea"
     :class="classes"
+    :size="size"
     :name="name"
     :label="label"
     :note="note"
@@ -101,8 +89,10 @@ const isPreview = ref(false)
     :check-icon="checkIcon"
     :check-text="checkText"
     :check-color="checkColor"
-    :hide-error="hideError"
     :validation="validation"
+    :warning="warning"
+    :hide-error="hideError"
+    :hide-warning="hideWarning"
   >
     <div class="box">
       <div v-if="preview !== undefined" class="control">
@@ -246,6 +236,12 @@ const isPreview = ref(false)
 .SInputTextarea.has-error {
   .box {
     border-color: var(--input-error-border-color);
+  }
+}
+
+.SInputTextarea.has-warning {
+  .box {
+    border-color: var(--input-warning-border-color);
   }
 }
 </style>

--- a/lib/styles/variables.css
+++ b/lib/styles/variables.css
@@ -858,6 +858,8 @@
   --input-focus-border-color: var(--c-border-info-1);
   --input-error-text-color: var(--c-text-danger-1);
   --input-error-border-color: var(--c-border-danger-1);
+  --input-warning-text-color: var(--c-text-warning-1);
+  --input-warning-border-color: var(--c-border-warning-1);
   --input-disabled-border-color: var(--c-border-mute-1);
   --input-disabled-value-color: var(--c-text-1);
   --input-disabled-bg-color: var(--c-bg-mute-1);

--- a/stories/components/SInputText.01_Playground.story.vue
+++ b/stories/components/SInputText.01_Playground.story.vue
@@ -15,7 +15,7 @@ const { data, init } = useData({
   name: null as string | null
 })
 
-const { validation, validateAndNotify } = useValidation(data, {
+const { validation, validateAndNotify, reset } = useValidation(data, {
   name: {
     required: required()
   }
@@ -53,8 +53,9 @@ async function submit() {
   }
 }
 
-function reset() {
+function onReset() {
   init()
+  reset()
   clearTimeout(timeout)
   inputState.value = undefined
 }
@@ -174,7 +175,7 @@ function state() {
 
         <div class="actions">
           <SButton size="small" mode="info" label="Submit" @click="submit" />
-          <SButton size="small" mode="mute" label="Reset" @click="reset" />
+          <SButton size="small" mode="mute" label="Reset" @click="onReset" />
         </div>
       </Board>
     </template>
@@ -184,7 +185,7 @@ function state() {
 <style scoped>
 .actions {
   display: flex;
-  gap: 12px;
+  gap: 8px;
   padding-top: 24px;
 }
 </style>


### PR DESCRIPTION
I'm not proud of my self but added `:warning` props to text, textarea, and number input components. Also refactored those to use base props exported from base input (there were just so many input to do it in one shot 😅 )

<img width="643" alt="Screenshot 2025-02-21 at 15 28 50" src="https://github.com/user-attachments/assets/4bd46e36-991f-4bf4-be81-5ef7060e4bcc" />
