### PR TITLE
fix: directly use `html[lang]` in rules

### DIFF
--- a/lib/composables/Lang.ts
+++ b/lib/composables/Lang.ts
@@ -30,9 +30,7 @@ export function provideLang(lang: Lang) {
 }
 
 export function useLang(): Lang {
-  // Doing `||` check here because for some reason it doesn't return
-  // the default value in tests but becomes `undefined`.
-  return inject(SefirotLangKey, 'en') || 'en'
+  return inject(SefirotLangKey, 'en')
 }
 
 export function useBrowserLang(): Lang {

--- a/lib/validation/Rule.ts
+++ b/lib/validation/Rule.ts
@@ -1,6 +1,6 @@
 import { type ValidationRuleWithParams } from '@vuelidate/core'
 import { type MessageProps as VMessageProps, helpers } from '@vuelidate/validators'
-import { type Lang, useLang } from '../composables/Lang'
+import { type Lang } from '../composables/Lang'
 import { _required } from './validators'
 
 export interface RuleOptions {
@@ -18,7 +18,9 @@ export interface MessageProps extends VMessageProps {
 export function createRule(
   options: RuleOptions
 ): ValidationRuleWithParams {
-  const lang = useLang()
+  const lang = typeof document !== 'undefined'
+    ? (document.documentElement.lang === 'ja' ? 'ja' : 'en')
+    : 'en'
 
   const params = options.params ?? {}
 


### PR DESCRIPTION
as they can be called without component instance and useLang won't work since it relies on provide/inject pattern