### PR TITLE
fix(input-select): explicit bg color to ensure legibility on Windows

### DIFF
--- a/lib/components/SInputSelect.vue
+++ b/lib/components/SInputSelect.vue
@@ -214,7 +214,7 @@ function emitChange(e: any): void {
 }
 
 .option {
-  color: initial;
+  background-color: var(--input-bg-color);
 }
 
 .icon {


### PR DESCRIPTION
Before:

<img width="688" height="211" alt="Image" src="https://github.com/user-attachments/assets/27ca7a38-748b-4b70-9aaa-c27aedd697ef" />

<img width="688" height="211" alt="Image" src="https://github.com/user-attachments/assets/934312f2-cdd1-49a5-87d3-19775de0be76" />

After:

(Unselected)

<img width="688" height="211" alt="Image" src="https://github.com/user-attachments/assets/8cefde32-a106-4f98-b7bc-36c21df72494" />

<img width="688" height="211" alt="Image" src="https://github.com/user-attachments/assets/bb798b96-8b47-485e-8dee-341a768e14b5" />

(Selected)

<img width="688" height="211" alt="Image" src="https://github.com/user-attachments/assets/950db2f8-4994-46f1-860d-8f7931c4d6a9" />

<img width="688" height="211" alt="Image" src="https://github.com/user-attachments/assets/d8108bee-893c-41b6-b2fe-0201df45feb8" />

Note that I removed `color: initial` to make the selected state options look better.
Otherwise, with `color: initial`, the unselectable `Please select` would always look the same as other options.