### PR TITLE
feat(pagination): add disabled prop to SPagination and SControlPagination

### DIFF
--- a/docs/components/control.md
+++ b/docs/components/control.md
@@ -339,6 +339,7 @@ import { type Size } from '@globalbrain/sefirot/lib/components/SPagination.vue'
 
 interface Props {
   size?: Size
+  disabled?: boolean
   total: number
   page: number
   perPage: number

--- a/lib/components/SControlPagination.vue
+++ b/lib/components/SControlPagination.vue
@@ -4,6 +4,7 @@ import SPagination, { type Size } from './SPagination.vue'
 
 defineProps<{
   size?: Size
+  disabled?: boolean
   total: number
   page: number
   perPage: number
@@ -22,6 +23,7 @@ const position = useControlPosition()
   <div class="SControlPagination">
     <SPagination
       :size
+      :disabled
       :align="position"
       :total
       :page

--- a/lib/components/SPagination.vue
+++ b/lib/components/SPagination.vue
@@ -11,12 +11,14 @@ export type Align = 'left' | 'center' | 'right'
 
 const props = withDefaults(defineProps<{
   size?: Size
+  disabled?: boolean
   align?: Align
   total: number
   page: number
   perPage: number
 }>(), {
   size: 'medium',
+  disabled: false,
   align: 'center'
 })
 
@@ -49,11 +51,11 @@ const hasNext = computed(() => {
 })
 
 function prev() {
-  hasPrev.value && emit('prev')
+  !props.disabled && hasPrev.value && emit('prev')
 }
 
 function next() {
-  hasNext.value && emit('next')
+  !props.disabled && hasNext.value && emit('next')
 }
 </script>
 
@@ -66,7 +68,7 @@ function next() {
         :size
         :lead-icon="IconCaretLeft"
         :label="t.prev"
-        :disabled="!hasPrev"
+        :disabled="disabled || !hasPrev"
         @click="prev"
       />
     </div>
@@ -80,7 +82,7 @@ function next() {
         :size
         :trail-icon="IconCaretRight"
         :label="t.next"
-        :disabled="!hasNext"
+        :disabled="disabled || !hasNext"
         @click="next"
       />
     </div>

--- a/lib/components/SPagination.vue
+++ b/lib/components/SPagination.vue
@@ -22,7 +22,7 @@ const props = withDefaults(defineProps<{
   align: 'center'
 })
 
-const emit = defineEmits<{
+defineEmits<{
   prev: []
   next: []
 }>()
@@ -49,14 +49,6 @@ const hasPrev = computed(() => {
 const hasNext = computed(() => {
   return to.value < props.total
 })
-
-function prev() {
-  hasPrev.value && emit('prev')
-}
-
-function next() {
-  hasNext.value && emit('next')
-}
 </script>
 
 <template>
@@ -69,7 +61,7 @@ function next() {
         :lead-icon="IconCaretLeft"
         :label="t.prev"
         :disabled="disabled || !hasPrev"
-        @click="prev"
+        @click="$emit('prev')"
       />
     </div>
     <div class="text">
@@ -83,7 +75,7 @@ function next() {
         :trail-icon="IconCaretRight"
         :label="t.next"
         :disabled="disabled || !hasNext"
-        @click="next"
+        @click="$emit('next')"
       />
     </div>
   </div>

--- a/lib/components/SPagination.vue
+++ b/lib/components/SPagination.vue
@@ -51,11 +51,11 @@ const hasNext = computed(() => {
 })
 
 function prev() {
-  !props.disabled && hasPrev.value && emit('prev')
+  hasPrev.value && emit('prev')
 }
 
 function next() {
-  !props.disabled && hasNext.value && emit('next')
+  hasNext.value && emit('next')
 }
 </script>
 


### PR DESCRIPTION
There are some cases where we want to explicitly disable the pagination buttons (the "prev" and "next" buttons), such as when waiting for a network request to complete.

To handle this, add a `disabled` prop to `SPagination` and `SControlPagination`.