### PR TITLE
feat(data-list): introduce `<SDataList>`

### DIFF
--- a/lib/components/SDataList.vue
+++ b/lib/components/SDataList.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { provideDataListState } from '../composables/DataList'
+
+const props = withDefaults(defineProps<{
+  labelWidth?: string
+}>(), {
+  labelWidth: '128px'
+})
+
+provideDataListState({
+  labelWidth: computed(() => props.labelWidth)
+})
+</script>
+
+<template>
+  <div class="SDataList">
+    <slot />
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SDataList :deep(.SDataListItem::after),
+.SDataList :deep(.SDataListItem:first-child::before) {
+  display: block;
+  border-top: 1px dashed var(--c-divider);
+  width: 100%;
+  content: "";
+}
+</style>

--- a/lib/components/SDataListItem.vue
+++ b/lib/components/SDataListItem.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { Comment, Text, computed, useSlots } from 'vue'
+import { useDataListState } from '../composables/DataList'
+
+const props = withDefaults(defineProps<{
+  dir?: 'row' | 'column'
+  maxWidth?: string
+  align?: 'left' | 'right'
+  tnum?: boolean
+  trim?: boolean
+}>(), {
+  dir: 'row',
+  maxWidth: '100%'
+})
+
+const {
+  labelWidth
+} = useDataListState()
+
+const slots = useSlots()
+
+const classes = computed(() => [
+  props.dir,
+  props.align,
+  { tnum: props.tnum },
+  { trim: props.trim }
+])
+
+const labelStyles = computed(() => ({
+  width: props.dir === 'row' ? labelWidth.value : '100%'
+}))
+
+const valueStyles = computed(() => ({
+  maxWidth: props.maxWidth
+}))
+
+const hasValue = computed(() => hasSlotContent('value'))
+
+function hasSlotContent(name = 'default'): boolean {
+  return !!slots[name]?.().some((s) => {
+    if (s.type === Comment) {
+      return false
+    }
+    if (s.type === Text && typeof s.children === 'string') {
+      return !!s.children.trim()
+    }
+    return true
+  })
+}
+</script>
+
+<template>
+  <div class="SDataListItem" :class="classes">
+    <div class="content">
+      <div class="label" :style="labelStyles">
+        <slot name="label" />
+      </div>
+      <div v-if="!hasValue" class="empty">
+        —
+      </div>
+      <div v-else-if="hasValue" class="value" :style="valueStyles">
+        <slot name="value" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.SDataListItem {
+  width: 100%;
+  max-width: 100%;
+}
+
+.content {
+  display: flex;
+  padding: 10px 0;
+  min-height: 48px;
+}
+
+.label {
+  flex-shrink: 0;
+  padding: 2px 0;
+  line-height: 24px;
+  font-size: 14px;
+  color: var(--c-text-2);
+}
+
+.empty {
+  flex-grow: 1;
+  padding: 2px 0;
+  line-height: 24px;
+  font-size: 14px;
+  color: var(--c-text-3);
+}
+
+.value {
+  flex-grow: 1;
+  padding: 2px 0;
+  line-height: 24px;
+  font-size: 14px;
+  color: var(--c-text-1);
+}
+
+.SDataListItem.row .content {
+  flex-direction: row;
+}
+
+.SDataListItem.column .content {
+  flex-direction: column;
+}
+
+.SDataListItem.left .value {
+  text-align: left;
+}
+
+.SDataListItem.right .value {
+  text-align: right;
+}
+
+.SDataListItem.tnum .value {
+  font-feature-settings: "tnum";
+}
+
+.SDataListItem.trim {
+  .content,
+  .value {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+</style>

--- a/lib/composables/DataList.ts
+++ b/lib/composables/DataList.ts
@@ -1,0 +1,23 @@
+import { type ComputedRef, inject, provide } from 'vue'
+
+export interface DataListState {
+  labelWidth: ComputedRef<string>
+}
+
+export const DataListStateKey = 'sefirot-data-list-state-key'
+
+export function provideDataListState(state: DataListState): void {
+  provide(DataListStateKey, state)
+}
+
+export function useDataListState(): DataListState {
+  const state = inject<DataListState | null>(DataListStateKey, null) || null
+  if (!state) {
+    throw new Error(
+      'Unexpected call to `useDataListState`. This probably means you are using'
+      + '`<DDataList>` child component outside of `<DDataList>`. Make sure'
+      + ' to wrap the component within `<DDataList>` component.'
+    )
+  }
+  return state
+}

--- a/stories/components/SDataList.01_Playground.story.vue
+++ b/stories/components/SDataList.01_Playground.story.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import SDataList from 'sefirot/components/SDataList.vue'
+import SDataListItem from 'sefirot/components/SDataListItem.vue'
+import SPill from 'sefirot/components/SPill.vue'
+import SState from 'sefirot/components/SState.vue'
+
+const title = 'Components / SDataList / 01. Playground'
+
+const actions = [
+  // { icon: IconNotePencil, onClick: () => {} },
+  // {
+  //   type: 'menu' as const,
+  //   icon: IconDotsThree,
+  //   options: [
+  //     { label: 'Inspect', onClick: () => {} },
+  //     { label: 'Preview', onClick: () => {} },
+  //     { label: 'Delete', onClick: () => {} }
+  //   ]
+  // }
+]
+
+function initState() {
+  return {
+    labelWidth: '160px'
+  }
+}
+</script>
+
+<template>
+  <Story :title :init-state source="Not available" auto-props-disabled>
+    <template #controls="{ state }">
+      <HstText
+        title="SDataList.labelWidth"
+        v-model="state.labelWidth"
+      />
+    </template>
+
+    <template #default="{ state }">
+      <Board :title>
+        <SDataList :label-width="state.labelWidth">
+          <SDataListItem>
+            <template #label>Company</template>
+            <template #value>ABC Data Studio</template>
+          </SDataListItem>
+          <SDataListItem>
+            <template #label>Status</template>
+            <template #value>
+              <SState mode="info" label="Active" />
+            </template>
+          </SDataListItem>
+          <SDataListItem tnum>
+            <template #label>Num. of employees</template>
+            <template #value>12,000</template>
+          </SDataListItem>
+          <SDataListItem>
+            <template #label>Sectors</template>
+            <template #value>
+              <div class="s-flex s-gap-8">
+                <SPill label="AI" />
+                <SPill label="Data Science" />
+              </div>
+            </template>
+          </SDataListItem>
+          <SDataListItem>
+            <template #label>Optional field</template>
+          </SDataListItem>
+          <SDataListItem dir="column" max-width="640px">
+            <template #label>Description</template>
+            <template #value>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            </template>
+          </SDataListItem>
+        </SDataList>
+      </Board>
+    </template>
+  </Story>
+</template>


### PR DESCRIPTION
Add new component `<SDataList>`. This component is successor of `<SDesc>`. Which aims to create component for this kind of key-value pair data display. If this works well, we might want to deprecate `<SDesc>`.

<img width="665" height="408" alt="Screenshot 2025-07-11 at 17 00 14" src="https://github.com/user-attachments/assets/c3725c0c-e232-484f-bc4b-519a563a82e6" />

## Example

```html
<SDataList label-width="128px">
  <SDataListItem>
    <template #label>Company</template>
    <template #value>ABC Data Studio</template>
  </SDataListItem>
  <SDataListItem tnum>
    <template #label>Num. of employees</template>
    <template #value>12,000</template>
  </SDataListItem>
</SDataList>
```

## API design concept

Unlike `<SDesc>`, instead of making many small components, it uses named slot and primitive props to control things.

So instead of trying to scope values into "feature" such as text, number, date, pill, etc. It will let the caller to define appropriate styles.

### Basic props

```ts
interface Props {
  // Whether label and value should be stacked by
  // `flex-direction: 'row'` or `flex-direction: 'column'`
  dir?: 'row' | 'column'

  // Max width for value content. Mostly used when value is
  // a long text like input from textarea input.
  maxWidth?: string

  // Align value to left or right.
  align?: 'left' | 'right'

  // Set `font-feature-settings: "tnum"`.
  // Use when the value is number or date.
  tnum?: boolean

  // Adds `text-overflow: ellipsis` to trim the overflowing value.
  trim?: boolean
}
```

### Using special values

Users may place any component inside `#value` slot and use utility styles to customize simple display. For example, when we want to display multiple pills, we could do this.

```html
<SDataList label-width="128px">
  <SDataListItem>
    <template #label>Sectors</template>
    <template #value>
      <div class="s-flex s-gap-8">
        <SPill label="AI" />
        <SPill label="Data Science" />
      </div>
    </template>
  </SDataListItem>
</SDataList>
```

## Root props

`SDescList:labelWidth` will determine fixed label width when the list is stacked horizontally.