### PR TITLE
feat(table): support specifying width in column options

### DIFF
--- a/lib/components/STable.vue
+++ b/lib/components/STable.vue
@@ -61,6 +61,13 @@ const cellOfColToGrow = computed(() => {
 const colWidths = reactive<Record<string, string>>({})
 const blockWidth = ref<number | undefined>()
 
+watch(() => unref(props.options.columns), (columns) => {
+  Object.keys(columns).forEach((key) => {
+    const width = columns[key]?.width
+    if (width) { colWidths[key] = width }
+  })
+}, { immediate: true, deep: true, flush: 'pre' })
+
 const showHeader = computed(() => {
   const header = unref(props.options.header)
 

--- a/lib/composables/Table.ts
+++ b/lib/composables/Table.ts
@@ -45,6 +45,7 @@ export interface TableColumn<V, R, SV, SR> {
   className?: string
   dropdown?: DropdownSection[]
   freeze?: boolean
+  width?: string
   grow?: boolean
   resizable?: boolean
   cell?: TableCell<V, R> | TableColumnCellFn<V, R>

--- a/stories/components/STable.01_Playground.story.vue
+++ b/stories/components/STable.01_Playground.story.vue
@@ -242,8 +242,7 @@ const table = useTable({
         mode: (record.status === 'Published'
           ? 'success'
           : record.status === 'Draft' ? 'info' : 'mute')
-      }),
-      width: '128px'
+      })
     },
 
     authors: {
@@ -392,6 +391,7 @@ const selected = ref<string[]>([])
 
 <style scoped lang="postcss">
 .table :deep(.col-name)      { --table-col-width: 144px; }
+.table :deep(.col-status)    { --table-col-width: 128px; }
 .table :deep(.col-authors)   { --table-col-width: 128px; }
 .table :deep(.col-type)      { --table-col-width: 128px; }
 .table :deep(.col-width)     { --table-col-width: 128px; }

--- a/stories/components/STable.01_Playground.story.vue
+++ b/stories/components/STable.01_Playground.story.vue
@@ -242,7 +242,8 @@ const table = useTable({
         mode: (record.status === 'Published'
           ? 'success'
           : record.status === 'Draft' ? 'info' : 'mute')
-      })
+      }),
+      width: '128px'
     },
 
     authors: {
@@ -391,7 +392,6 @@ const selected = ref<string[]>([])
 
 <style scoped lang="postcss">
 .table :deep(.col-name)      { --table-col-width: 144px; }
-.table :deep(.col-status)    { --table-col-width: 128px; }
 .table :deep(.col-authors)   { --table-col-width: 128px; }
 .table :deep(.col-type)      { --table-col-width: 128px; }
 .table :deep(.col-width)     { --table-col-width: 128px; }


### PR DESCRIPTION
closes #630

doesn't support `%` as unit

- [x] revert story before merging
