### PR TITLE
feat(content): refine content styles

### DIFF
--- a/lib/components/SContent.vue
+++ b/lib/components/SContent.vue
@@ -8,25 +8,25 @@
 .SContent {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
 .SContent :deep(h1),
 .SContent :deep(.h1) {
   margin: 0;
   padding: 0;
-  max-width: 640px;
-  line-height: 40px;
-  font-size: 32px;
+  max-width: 720px;
+  line-height: 36px;
+  font-size: 24px;
   font-weight: 500;
   color: var(--c-text-1);
 }
 
 .SContent :deep(h2),
 .SContent :deep(.h2) {
-  margin: 0;
+  margin: 16px 0 0;
   padding: 0;
-  max-width: 640px;
+  max-width: 720px;
   line-height: 32px;
   font-size: 20px;
   font-weight: 500;
@@ -35,18 +35,27 @@
 
 .SContent :deep(h3),
 .SContent :deep(.h3) {
-  margin: 0;
+  margin: 16px 0 0;
   padding: 0;
-  max-width: 640px;
-  line-height: 24px;
-  font-size: 16px;
+  max-width: 720px;
+  line-height: 28px;
+  font-size: 18px;
   font-weight: 500;
   color: var(--c-text-1);
 }
 
+.SContent :deep(h1:first-child),
+.SContent :deep(.h1:first-child),
+.SContent :deep(h2:first-child),
+.SContent :deep(.h2:first-child),
+.SContent :deep(h3:first-child),
+.SContent :deep(.h3:first-child) {
+  margin-top: 0;
+}
+
 .SContent :deep(p) {
   margin: 0;
-  max-width: 640px;
+  max-width: 720px;
   line-height: 24px;
   font-size: 14px;
   font-weight: 400;
@@ -70,7 +79,7 @@
 .SContent :deep(ol) {
   margin: 0;
   padding-left: 0;
-  max-width: 640px;
+  max-width: 720px;
   list-style: none;
 }
 

--- a/lib/styles/utilities.css
+++ b/lib/styles/utilities.css
@@ -143,11 +143,13 @@
 .s-w-256  { width: 256px; }
 .s-w-320  { width: 320px; }
 .s-w-512  { width: 512px; }
+.s-w-720  { width: 720px; }
 .s-w-full { max-width: 100%; }
 
 .s-max-w-256    { max-width: 256px; }
 .s-max-w-320    { max-width: 320px; }
 .s-max-w-512    { max-width: 512px; }
+.s-max-w-720    { max-width: 720px; }
 .s-max-w-prose  { max-width: 65ch; }
 .s-max-w-full   { max-width: 100%; }
 .s-max-w-xs     { max-width: 320px; }

--- a/stories/components/SContent.01_Playground.story.vue
+++ b/stories/components/SContent.01_Playground.story.vue
@@ -9,11 +9,15 @@ const docs = '/components/content'
 <template>
   <Story :title source="Not available" auto-props-disabled>
     <Board :title :docs>
-      <div class="max-w-640">
+      <div class="max-w-720">
         <SContent>
+          <h1>Level one heading</h1>
+
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, <SLink href="https://example.com">quis nostrud exercitation</SLink> ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 
           <p><strong>Duis aute irure dolor in reprehenderit</strong> in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+
+          <h2>This is a level two heading</h2>
 
           <ul>
             <li>Excepteur sint occaecat cupidatat.</li>
@@ -26,6 +30,8 @@ const docs = '/components/content'
             </li>
             <li>Labore et dolore magna aliqua.</li>
           </ul>
+
+          <h3>This is a level three heading</h3>
 
           <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 


### PR DESCRIPTION
Refine `<SContent>` styling a bit.

1. New heading font sizes.
2. Increase max width to 720px.
    - Many AI chat responses uses around 720-768px width. Since we use font size 14px, I went with 720px for now.
    - Assuming that people are getting use to longer paragraph sizes.
3. Reduce paragraph gaps to 8px.
    - The component is used mainly in places where we have fewer texts. Like only heading plus 1 paragraph. In this kind of case, 8px instead of 12px looks bit nicer.

<img width="1392" height="1159" alt="Screenshot 2025-07-24 at 11 41 56" src="https://github.com/user-attachments/assets/298576df-e041-43ff-8dc6-8fe0bb8f8ece" />
