### PR TITLE
feat(button,input): add new `sm` and `md` size

### DIFF
--- a/lib/components/SButton.vue
+++ b/lib/components/SButton.vue
@@ -6,7 +6,17 @@ import SLink from './SLink.vue'
 import SSpinner from './SSpinner.vue'
 import STooltip from './STooltip.vue'
 
-export type Size = 'mini' | 'small' | 'medium' | 'large' | 'jumbo'
+export type Size =
+  | 'xs'
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  | 'mini'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'jumbo'
 
 export type Type = 'fill' | 'outline' | 'text'
 
@@ -206,17 +216,18 @@ function handleClick(): void {
   background-color: var(--button-count-bg-color);
 }
 
+.SButton.xs,
 .SButton.mini {
   min-width: 28px;
   min-height: 28px;
   font-size: var(--button-font-size, var(--button-mini-font-size));
 
   &.rounded                  { border-radius: 16px; }
-  &.has-label                { padding: var(--button-padding, 0 12px); }
+  &.has-label                { padding: var(--button-padding, 0 10px); }
   &.has-label.has-lead-icon  { padding: var(--button-padding, 0 10px 0 8px); }
   &.has-label.has-trail-icon { padding: var(--button-padding, 0 8px 0 10px); }
-  .content                   { gap: 4px; }
-  .icon-svg                  { width: 16px; height: 16px; }
+  .content                   { gap: 6px; }
+  .icon-svg                  { width: 14px; height: 14px; }
 
   .count {
     border-radius: 9px;
@@ -228,17 +239,18 @@ function handleClick(): void {
   }
 }
 
+.SButton.sm,
 .SButton.small {
   min-width: 32px;
   min-height: 32px;
   font-size: var(--button-font-size, var(--button-small-font-size));
 
   &.rounded                  { border-radius: 16px; }
-  &.has-label                { padding: var(--button-padding, 0 12px); }
+  &.has-label                { padding: var(--button-padding, 0 10px); }
   &.has-label.has-lead-icon  { padding: var(--button-padding, 0 10px 0 8px); }
   &.has-label.has-trail-icon { padding: var(--button-padding, 0 8px 0 10px); }
   .content                   { gap: 6px; }
-  .icon-svg                  { width: 16px; height: 16px; }
+  .icon-svg                  { width: 14px; height: 14px; }
 
   .count {
     border-radius: 9px;
@@ -250,17 +262,17 @@ function handleClick(): void {
   }
 }
 
-.SButton.medium {
-  min-width: 40px;
-  min-height: 40px;
+.SButton.md {
+  min-width: 36px;
+  min-height: 36px;
   font-size: var(--button-font-size, var(--button-medium-font-size));
 
-  &.rounded                  { border-radius: 20px; }
-  &.has-label                { padding: var(--button-padding, 0 16px); }
+  &.rounded                  { border-radius: 18px; }
+  &.has-label                { padding: var(--button-padding, 0 12px); }
   &.has-label.has-lead-icon  { padding: var(--button-padding, 0 12px 0 10px); }
   &.has-label.has-trail-icon { padding: var(--button-padding, 0 10px 0 12px); }
-  .content                   { gap: 8px; }
-  .icon-svg                  { width: 18px; height: 18px; }
+  .content                   { gap: 6px; }
+  .icon-svg                  { width: 16px; height: 16px; }
 
   .count {
     border-radius: 10px;
@@ -272,17 +284,19 @@ function handleClick(): void {
   }
 }
 
+.SButton.lg,
+.SButton.medium,
 .SButton.large {
-  min-width: 48px;
-  min-height: 48px;
+  min-width: 40px;
+  min-height: 40px;
   font-size: var(--button-font-size, var(--button-large-font-size));
 
-  &.rounded                  { border-radius: 24px; }
-  &.has-label                { padding: var(--button-padding, 0 20px); }
+  &.rounded                  { border-radius: 20px; }
+  &.has-label                { padding: var(--button-padding, 0 14px); }
   &.has-label.has-lead-icon  { padding: var(--button-padding, 0 14px 0 12px); }
   &.has-label.has-trail-icon { padding: var(--button-padding, 0 12px 0 14px); }
   .content                   { gap: 8px; }
-  .icon-svg                  { width: 18px; height: 18px; }
+  .icon-svg                  { width: 16px; height: 16px; }
 
   .count {
     border-radius: 10px;
@@ -294,16 +308,17 @@ function handleClick(): void {
   }
 }
 
+.SButton.xl,
 .SButton.jumbo {
-  min-width: 64px;
-  min-height: 64px;
+  min-width: 48px;
+  min-height: 48px;
   font-size: var(--button-font-size, var(--button-jumbo-font-size));
 
-  &.rounded                  { border-radius: 32px; }
-  &.has-label                { padding: var(--button-padding, 0 24px); }
-  &.has-label.has-lead-icon  { padding: var(--button-padding, 0 20px 0 18px); }
-  &.has-label.has-trail-icon { padding: var(--button-padding, 0 18px 0 20px); }
-  .content                   { gap: 8px; }
+  &.rounded                  { border-radius: 24px; }
+  &.has-label                { padding: var(--button-padding, 0 16px); }
+  &.has-label.has-lead-icon  { padding: var(--button-padding, 0 16px 0 14px); }
+  &.has-label.has-trail-icon { padding: var(--button-padding, 0 14px 0 16px); }
+  .content                   { gap: 10px; }
   .icon-svg                  { width: 20px; height: 20px; }
 
   .count {

--- a/lib/components/SInputBase.vue
+++ b/lib/components/SInputBase.vue
@@ -20,7 +20,7 @@ export interface Props {
   hideWarning?: boolean
 }
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
 const props = defineProps<Props>()
@@ -105,6 +105,8 @@ function getErrorMsg(validation: Validatable) {
   .check           { padding-top: 0; line-height: 20px; }
 }
 
+.SInputBase.sm,
+.SInputBase.md,
 .SInputBase.small {
   .label      { padding-bottom: 6px; min-height: 26px; }
   .label-text { font-size: var(--input-label-font-size, var(--input-small-label-font-size)); }

--- a/lib/components/SInputCheckbox.vue
+++ b/lib/components/SInputCheckbox.vue
@@ -5,7 +5,7 @@ import { type Component, computed } from 'vue'
 import { type Validatable } from '../composables/Validation'
 import SInputBase from './SInputBase.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
 const props = withDefaults(defineProps<{
@@ -60,6 +60,7 @@ function onClick() {
   <SInputBase
     class="SInputCheckbox"
     :class="classes"
+    :size
     :label
     :note
     :info
@@ -156,6 +157,12 @@ function onClick() {
   line-height: 20px;
   font-size: 14px;
   font-weight: 400;
+}
+
+.SInputCheckbox.md {
+  .input {
+    height: 36px;
+  }
 }
 
 .SInputCheckbox.disabled {

--- a/lib/components/SInputCheckboxes.vue
+++ b/lib/components/SInputCheckboxes.vue
@@ -4,7 +4,7 @@ import { type Validatable } from '../composables/Validation'
 import SInputBase from './SInputBase.vue'
 import SInputCheckbox from './SInputCheckbox.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
 export type Value = any
@@ -69,6 +69,7 @@ function handleChange(value: Value): void {
   <SInputBase
     class="SInputCheckboxes"
     :class="[size ?? 'small']"
+    :size
     :name
     :label
     :note
@@ -82,6 +83,7 @@ function handleChange(value: Value): void {
       <div class="row">
         <div v-for="option in options" :key="String(option.value)" class="col">
           <SInputCheckbox
+            size="sm"
             :text="option.label"
             :disabled="option.disabled ?? disabled"
             :model-value="isChecked(option.value)"

--- a/lib/components/SInputDate.vue
+++ b/lib/components/SInputDate.vue
@@ -5,7 +5,7 @@ import { type Validatable } from '../composables/Validation'
 import { type Day, day } from '../support/Day'
 import SInputBase from './SInputBase.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
 const props = defineProps<{
@@ -54,6 +54,7 @@ function emitBlur() {
   <SInputBase
     class="SInputDate"
     :class="classes"
+    :size
     :name
     :label
     :note
@@ -95,6 +96,7 @@ function emitBlur() {
 </template>
 
 <style lang="postcss" scoped>
+.SInputDate.sm,
 .SInputDate.mini {
   .input {
     padding: 3px 8px;
@@ -109,13 +111,27 @@ function emitBlur() {
   }
 }
 
+.SInputDate.md {
+  .input {
+    padding: 6px 10px;
+    max-width: 120px;
+    height: 36px;
+    line-height: 24px;
+    font-size: var(--input-font-size, var(--input-small-font-size));
+  }
+
+  .input.block {
+    max-width: 100%;
+  }
+}
+
 .SInputDate.small {
   .input {
     padding: 5px 12px;
     max-width: 136px;
     height: 40px;
     line-height: 24px;
-    font-size: var(--input-font-size, var(--input-small-font-size));
+    font-size: var(--input-font-size, 14px);
   }
 
   .input.block {

--- a/lib/components/SInputDropdown.vue
+++ b/lib/components/SInputDropdown.vue
@@ -241,6 +241,7 @@ function handleArray(value: OptionValue) {
   z-index: var(--z-index-dropdown);
 }
 
+.SInputDropdown.sm,
 .SInputDropdown.mini {
   .box {
     min-height: 32px;
@@ -258,6 +259,27 @@ function handleArray(value: OptionValue) {
 
   .box-icon {
     top: 3px;
+    right: 8px;
+  }
+}
+
+.SInputDropdown.md {
+  .box {
+    min-height: 36px;
+  }
+
+  .box-content {
+    padding: 0 30px 0 0;
+    line-height: 24px;
+    font-size: var(--input-font-size, 14px);
+  }
+
+  .box-placeholder {
+    padding-left: 10px;
+  }
+
+  .box-icon {
+    top: 5px;
     right: 8px;
   }
 }

--- a/lib/components/SInputDropdownItem.vue
+++ b/lib/components/SInputDropdownItem.vue
@@ -20,7 +20,7 @@ export interface ItemAvatar extends ItemBase {
   image?: string | null
 }
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 
 defineProps<{
   item: Item | Item[]
@@ -240,6 +240,7 @@ defineEmits<{
   height: 16px;
 }
 
+.SInputDropdownItem.sm,
 .SInputDropdownItem.mini {
   .many {
     padding: 3px 0 3px 3px;
@@ -256,6 +257,25 @@ defineEmits<{
   .one-avatar {
     gap: 6px;
     padding-left: 7px;
+  }
+}
+
+.SInputDropdownItem.md {
+  .many {
+    padding: 5px 0 5px 4px;
+  }
+
+  .one-text {
+    padding-left: 12px;
+  }
+
+  .one-text-value {
+    font-size: var(--input-font-size, 14px);
+  }
+
+  .one-avatar {
+    gap: 8px;
+    padding-left: 10px;
   }
 }
 

--- a/lib/components/SInputFile.vue
+++ b/lib/components/SInputFile.vue
@@ -3,7 +3,7 @@ import { type Component, computed, ref } from 'vue'
 import { type Validatable } from '../composables/Validation'
 import SInputBase from './SInputBase.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
 const props = defineProps<{
@@ -65,6 +65,7 @@ function onChange(e: Event) {
   <SInputBase
     class="SInputFile"
     :class="classes"
+    :size
     :label
     :note
     :info
@@ -101,6 +102,7 @@ function onChange(e: Event) {
 </template>
 
 <style lang="postcss" scoped>
+.SInputFile.sm,
 .SInputFile.mini {
   .action {
     padding: 3px 8px 3px 3px;
@@ -117,6 +119,26 @@ function onChange(e: Event) {
   .placeholder {
     line-height: 30px;
     font-size: var(--input-font-size, var(--input-mini-font-size));
+    font-weight: 400;
+  }
+}
+
+.SInputFile.md {
+  .action {
+    padding: 3px 8px 3px 3px;
+  }
+
+  .button {
+    padding: 0 8px;
+    line-height: 26px;
+    font-size: 12px;
+    font-weight: 500;
+  }
+
+  .file-name,
+  .placeholder {
+    line-height: 34px;
+    font-size: var(--input-font-size, 14px);
     font-weight: 400;
   }
 }

--- a/lib/components/SInputHMS.vue
+++ b/lib/components/SInputHMS.vue
@@ -184,6 +184,7 @@ function createRequiredTouched(): boolean[] {
 </template>
 
 <style lang="postcss" scoped>
+.SInputHMS.sm,
 .SInputHMS.mini {
   .container {
     padding: 0 8px;
@@ -204,6 +205,32 @@ function createRequiredTouched(): boolean[] {
 
   .separator::before {
     padding: 0 4px;
+  }
+}
+
+.SInputHMS.md {
+  .container {
+    padding: 0 10px;
+    min-height: 36px;
+  }
+
+  .input {
+    flex-shrink: 0;
+    padding: 5px 0;
+    width: 20px;
+    text-align: center;
+    line-height: 24px;
+    font-size: var(--input-font-size, 14px);
+  }
+
+  .separator {
+    padding: 4px 0;
+    line-height: 24px;
+    font-size: var(--input-font-size, 14px);
+  }
+
+  .separator::before {
+    padding: 0 6px;
   }
 }
 

--- a/lib/components/SInputRadio.vue
+++ b/lib/components/SInputRadio.vue
@@ -3,7 +3,7 @@ import { type Component, computed } from 'vue'
 import { type Validatable } from '../composables/Validation'
 import SInputBase from './SInputBase.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
 const props = defineProps<{
@@ -45,6 +45,7 @@ function onClick() {
   <SInputBase
     class="SInputRadio"
     :class="classes"
+    :size
     :label
     :note
     :info
@@ -137,6 +138,12 @@ function onClick() {
   line-height: 20px;
   font-size: 14px;
   font-weight: 400;
+}
+
+.SInputRadio.md {
+  .input {
+    height: 36px;
+  }
 }
 
 .SInputRadio.disabled {

--- a/lib/components/SInputRadios.vue
+++ b/lib/components/SInputRadios.vue
@@ -11,7 +11,7 @@ import { type Validatable } from '../composables/Validation'
 import SInputBase from './SInputBase.vue'
 import SInputRadio from './SInputRadio.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type Color = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
 export interface Option<
@@ -88,6 +88,7 @@ function onChange(value: ValueType) {
   <SInputBase
     class="SInputRadios"
     :class="[size ?? 'small']"
+    :size
     :label
     :note
     :info
@@ -102,6 +103,7 @@ function onChange(value: ValueType) {
       <div class="row">
         <div v-for="(option, index) in options" :key="index" class="col">
           <SInputRadio
+            size="sm"
             :text="option.label"
             :disabled="option.disabled ?? disabled"
             :model-value="isChecked(option.value)"

--- a/lib/components/SInputSegments.vue
+++ b/lib/components/SInputSegments.vue
@@ -4,7 +4,7 @@ import { type Validatable } from '../composables/Validation'
 import SInputBase from './SInputBase.vue'
 import SInputSegmentsOption, { type Mode } from './SInputSegmentsOption.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type Color = 'default' | 'mute' | 'neutral' | 'info' | 'success' | 'warning' | 'danger'
 export type CheckColor = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
@@ -90,10 +90,18 @@ function onSelect(value: T) {
 </template>
 
 <style scoped lang="postcss">
+.SInputSegments.sm,
 .SInputSegments.mini {
   .box {
     padding: 2px;
     height: 32px;
+  }
+}
+
+.SInputSegments.md {
+  .box {
+    padding: 2px;
+    height: 36px;
   }
 }
 

--- a/lib/components/SInputSegmentsOption.vue
+++ b/lib/components/SInputSegmentsOption.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T extends string | number | boolean">
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type Mode = 'default' | 'mute' | 'neutral' | 'info' | 'success' | 'warning' | 'danger'
 
 const props = defineProps<{
@@ -78,9 +78,20 @@ function onClick() {
   }
 }
 
+.SInputSegmentsOption.sm,
 .SInputSegmentsOption.mini {
   .SInputSegmentsOption + &::before {
     top: 4px;
+  }
+
+  .label {
+    padding: 0 12px;
+  }
+}
+
+.SInputSegmentsOption.md {
+  .SInputSegmentsOption + &::before {
+    top: 6px;
   }
 
   .label {

--- a/lib/components/SInputSelect.vue
+++ b/lib/components/SInputSelect.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import IconCaretDown from '~icons/ph/caret-down-bold'
-import IconCaretUp from '~icons/ph/caret-up-bold'
+import IconCaretDown from '~icons/ph/caret-down'
+import IconCaretUp from '~icons/ph/caret-up'
 import { computed, ref } from 'vue'
 import SInputBase, { type Props as BaseProps } from './SInputBase.vue'
 
@@ -121,6 +121,7 @@ function emitChange(e: any): void {
 </template>
 
 <style scoped lang="postcss">
+.SInputSelect.sm,
 .SInputSelect.mini {
   line-height: 30px;
   font-size: var(--input-font-size, var(--input-mini-font-size));
@@ -129,6 +130,16 @@ function emitChange(e: any): void {
   .select   { padding: 0 30px 0 10px; }
   .icon     { top: 5px; right: 8px; }
   .icon-svg { width: 12px; height: 12px; }
+}
+
+.SInputSelect.md {
+  line-height: 34px;
+  font-size: var(--input-font-size, 14px);
+
+  .box      { height: 36px; }
+  .select   { padding: 0 30px 0 10px; }
+  .icon     { top: 5px; right: 8px; }
+  .icon-svg { width: 14px; height: 14px; }
 }
 
 .SInputSelect.small {

--- a/lib/components/SInputSwitch.vue
+++ b/lib/components/SInputSwitch.vue
@@ -3,7 +3,7 @@ import { type Component, computed } from 'vue'
 import { type Validatable } from '../composables/Validation'
 import SInputBase from './SInputBase.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type ActiveColor = 'info' | 'success' | 'warning' | 'danger'
 export type CheckColor = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
@@ -58,6 +58,7 @@ function emitChange(): void {
   <SInputBase
     class="SInputSwitch"
     :class="classes"
+    :size
     :name
     :label
     :note
@@ -115,6 +116,7 @@ function emitChange(): void {
   transition: background-color 0.25s, transform 0.25s;
 }
 
+.SInputSwitch.sm,
 .SInputSwitch.mini {
   .input {
     height: 32px;
@@ -126,20 +128,48 @@ function emitChange(): void {
   }
 
   .box {
-    border-radius: 9px;
-    width: 32px;
-    height: 18px;
+    border-radius: 10px;
+    width: 36px;
+    height: 20px;
   }
 
   .toggle {
-    top: 1px;
-    left: 1px;
+    top: 2px;
+    left: 2px;
     width: 14px;
     height: 14px;
   }
 
   .input.on .toggle {
-    transform: translateX(14px);
+    transform: translateX(16px);
+  }
+}
+
+.SInputSwitch.md {
+  .input {
+    height: 36px;
+  }
+
+  .text {
+    line-height: 20px;
+    font-size: 14px;
+  }
+
+  .box {
+    border-radius: 12px;
+    width: 44px;
+    height: 24px;
+  }
+
+  .toggle {
+    top: 3px;
+    left: 3px;
+    width: 16px;
+    height: 16px;
+  }
+
+  .input.on .toggle {
+    transform: translateX(20px);
   }
 }
 

--- a/lib/components/SInputSwitches.vue
+++ b/lib/components/SInputSwitches.vue
@@ -4,7 +4,7 @@ import { type Validatable } from '../composables/Validation'
 import SInputBase from './SInputBase.vue'
 import SInputSwitch from './SInputSwitch.vue'
 
-export type Size = 'mini' | 'small' | 'medium'
+export type Size = 'sm' | 'md' | 'mini' | 'small' | 'medium'
 export type CheckColor = 'neutral' | 'mute' | 'info' | 'success' | 'warning' | 'danger'
 
 export interface Option {
@@ -54,6 +54,7 @@ function handleChange(value: any): void {
   <SInputBase
     class="SInputSwitches"
     :class="classes"
+    :size
     :name
     :label
     :note
@@ -68,7 +69,7 @@ function handleChange(value: any): void {
       <div class="row">
         <div v-for="(option, index) in options" :key="index" class="col">
           <SInputSwitch
-            :size
+            size="sm"
             :text="option.label"
             :model-value="isChecked(option.value)"
             @update:model-value="handleChange(option.value)"

--- a/lib/components/SInputText.vue
+++ b/lib/components/SInputText.vue
@@ -161,7 +161,8 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
 </template>
 
 <style scoped lang="postcss">
-.SInputText.mini {
+.SInputText.sm,
+.SInputText.small {
   .box   { min-height: 32px; }
   .value { min-height: 30px; }
   .area  { min-height: 30px; }
@@ -207,6 +208,55 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
     margin-right: -2px;
     width: 10px;
     height: 10px;
+  }
+}
+
+.SInputText.md {
+  .box   { min-height: 36px; }
+  .value { min-height: 34px; }
+  .area  { min-height: 34px; }
+  .unit  { min-height: 34px; }
+
+  .input {
+    padding: 5px 10px;
+    letter-spacing: 0;
+    line-height: 24px;
+    font-size: var(--input-font-size, 14px);
+  }
+
+  .unit + .area .input      { padding-left: 8px; }
+  .area:has(+ .unit) .input { padding-right: 8px; }
+
+  .unit {
+    padding: 5px 10px;
+    line-height: 24px;
+    font-size: var(--input-font-size, 14px);
+  }
+
+  .unit.before { padding-right: 0; }
+  .unit.after  { padding-left: 0; }
+
+  .unit-icon {
+    width: 16px;
+    height: 16px;
+  }
+
+  :slotted(.SInputAddon) .action {
+    padding: 0 12px;
+    font-size: 14px;
+    font-weight: 500;
+  }
+
+  :slotted(.SInputAddon) .action-icon {
+    width: 16px;
+    height: 16px;
+  }
+
+  :slotted(.SInputAddon) .caret {
+    margin-left: 6px;
+    margin-right: -2px;
+    width: 12px;
+    height: 12px;
   }
 }
 
@@ -421,10 +471,6 @@ function getValue(e: Event | FocusEvent | KeyboardEvent): string | null {
   align-items: center;
   justify-content: center;
   color: var(--c-text-2);
-}
-
-.unit-text {
-  font-weight: 500;
 }
 
 .addon {

--- a/lib/components/SInputTextarea.vue
+++ b/lib/components/SInputTextarea.vue
@@ -27,6 +27,8 @@ const emit = defineEmits<{
 }>()
 
 const sizePaddingYDict = {
+  sm: 12,
+  md: 14,
   mini: 12,
   small: 14,
   medium: 22
@@ -182,14 +184,26 @@ const isPreview = ref(false)
   }
 }
 
+.SInputTextarea.sm,
 .SInputTextarea.mini {
   .input,
   .prose {
-    padding: 6px 10px;
+    padding: 3px 8px;
     width: 100%;
     min-height: 30px;
-    line-height: 20px;
+    line-height: 24px;
     font-size: var(--input-font-size, var(--input-mini-font-size));
+  }
+}
+
+.SInputTextarea.md {
+  .input,
+  .prose {
+    padding: 5px 10px;
+    width: 100%;
+    min-height: 34px;
+    line-height: 24px;
+    font-size: var(--input-font-size, 14px);
   }
 }
 

--- a/lib/components/SInputYMD.vue
+++ b/lib/components/SInputYMD.vue
@@ -187,6 +187,7 @@ function createRequiredTouched(): boolean[] {
 </template>
 
 <style scoped lang="postcss">
+.SInputYMD.sm,
 .SInputYMD.mini {
   .container {
     padding: 0 4px;
@@ -206,6 +207,31 @@ function createRequiredTouched(): boolean[] {
     padding: 3px 0;
     line-height: 24px;
     font-size: var(--input-font-size, var(--input-mini-font-size));
+  }
+}
+
+.SInputYMD.md {
+  .container {
+    padding: 0 6px;
+    height: 36px;
+  }
+
+  .input {
+    padding: 5px 0;
+    text-align: center;
+    line-height: 24px;
+    font-size: var(--input-font-size, 14px);
+  }
+
+  .input.year  { margin-right: 2px; }
+  .input.year  { width: 48px; }
+  .input.month { width: 32px; }
+  .input.date  { width: 32px; }
+
+  .separator {
+    padding: 5px 0;
+    line-height: 24px;
+    font-size: var(--input-font-size, 14px);
   }
 }
 

--- a/lib/styles/variables.css
+++ b/lib/styles/variables.css
@@ -419,7 +419,7 @@
 
 :root {
   --button-mini-font-size: 12px;
-  --button-small-font-size: 13px;
+  --button-small-font-size: 12px;
   --button-medium-font-size: 14px;
   --button-large-font-size: 14px;
   --button-jumbo-font-size: 16px;

--- a/stories/components/SButton.01_Playground.story.vue
+++ b/stories/components/SButton.01_Playground.story.vue
@@ -18,11 +18,11 @@ const modes = [
 ]
 
 const sizes = [
-  { label: 'mini', value: 'mini' },
-  { label: 'small', value: 'small' },
-  { label: 'medium', value: 'medium' },
-  { label: 'large', value: 'large' },
-  { label: 'jumbo', value: 'jumbo' }
+  { label: 'xs', value: 'xs' },
+  { label: 'sm', value: 'sm' },
+  { label: 'md', value: 'md' },
+  { label: 'lg', value: 'lg' },
+  { label: 'xl', value: 'xl' }
 ]
 
 const contentModes = [
@@ -40,7 +40,7 @@ const contentModes = [
 
 function initState() {
   return {
-    size: 'medium',
+    size: 'md',
     type: 'fill',
     mode: 'default',
     labelMode: null,

--- a/stories/components/SButton.04_Icons.story.vue
+++ b/stories/components/SButton.04_Icons.story.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import IconCheckCircle from '~icons/ph/check-circle-bold'
-import IconImageSquare from '~icons/ph/image-square-bold'
-import IconMagnifyingGlass from '~icons/ph/magnifying-glass-bold'
+import IconCheckCircle from '~icons/ph/check-circle'
+import IconImageSquare from '~icons/ph/image-square'
+import IconMagnifyingGlass from '~icons/ph/magnifying-glass'
 import SButton from 'sefirot/components/SButton.vue'
 
 const title = 'Components / SButton / 04. Icons'

--- a/stories/components/SInputCheckbox.01_Playground.story.vue
+++ b/stories/components/SInputCheckbox.01_Playground.story.vue
@@ -9,7 +9,7 @@ const value = ref(false)
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Note text',
@@ -27,9 +27,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputCheckboxes.01_Playground.story.vue
+++ b/stories/components/SInputCheckboxes.01_Playground.story.vue
@@ -15,7 +15,7 @@ const options = [
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Note text',
@@ -34,8 +34,7 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
+          md: 'md',
           medium: 'medium'
         }"
         v-model="state.size"

--- a/stories/components/SInputDate.01_Playground.story.vue
+++ b/stories/components/SInputDate.01_Playground.story.vue
@@ -8,7 +8,7 @@ const value = ref(null)
 
 function initState() {
   return {
-    size: 'small'
+    size: 'md'
   }
 }
 </script>
@@ -19,9 +19,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />
@@ -32,10 +31,6 @@ function initState() {
         <SInputDate
           label="Label"
           :size="state.size"
-          info="Some helpful information."
-          note="Note text"
-          text="Text for the checkbox"
-          help="This is a help text."
           v-model="value"
         />
       </Board>

--- a/stories/components/SInputDropdown.01_Playground.story.vue
+++ b/stories/components/SInputDropdown.01_Playground.story.vue
@@ -19,7 +19,7 @@ const options: OptionText[] = [
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     position: '',
     nullable: true
   }
@@ -32,9 +32,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputDropdown.02_Avatar_Options.story.vue
+++ b/stories/components/SInputDropdown.02_Avatar_Options.story.vue
@@ -17,7 +17,7 @@ const options: OptionAvatar[] = [
 
 function initState() {
   return {
-    size: 'small'
+    size: 'md'
   }
 }
 </script>
@@ -28,9 +28,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputFile.01_Playground.story.vue
+++ b/stories/components/SInputFile.01_Playground.story.vue
@@ -9,7 +9,7 @@ const input = ref(null)
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Note text',
@@ -27,9 +27,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputHMS.01_Playground.story.vue
+++ b/stories/components/SInputHMS.01_Playground.story.vue
@@ -13,7 +13,7 @@ const input = ref({
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Note',
@@ -33,9 +33,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputNumber.01_Playground.story.vue
+++ b/stories/components/SInputNumber.01_Playground.story.vue
@@ -10,7 +10,7 @@ const input = ref<number | null>(null)
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Note text',
@@ -38,9 +38,8 @@ function onInput(value: number | null) {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputRadios.01_Playground.story.vue
+++ b/stories/components/SInputRadios.01_Playground.story.vue
@@ -15,7 +15,7 @@ const options = [
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Note text',
@@ -33,9 +33,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputSegments.01_Playground.story.vue
+++ b/stories/components/SInputSegments.01_Playground.story.vue
@@ -16,7 +16,7 @@ const value = ref('table')
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Project view',
     info: '',
     note: '',
@@ -34,9 +34,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputSelect.01_Playground.story.vue
+++ b/stories/components/SInputSelect.01_Playground.story.vue
@@ -16,7 +16,7 @@ const options = [
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Note text',
@@ -35,9 +35,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputSwitch.01_Playground.story.vue
+++ b/stories/components/SInputSwitch.01_Playground.story.vue
@@ -9,7 +9,7 @@ const on = ref(false)
 
 function initState() {
   return {
-    size: 'small' as Size,
+    size: 'md' as Size,
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Note text',
@@ -28,9 +28,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputSwitches.01_Playground.story.vue
+++ b/stories/components/SInputSwitches.01_Playground.story.vue
@@ -18,6 +18,7 @@ const options = [
     <Board :title>
       <SInputSwitches
         class="switches"
+        size="md"
         name="input"
         label="Label"
         info="Some helpful information."

--- a/stories/components/SInputText.01_Playground.story.vue
+++ b/stories/components/SInputText.01_Playground.story.vue
@@ -62,7 +62,7 @@ function onReset() {
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Required',
@@ -85,9 +85,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputTextarea.01_Playground.story.vue
+++ b/stories/components/SInputTextarea.01_Playground.story.vue
@@ -19,7 +19,7 @@ const { validation } = useValidation(data, {
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Note text',
@@ -39,9 +39,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />

--- a/stories/components/SInputYMD.01_Playground.story.vue
+++ b/stories/components/SInputYMD.01_Playground.story.vue
@@ -13,7 +13,7 @@ const input = ref({
 
 function initState() {
   return {
-    size: 'small',
+    size: 'md',
     label: 'Label',
     info: 'Some helpful information.',
     note: 'Note',
@@ -34,9 +34,8 @@ function initState() {
       <HstSelect
         title="size"
         :options="{
-          mini: 'mini',
-          small: 'small',
-          medium: 'medium'
+          sm: 'sm',
+          md: 'md'
         }"
         v-model="state.size"
       />


### PR DESCRIPTION
Added new sizes.

- Button: `xs` | 'sm' | 'md' | 'lg' | 'xl'
- Inputs: `sm` | 'md'

We still keep old values so no breaking changes. Adding only `sm` | `md` to input because we reraly use others.

@brc-dd 
Can you please do rough testing 🙏  I've updated relevant stories so you should be able to test in Histoire.