### PR TITLE
feat(http): support configuring stringify options

### DIFF
--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -81,7 +81,7 @@ Performs a `GET` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  get<T = any>(url: string, options?: FetchOptions): Promise<T>
+  get<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
 }
 ```
 
@@ -93,7 +93,7 @@ Performs a `HEAD` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  head<T = any>(url: string, options?: FetchOptions): Promise<T>
+  head<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
 }
 ```
 
@@ -105,7 +105,7 @@ Performs a `POST` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  post<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
+  post<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
 }
 ```
 
@@ -117,7 +117,7 @@ Performs a `PUT` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  put<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
+  put<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
 }
 ```
 
@@ -129,7 +129,7 @@ Performs a `PATCH` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  patch<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
+  patch<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
 }
 ```
 
@@ -141,7 +141,7 @@ Performs a `DELETE` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  delete<T = any>(url: string, options?: FetchOptions): Promise<T>
+  delete<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
 }
 ```
 
@@ -153,7 +153,7 @@ Performs a `POST` request with `multipart/form-data` content type. Useful for up
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  upload<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
+  upload<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
 }
 ```
 
@@ -165,6 +165,6 @@ Download a file from the response. Use this method when you want browser to save
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  download<T = any>(url: string, options?: FetchOptions): Promise<T>
+  download<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
 }
 ```

--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -87,7 +87,7 @@ Performs a `GET` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  get<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
+  get<T = any>(url: string, options?: FetchOptions): Promise<T>
 }
 ```
 
@@ -99,7 +99,7 @@ Performs a `HEAD` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  head<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
+  head<T = any>(url: string, options?: FetchOptions): Promise<T>
 }
 ```
 
@@ -111,7 +111,7 @@ Performs a `POST` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  post<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
+  post<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
 }
 ```
 
@@ -123,7 +123,7 @@ Performs a `PUT` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  put<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
+  put<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
 }
 ```
 
@@ -135,7 +135,7 @@ Performs a `PATCH` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  patch<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
+  patch<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
 }
 ```
 
@@ -147,7 +147,7 @@ Performs a `DELETE` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  delete<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
+  delete<T = any>(url: string, options?: FetchOptions): Promise<T>
 }
 ```
 
@@ -159,7 +159,7 @@ Performs a `POST` request with `multipart/form-data` content type. Useful for up
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  upload<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
+  upload<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
 }
 ```
 
@@ -171,6 +171,6 @@ Download a file from the response. Use this method when you want browser to save
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  download<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
+  download<T = any>(url: string, options?: FetchOptions): Promise<T>
 }
 ```

--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -70,7 +70,7 @@ interface HttpOptions {
    * 
    * @default {}
    */
-  stringifyOptions?: IStringifyOptions
+  stringifyOptions?: import('qs').IStringifyOptions
 }
 
 interface HttpClient {
@@ -87,7 +87,7 @@ Performs a `GET` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  get<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
+  get<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
 }
 ```
 
@@ -99,7 +99,7 @@ Performs a `HEAD` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  head<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
+  head<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
 }
 ```
 
@@ -111,7 +111,7 @@ Performs a `POST` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  post<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
+  post<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
 }
 ```
 
@@ -123,7 +123,7 @@ Performs a `PUT` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  put<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
+  put<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
 }
 ```
 
@@ -135,7 +135,7 @@ Performs a `PATCH` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  patch<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
+  patch<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
 }
 ```
 
@@ -147,7 +147,7 @@ Performs a `DELETE` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  delete<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
+  delete<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
 }
 ```
 
@@ -159,7 +159,7 @@ Performs a `POST` request with `multipart/form-data` content type. Useful for up
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  upload<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
+  upload<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
 }
 ```
 
@@ -171,6 +171,6 @@ Download a file from the response. Use this method when you want browser to save
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  download<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
+  download<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T>
 }
 ```

--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -65,6 +65,12 @@ interface HttpOptions {
    * @default '__payload__'
    */
   payloadKey?: string
+  /**
+   * The options for the stringify function to create a queryString.
+   * 
+   * @default {}
+   */
+  stringifyOptions?: IStringifyOptions<BooleanOptional>
 }
 
 interface HttpClient {

--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -70,7 +70,7 @@ interface HttpOptions {
    * 
    * @default {}
    */
-  stringifyOptions?: IStringifyOptions<BooleanOptional>
+  stringifyOptions?: IStringifyOptions
 }
 
 interface HttpClient {
@@ -87,7 +87,7 @@ Performs a `GET` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  get<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
+  get<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
 }
 ```
 
@@ -99,7 +99,7 @@ Performs a `HEAD` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  head<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
+  head<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
 }
 ```
 
@@ -111,7 +111,7 @@ Performs a `POST` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  post<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
+  post<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
 }
 ```
 
@@ -123,7 +123,7 @@ Performs a `PUT` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  put<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
+  put<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
 }
 ```
 
@@ -135,7 +135,7 @@ Performs a `PATCH` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  patch<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
+  patch<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
 }
 ```
 
@@ -147,7 +147,7 @@ Performs a `DELETE` request.
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  delete<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
+  delete<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
 }
 ```
 
@@ -159,7 +159,7 @@ Performs a `POST` request with `multipart/form-data` content type. Useful for up
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  upload<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
+  upload<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
 }
 ```
 
@@ -171,6 +171,6 @@ Download a file from the response. Use this method when you want browser to save
 import { type FetchOptions } from 'ofetch'
 
 class Http {
-  download<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T>
+  download<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions): Promise<T>
 }
 ```

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -71,8 +71,8 @@ export class Http {
     return xsrfToken
   }
 
-  private async buildRequest(url: string, fetchOptions: FetchOptions = {}): Promise<[string, FetchOptions]> {
-    const { method, params, query, ...options } = fetchOptions
+  private async buildRequest(url: string, _options: FetchOptions = {}): Promise<[string, FetchOptions]> {
+    const { method, params, query, ...options } = _options
     const xsrfToken = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '') && (await this.ensureXsrfToken())
 
     const queryString = stringify({ ...params, ...query }, { encodeValuesOnly: true, ...Http.stringifyOptions })
@@ -95,23 +95,23 @@ export class Http {
     ]
   }
 
-  private async performRequest<T>(url: string, fetchOptions: FetchOptions = {}): Promise<T> {
-    return Http.client(...(await this.buildRequest(url, fetchOptions)))
+  private async performRequest<T>(url: string, options: FetchOptions = {}): Promise<T> {
+    return Http.client(...(await this.buildRequest(url, options)))
   }
 
-  private async performRequestRaw<T>(url: string, fetchOptions: FetchOptions = {}): Promise<FetchResponse<T>> {
-    return Http.client.raw(...(await this.buildRequest(url, fetchOptions)))
+  private async performRequestRaw<T>(url: string, options: FetchOptions = {}): Promise<FetchResponse<T>> {
+    return Http.client.raw(...(await this.buildRequest(url, options)))
   }
 
-  async get<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T> {
-    return this.performRequest<T>(url, { method: 'GET', ...fetchOptions })
+  async get<T = any>(url: string, options?: FetchOptions): Promise<T> {
+    return this.performRequest<T>(url, { method: 'GET', ...options })
   }
 
-  async head<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T> {
-    return this.performRequest<T>(url, { method: 'HEAD', ...fetchOptions })
+  async head<T = any>(url: string, options?: FetchOptions): Promise<T> {
+    return this.performRequest<T>(url, { method: 'HEAD', ...options })
   }
 
-  async post<T = any>(url: string, body?: any, fetchOptions?: FetchOptions): Promise<T> {
+  async post<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T> {
     if (body && !isFormData(body)) {
       let hasFile = false
 
@@ -132,30 +132,30 @@ export class Http {
       }
     }
 
-    return this.performRequest<T>(url, { method: 'POST', body, ...fetchOptions })
+    return this.performRequest<T>(url, { method: 'POST', body, ...options })
   }
 
-  async put<T = any>(url: string, body?: any, fetchOptions?: FetchOptions): Promise<T> {
-    return this.performRequest<T>(url, { method: 'PUT', body, ...fetchOptions })
+  async put<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T> {
+    return this.performRequest<T>(url, { method: 'PUT', body, ...options })
   }
 
-  async patch<T = any>(url: string, body?: any, fetchOptions?: FetchOptions): Promise<T> {
-    return this.performRequest<T>(url, { method: 'PATCH', body, ...fetchOptions })
+  async patch<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T> {
+    return this.performRequest<T>(url, { method: 'PATCH', body, ...options })
   }
 
-  async delete<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T> {
-    return this.performRequest<T>(url, { method: 'DELETE', ...fetchOptions })
+  async delete<T = any>(url: string, options?: FetchOptions): Promise<T> {
+    return this.performRequest<T>(url, { method: 'DELETE', ...options })
   }
 
-  async upload<T = any>(url: string, body?: any, fetchOptions?: FetchOptions): Promise<T> {
-    return this.post<T>(url, this.objectToFormData(body), fetchOptions)
+  async upload<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T> {
+    return this.post<T>(url, this.objectToFormData(body), options)
   }
 
-  async download(url: string, fetchOptions?: FetchOptions): Promise<void> {
+  async download(url: string, options?: FetchOptions): Promise<void> {
     const { _data: blob, headers } = await this.performRequestRaw<Blob>(url, {
       method: 'GET',
       responseType: 'blob',
-      ...fetchOptions
+      ...options
     })
 
     if (!blob) {

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -1,13 +1,7 @@
 import { parse as parseContentDisposition } from '@tinyhttp/content-disposition'
 import { parse as parseCookie } from '@tinyhttp/cookie'
 import FileSaver from 'file-saver'
-import {
-  FetchError,
-  type FetchOptions,
-  type FetchRequest,
-  type FetchResponse,
-  ofetch
-} from 'ofetch'
+import { FetchError, type FetchOptions, type FetchRequest, type FetchResponse, ofetch } from 'ofetch'
 import { type IStringifyOptions, stringify } from 'qs'
 import { type Lang } from '../composables/Lang'
 import { isBlob, isError, isFormData, isRequest, isResponse, isString } from '../support/Utils'
@@ -77,19 +71,11 @@ export class Http {
     return xsrfToken
   }
 
-  private async buildRequest(
-    url: string,
-    fetchOptions: FetchOptions = {},
-    stringifyOptions: IStringifyOptions = {}
-  ): Promise<[string, FetchOptions]> {
+  private async buildRequest(url: string, fetchOptions: FetchOptions = {}): Promise<[string, FetchOptions]> {
     const { method, params, query, ...options } = fetchOptions
-    const xsrfToken
-      = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '') && (await this.ensureXsrfToken())
+    const xsrfToken = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '') && (await this.ensureXsrfToken())
 
-    const queryString = stringify(
-      { ...params, ...query },
-      { encodeValuesOnly: true, ...Http.stringifyOptions, ...stringifyOptions }
-    )
+    const queryString = stringify({ ...params, ...query }, { encodeValuesOnly: true, ...Http.stringifyOptions })
 
     return [
       `${url}${queryString ? `?${queryString}` : ''}`,
@@ -109,44 +95,23 @@ export class Http {
     ]
   }
 
-  private async performRequest<T>(
-    url: string,
-    fetchOptions: FetchOptions = {},
-    stringifyOptions: IStringifyOptions = {}
-  ): Promise<T> {
-    return Http.client(...(await this.buildRequest(url, fetchOptions, stringifyOptions)))
+  private async performRequest<T>(url: string, fetchOptions: FetchOptions = {}): Promise<T> {
+    return Http.client(...(await this.buildRequest(url, fetchOptions)))
   }
 
-  private async performRequestRaw<T>(
-    url: string,
-    fetchOptions: FetchOptions = {},
-    stringifyOptions: IStringifyOptions = {}
-  ): Promise<FetchResponse<T>> {
-    return Http.client.raw(...(await this.buildRequest(url, fetchOptions, stringifyOptions)))
+  private async performRequestRaw<T>(url: string, fetchOptions: FetchOptions = {}): Promise<FetchResponse<T>> {
+    return Http.client.raw(...(await this.buildRequest(url, fetchOptions)))
   }
 
-  async get<T = any>(
-    url: string,
-    fetchOptions?: FetchOptions,
-    stringifyOptions?: IStringifyOptions
-  ): Promise<T> {
-    return this.performRequest<T>(url, { method: 'GET', ...fetchOptions }, stringifyOptions)
+  async get<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T> {
+    return this.performRequest<T>(url, { method: 'GET', ...fetchOptions })
   }
 
-  async head<T = any>(
-    url: string,
-    fetchOptions?: FetchOptions,
-    stringifyOptions?: IStringifyOptions
-  ): Promise<T> {
-    return this.performRequest<T>(url, { method: 'HEAD', ...fetchOptions }, stringifyOptions)
+  async head<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T> {
+    return this.performRequest<T>(url, { method: 'HEAD', ...fetchOptions })
   }
 
-  async post<T = any>(
-    url: string,
-    body?: any,
-    fetchOptions?: FetchOptions,
-    stringifyOptions?: IStringifyOptions
-  ): Promise<T> {
+  async post<T = any>(url: string, body?: any, fetchOptions?: FetchOptions): Promise<T> {
     if (body && !isFormData(body)) {
       let hasFile = false
 
@@ -167,54 +132,31 @@ export class Http {
       }
     }
 
-    return this.performRequest<T>(url, { method: 'POST', body, ...fetchOptions }, stringifyOptions)
+    return this.performRequest<T>(url, { method: 'POST', body, ...fetchOptions })
   }
 
-  async put<T = any>(
-    url: string,
-    body?: any,
-    fetchOptions?: FetchOptions,
-    stringifyOptions?: IStringifyOptions
-  ): Promise<T> {
-    return this.performRequest<T>(url, { method: 'PUT', body, ...fetchOptions }, stringifyOptions)
+  async put<T = any>(url: string, body?: any, fetchOptions?: FetchOptions): Promise<T> {
+    return this.performRequest<T>(url, { method: 'PUT', body, ...fetchOptions })
   }
 
-  async patch<T = any>(
-    url: string,
-    body?: any,
-    fetchOptions?: FetchOptions,
-    stringifyOptions?: IStringifyOptions
-  ): Promise<T> {
-    return this.performRequest<T>(url, { method: 'PATCH', body, ...fetchOptions }, stringifyOptions)
+  async patch<T = any>(url: string, body?: any, fetchOptions?: FetchOptions): Promise<T> {
+    return this.performRequest<T>(url, { method: 'PATCH', body, ...fetchOptions })
   }
 
-  async delete<T = any>(
-    url: string,
-    fetchOptions?: FetchOptions,
-    stringifyOptions?: IStringifyOptions
-  ): Promise<T> {
-    return this.performRequest<T>(url, { method: 'DELETE', ...fetchOptions }, stringifyOptions)
+  async delete<T = any>(url: string, fetchOptions?: FetchOptions): Promise<T> {
+    return this.performRequest<T>(url, { method: 'DELETE', ...fetchOptions })
   }
 
-  async upload<T = any>(
-    url: string,
-    body?: any,
-    fetchOptions?: FetchOptions,
-    stringifyOptions?: IStringifyOptions
-  ): Promise<T> {
-    return this.post<T>(url, this.objectToFormData(body), fetchOptions, stringifyOptions)
+  async upload<T = any>(url: string, body?: any, fetchOptions?: FetchOptions): Promise<T> {
+    return this.post<T>(url, this.objectToFormData(body), fetchOptions)
   }
 
-  async download(
-    url: string,
-    fetchOptions?: FetchOptions,
-    stringifyOptions?: IStringifyOptions
-  ): Promise<void> {
-    const { _data: blob, headers } = await this.performRequestRaw<Blob>(
-      url,
-      { method: 'GET', responseType: 'blob', ...fetchOptions },
-      stringifyOptions
-    )
+  async download(url: string, fetchOptions?: FetchOptions): Promise<void> {
+    const { _data: blob, headers } = await this.performRequestRaw<Blob>(url, {
+      method: 'GET',
+      responseType: 'blob',
+      ...fetchOptions
+    })
 
     if (!blob) {
       throw new Error('No blob')
@@ -226,12 +168,7 @@ export class Http {
     FileSaver.saveAs(blob, filename as string)
   }
 
-  private objectToFormData(
-    obj: any,
-    form?: FormData,
-    namespace?: string,
-    onlyFiles = false
-  ): FormData {
+  private objectToFormData(obj: any, form?: FormData, namespace?: string, onlyFiles = false): FormData {
     const fd = form || new FormData()
     let formKey: string
 
@@ -264,20 +201,10 @@ export class Http {
 export function isFetchError(e: unknown): e is FetchError {
   return (
     e instanceof FetchError
-    || (isError(e)
-      && (isString((e as FetchError).request) || isRequest((e as FetchError).request))
-      && ((e as FetchError).response === undefined || isResponse((e as FetchError).response))
-      && e.message.startsWith(
-        `[${
-          ((e as FetchError).request as Request | undefined)?.method
-          || (e as FetchError).options?.method
-          || 'GET'
-        }] ${JSON.stringify(
-          ((e as FetchError).request as Request | undefined)?.url
-            || String((e as FetchError).request)
-            || '/'
-        )}: `
-      ))
+    || (isError<FetchError>(e)
+      && (e.response === undefined || isResponse(e.response))
+      && ((isString(e.request) && e.message.startsWith(`[${e.options?.method || 'GET'}] ${e.request || '/'}: `))
+        || (isRequest(e.request) && e.message.startsWith(`[${e.request.method}] ${e.request.url}: `))))
   )
 }
 

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -1,8 +1,14 @@
 import { parse as parseContentDisposition } from '@tinyhttp/content-disposition'
 import { parse as parseCookie } from '@tinyhttp/cookie'
 import FileSaver from 'file-saver'
-import { FetchError, type FetchOptions, type FetchRequest, type FetchResponse, ofetch } from 'ofetch'
-import { type BooleanOptional, type IStringifyOptions, stringify } from 'qs'
+import {
+  FetchError,
+  type FetchOptions,
+  type FetchRequest,
+  type FetchResponse,
+  ofetch
+} from 'ofetch'
+import { type IStringifyOptions, stringify } from 'qs'
 import { type Lang } from '../composables/Lang'
 import { isBlob, isError, isFormData, isRequest, isResponse, isString } from '../support/Utils'
 
@@ -20,7 +26,7 @@ export interface HttpOptions {
   lang?: Lang
   payloadKey?: string
   headers?: () => Awaitable<Record<string, string>>
-  stringifyOptions?: IStringifyOptions<BooleanOptional>
+  stringifyOptions?: IStringifyOptions
 }
 
 export class Http {
@@ -30,7 +36,7 @@ export class Http {
   private static lang: Lang | undefined = undefined
   private static payloadKey = '__payload__'
   private static headers: () => Awaitable<Record<string, string>> = async () => ({})
-  private static stringifyOptions: IStringifyOptions<BooleanOptional> = {}
+  private static stringifyOptions: IStringifyOptions = {}
 
   static config(options: HttpOptions): void {
     if (options.baseUrl) {
@@ -71,10 +77,19 @@ export class Http {
     return xsrfToken
   }
 
-  private async buildRequest(url: string, fetchOptions: FetchOptions = {}, stringifyOptions: IStringifyOptions<BooleanOptional> = {}): Promise<[string, FetchOptions]> {
+  private async buildRequest(
+    url: string,
+    fetchOptions: FetchOptions = {},
+    stringifyOptions: IStringifyOptions = {}
+  ): Promise<[string, FetchOptions]> {
     const { method, params, query, ...options } = fetchOptions
-    const xsrfToken = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '') && (await this.ensureXsrfToken())
-    const queryString = stringify({ ...params, ...query }, { encodeValuesOnly: true, ...Http.stringifyOptions, ...stringifyOptions })
+    const xsrfToken
+      = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '') && (await this.ensureXsrfToken())
+
+    const queryString = stringify(
+      { ...params, ...query },
+      { encodeValuesOnly: true, ...Http.stringifyOptions, ...stringifyOptions }
+    )
 
     return [
       `${url}${queryString ? `?${queryString}` : ''}`,
@@ -94,23 +109,44 @@ export class Http {
     ]
   }
 
-  private async performRequest<T>(url: string, fetchOptions: FetchOptions = {}, stringifyOptions: IStringifyOptions<BooleanOptional> = {}): Promise<T> {
+  private async performRequest<T>(
+    url: string,
+    fetchOptions: FetchOptions = {},
+    stringifyOptions: IStringifyOptions = {}
+  ): Promise<T> {
     return Http.client(...(await this.buildRequest(url, fetchOptions, stringifyOptions)))
   }
 
-  private async performRequestRaw<T>(url: string, fetchOptions: FetchOptions = {}, stringifyOptions: IStringifyOptions<BooleanOptional> = {}): Promise<FetchResponse<T>> {
+  private async performRequestRaw<T>(
+    url: string,
+    fetchOptions: FetchOptions = {},
+    stringifyOptions: IStringifyOptions = {}
+  ): Promise<FetchResponse<T>> {
     return Http.client.raw(...(await this.buildRequest(url, fetchOptions, stringifyOptions)))
   }
 
-  async get<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T> {
+  async get<T = any>(
+    url: string,
+    fetchOptions?: FetchOptions,
+    stringifyOptions?: IStringifyOptions
+  ): Promise<T> {
     return this.performRequest<T>(url, { method: 'GET', ...fetchOptions }, stringifyOptions)
   }
 
-  async head<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T> {
+  async head<T = any>(
+    url: string,
+    fetchOptions?: FetchOptions,
+    stringifyOptions?: IStringifyOptions
+  ): Promise<T> {
     return this.performRequest<T>(url, { method: 'HEAD', ...fetchOptions }, stringifyOptions)
   }
 
-  async post<T = any>(url: string, body?: any, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T> {
+  async post<T = any>(
+    url: string,
+    body?: any,
+    fetchOptions?: FetchOptions,
+    stringifyOptions?: IStringifyOptions
+  ): Promise<T> {
     if (body && !isFormData(body)) {
       let hasFile = false
 
@@ -134,28 +170,51 @@ export class Http {
     return this.performRequest<T>(url, { method: 'POST', body, ...fetchOptions }, stringifyOptions)
   }
 
-  async put<T = any>(url: string, body?: any, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T> {
+  async put<T = any>(
+    url: string,
+    body?: any,
+    fetchOptions?: FetchOptions,
+    stringifyOptions?: IStringifyOptions
+  ): Promise<T> {
     return this.performRequest<T>(url, { method: 'PUT', body, ...fetchOptions }, stringifyOptions)
   }
 
-  async patch<T = any>(url: string, body?: any, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T> {
+  async patch<T = any>(
+    url: string,
+    body?: any,
+    fetchOptions?: FetchOptions,
+    stringifyOptions?: IStringifyOptions
+  ): Promise<T> {
     return this.performRequest<T>(url, { method: 'PATCH', body, ...fetchOptions }, stringifyOptions)
   }
 
-  async delete<T = any>(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T> {
+  async delete<T = any>(
+    url: string,
+    fetchOptions?: FetchOptions,
+    stringifyOptions?: IStringifyOptions
+  ): Promise<T> {
     return this.performRequest<T>(url, { method: 'DELETE', ...fetchOptions }, stringifyOptions)
   }
 
-  async upload<T = any>(url: string, body?: any, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<T> {
+  async upload<T = any>(
+    url: string,
+    body?: any,
+    fetchOptions?: FetchOptions,
+    stringifyOptions?: IStringifyOptions
+  ): Promise<T> {
     return this.post<T>(url, this.objectToFormData(body), fetchOptions, stringifyOptions)
   }
 
-  async download(url: string, fetchOptions?: FetchOptions, stringifyOptions?: IStringifyOptions<BooleanOptional>): Promise<void> {
-    const { _data: blob, headers } = await this.performRequestRaw<Blob>(url, {
-      method: 'GET',
-      responseType: 'blob',
-      ...fetchOptions
-    }, stringifyOptions)
+  async download(
+    url: string,
+    fetchOptions?: FetchOptions,
+    stringifyOptions?: IStringifyOptions
+  ): Promise<void> {
+    const { _data: blob, headers } = await this.performRequestRaw<Blob>(
+      url,
+      { method: 'GET', responseType: 'blob', ...fetchOptions },
+      stringifyOptions
+    )
 
     if (!blob) {
       throw new Error('No blob')
@@ -167,7 +226,12 @@ export class Http {
     FileSaver.saveAs(blob, filename as string)
   }
 
-  private objectToFormData(obj: any, form?: FormData, namespace?: string, onlyFiles = false): FormData {
+  private objectToFormData(
+    obj: any,
+    form?: FormData,
+    namespace?: string,
+    onlyFiles = false
+  ): FormData {
     const fd = form || new FormData()
     let formKey: string
 
@@ -205,9 +269,13 @@ export function isFetchError(e: unknown): e is FetchError {
       && ((e as FetchError).response === undefined || isResponse((e as FetchError).response))
       && e.message.startsWith(
         `[${
-          ((e as FetchError).request as Request | undefined)?.method || (e as FetchError).options?.method || 'GET'
+          ((e as FetchError).request as Request | undefined)?.method
+          || (e as FetchError).options?.method
+          || 'GET'
         }] ${JSON.stringify(
-          ((e as FetchError).request as Request | undefined)?.url || String((e as FetchError).request) || '/'
+          ((e as FetchError).request as Request | undefined)?.url
+            || String((e as FetchError).request)
+            || '/'
         )}: `
       ))
   )

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -203,8 +203,8 @@ export function isFetchError(e: unknown): e is FetchError {
     e instanceof FetchError
     || (isError<FetchError>(e)
       && (e.response === undefined || isResponse(e.response))
-      && ((isString(e.request) && e.message.startsWith(`[${e.options?.method || 'GET'}] ${e.request || '/'}: `))
-        || (isRequest(e.request) && e.message.startsWith(`[${e.request.method}] ${e.request.url}: `))))
+      && ((isString(e.request) && e.message.startsWith(`[${e.options?.method || 'GET'}] ${JSON.stringify(e.request || '/')}: `))
+        || (isRequest(e.request) && e.message.startsWith(`[${e.request.method}] ${JSON.stringify(e.request.url)}: `))))
   )
 }
 

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -19,6 +19,7 @@ export interface HttpOptions {
   client?: HttpClient
   lang?: Lang
   payloadKey?: string
+  stringifyOptions?: IStringifyOptions<BooleanOptional>
   headers?: () => Awaitable<Record<string, string>>
 }
 
@@ -28,6 +29,7 @@ export class Http {
   private static client: HttpClient = ofetch
   private static lang: Lang | undefined = undefined
   private static payloadKey = '__payload__'
+  private static stringifyOptions: IStringifyOptions<BooleanOptional> = {}
   private static headers: () => Awaitable<Record<string, string>> = async () => ({})
 
   static config(options: HttpOptions): void {
@@ -45,6 +47,9 @@ export class Http {
     }
     if (options.payloadKey) {
       Http.payloadKey = options.payloadKey
+    }
+    if (options.stringifyOptions) {
+      Http.stringifyOptions = options.stringifyOptions
     }
     if (options.headers) {
       Http.headers = options.headers
@@ -69,7 +74,7 @@ export class Http {
   private async buildRequest(url: string, fetchOptions: FetchOptions = {}, stringifyOptions: IStringifyOptions<BooleanOptional> = {}): Promise<[string, FetchOptions]> {
     const { method, params, query, ...options } = fetchOptions
     const xsrfToken = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '') && (await this.ensureXsrfToken())
-    const queryString = stringify({ ...params, ...query }, { encodeValuesOnly: true, ...stringifyOptions })
+    const queryString = stringify({ ...params, ...query }, { encodeValuesOnly: true, ...Http.stringifyOptions, ...stringifyOptions } as IStringifyOptions<BooleanOptional>)
 
     return [
       `${url}${queryString ? `?${queryString}` : ''}`,

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -19,8 +19,8 @@ export interface HttpOptions {
   client?: HttpClient
   lang?: Lang
   payloadKey?: string
-  stringifyOptions?: IStringifyOptions<BooleanOptional>
   headers?: () => Awaitable<Record<string, string>>
+  stringifyOptions?: IStringifyOptions<BooleanOptional>
 }
 
 export class Http {
@@ -29,8 +29,8 @@ export class Http {
   private static client: HttpClient = ofetch
   private static lang: Lang | undefined = undefined
   private static payloadKey = '__payload__'
-  private static stringifyOptions: IStringifyOptions<BooleanOptional> = {}
   private static headers: () => Awaitable<Record<string, string>> = async () => ({})
+  private static stringifyOptions: IStringifyOptions<BooleanOptional> = {}
 
   static config(options: HttpOptions): void {
     if (options.baseUrl) {
@@ -48,11 +48,11 @@ export class Http {
     if (options.payloadKey) {
       Http.payloadKey = options.payloadKey
     }
-    if (options.stringifyOptions) {
-      Http.stringifyOptions = options.stringifyOptions
-    }
     if (options.headers) {
       Http.headers = options.headers
+    }
+    if (options.stringifyOptions) {
+      Http.stringifyOptions = options.stringifyOptions
     }
   }
 
@@ -74,7 +74,7 @@ export class Http {
   private async buildRequest(url: string, fetchOptions: FetchOptions = {}, stringifyOptions: IStringifyOptions<BooleanOptional> = {}): Promise<[string, FetchOptions]> {
     const { method, params, query, ...options } = fetchOptions
     const xsrfToken = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '') && (await this.ensureXsrfToken())
-    const queryString = stringify({ ...params, ...query }, { encodeValuesOnly: true, ...Http.stringifyOptions, ...stringifyOptions } as IStringifyOptions<BooleanOptional>)
+    const queryString = stringify({ ...params, ...query }, { encodeValuesOnly: true, ...Http.stringifyOptions, ...stringifyOptions })
 
     return [
       `${url}${queryString ? `?${queryString}` : ''}`,

--- a/lib/support/Utils.ts
+++ b/lib/support/Utils.ts
@@ -16,7 +16,7 @@ export function isDate(value: unknown): value is Date {
   return _isDate(value)
 }
 
-export function isError(value: unknown): value is Error {
+export function isError<T extends Error = Error>(value: unknown): value is T {
   return _isError(value)
 }
 


### PR DESCRIPTION
In some cases, we'd like to pass options to the stringify method when processing query parameters for HTTP requests.
For example, some servers accept array query parameters in the format `a=b&a=c&a=d`, while others require a different format like `a[0]=b&a[1]=c&a[2]=d`.
In such cases, we'd like to pass the `arrayFormat` option to the stringify method.