### PR TITLE
fix(lang): prevent erroneous type widening

### DIFF
--- a/lib/composables/Lang.ts
+++ b/lib/composables/Lang.ts
@@ -8,7 +8,7 @@ export interface Trans<T> {
 
 export interface TransMessages<T> {
   en: T
-  ja: T
+  ja: NoInfer<T>
 }
 
 export const SefirotLangKey: InjectionKey<Lang> = Symbol.for('sefirot-lang-key')


### PR DESCRIPTION
With current version this doesn't throw error:

```ts
const { t } = useTrans({
  en: {
    foo: 'foo'
  },
  ja: {
    bar: 'bar'
  }
})
```

It becomes:

```ts
const t: {
    foo: string;
    bar?: undefined;
} | {
    bar: string;
    foo?: undefined;
}
```

After change it will throw error:

<img width="954" height="168" alt="image" src="https://github.com/user-attachments/assets/3e00ffca-10ab-4f5b-92b3-0d8beec64529" />
