### PR TITLE
feat(style): add new bg color scheme and update pill and state style

### DIFF
--- a/lib/components/SState.vue
+++ b/lib/components/SState.vue
@@ -28,10 +28,10 @@ const classes = computed(() => [
 .SState {
   display: inline-flex;
   align-items: center;
-  border: 1px solid var(--c-border-mute-1);
+  border: 1px solid var(--c-divider);
   font-weight: 500;
   white-space: nowrap;
-  background-color: var(--c-bg-mute-1);
+  background-color: transparent;
 }
 
 .SState.mini {

--- a/lib/styles/variables.css
+++ b/lib/styles/variables.css
@@ -229,6 +229,10 @@
  * -------------------------------------------------------------------------- */
 
 :root {
+  --c-bg-1: var(--c-white);
+  --c-bg-2: var(--c-gray-3);
+  --c-bg-3: var(--c-gray-4);
+
   --c-bg-elv-1: #ffffff;
   --c-bg-elv-2: #f5f5f7;
   --c-bg-elv-3: #ffffff;
@@ -264,6 +268,10 @@
 }
 
 .dark {
+  --c-bg-1: var(--c-gray-1);
+  --c-bg-2: var(--c-gray-3);
+  --c-bg-3: var(--c-gray-4);
+
   --c-bg-elv-1: #000000;
   --c-bg-elv-2: #151517;
   --c-bg-elv-3: #1b1b1f;
@@ -719,17 +727,17 @@
  * -------------------------------------------------------------------------- */
 
 :root {
-  --pill-dimm-default-border-color: var(--c-border-mute-1);
+  --pill-dimm-default-border-color: var(--c-divider);
   --pill-dimm-default-text-color: var(--c-text-1);
-  --pill-dimm-default-bg-color: var(--c-bg-mute-1);
-  --pill-dimm-default-hover-bg-color: var(--c-bg-mute-2);
-  --pill-dimm-default-active-bg-color: var(--c-bg-mute-3);
+  --pill-dimm-default-bg-color: transparent;
+  --pill-dimm-default-hover-bg-color: var(--c-bg-2);
+  --pill-dimm-default-active-bg-color: var(--c-bg-3);
 
-  --pill-dimm-mute-border-color: var(--c-border-mute-1);
+  --pill-dimm-mute-border-color: var(--c-divider);
   --pill-dimm-mute-text-color: var(--c-text-2);
-  --pill-dimm-mute-bg-color: var(--c-bg-mute-1);
-  --pill-dimm-mute-hover-bg-color: var(--c-bg-mute-2);
-  --pill-dimm-mute-active-bg-color: var(--c-bg-mute-3);
+  --pill-dimm-mute-bg-color: transparent;
+  --pill-dimm-mute-hover-bg-color: var(--c-bg-2);
+  --pill-dimm-mute-active-bg-color: var(--c-bg-3);
 
   --pill-dimm-neutral-border-color: var(--c-neutral-1);
   --pill-dimm-neutral-text-color: var(--c-text-inverse-1);


### PR DESCRIPTION
In order to adhere the latest style. Basically transparent BG.

<img width="602" alt="Screenshot 2025-04-30 at 12 02 21" src="https://github.com/user-attachments/assets/c5643ebe-c22e-4d65-8b9c-b157e1aaa2e9" />

<img width="434" alt="Screenshot 2025-04-30 at 12 02 27" src="https://github.com/user-attachments/assets/93535419-6b74-4d3f-a153-eec7f0393254" />
