### PR TITLE
fix(input-select): apply `:size` prop

### DIFF
--- a/lib/components/SInputBase.vue
+++ b/lib/components/SInputBase.vue
@@ -197,7 +197,7 @@ function getErrorMsg(validation: Validatable) {
   width: 100%;
   max-width: 65ch;
   margin: 0;
-  padding: 6px 0 0 0;
+  padding: 4px 0 0 0;
   line-height: 20px;
   font-size: 12px;
   font-weight: 400;

--- a/lib/components/SInputSelect.vue
+++ b/lib/components/SInputSelect.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
 import IconCaretDown from '~icons/ph/caret-down-bold'
 import IconCaretUp from '~icons/ph/caret-up-bold'
-import { type Component, computed, ref } from 'vue'
-import { type Validatable } from '../composables/Validation'
-import SInputBase from './SInputBase.vue'
+import { computed, ref } from 'vue'
+import SInputBase, { type Props as BaseProps } from './SInputBase.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
-export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
+export interface Props extends BaseProps {
+  placeholder?: string
+  options: Option[]
+  nullable?: boolean
+  disabled?: boolean
+  value?: Value
+  modelValue?: Value
+}
+
 export type Value = any
 
 export interface Option {
@@ -15,24 +21,7 @@ export interface Option {
   disabled?: boolean
 }
 
-const props = withDefaults(defineProps<{
-  size?: Size
-  label?: string
-  info?: string
-  note?: string
-  help?: string
-  placeholder?: string
-  checkIcon?: Component
-  checkText?: string
-  checkColor?: Color
-  options: Option[]
-  nullable?: boolean
-  disabled?: boolean
-  value?: Value
-  modelValue?: Value
-  validation?: Validatable
-  hideError?: boolean
-}>(), {
+const props = withDefaults(defineProps<Props>(), {
   value: undefined,
   modelValue: undefined
 })
@@ -80,10 +69,11 @@ function emitChange(e: any): void {
   <SInputBase
     class="SInputSelect"
     :class="classes"
-    :label="label"
-    :note="note"
-    :info="info"
-    :help="help"
+    :size
+    :label
+    :note
+    :info
+    :help
     :check-icon="checkIcon"
     :check-text="checkText"
     :check-color="checkColor"


### PR DESCRIPTION
`:size` was not working for `<SInputSelect>` so fixing it. Also;

- Use BaseProp from `<SInputBase>`
- Adjust "help" text padding top `6px` -> `4px` (just a styling issue I noticed).