### PR TITLE
feat(SInputTextarea): add an "actions" slot to display action bar

### DIFF
--- a/lib/components/SInputTextarea.vue
+++ b/lib/components/SInputTextarea.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-
-import SControl from './SControl.vue'
-import SControlRight from './SControlRight.vue'
 import SInputBase, { type Props as BaseProps } from './SInputBase.vue'
 import SInputSegments from './SInputSegments.vue'
 
@@ -107,21 +104,21 @@ const isPreview = ref(false)
   >
     <div class="box">
       <div v-if="preview !== undefined || $slots.actions" class="control">
-        <SInputSegments
-          v-if="preview !== undefined"
-          v-model="isPreview"
-          :options="[
-            { label: writeLabel ?? 'Write', value: false },
-            { label: previewLabel ?? 'Preview', value: true }
-          ]"
-          size="mini"
-        />
+        <div class="preview">
+          <SInputSegments
+            v-if="preview !== undefined"
+            v-model="isPreview"
+            :options="[
+              { label: writeLabel ?? 'Write', value: false },
+              { label: previewLabel ?? 'Preview', value: true }
+            ]"
+            size="mini"
+          />
+        </div>
 
-        <SControl v-if="$slots.actions && !isPreview" class="control">
-          <SControlRight>
-            <slot name="actions" />
-          </SControlRight>
-        </SControl>
+        <div v-if="$slots.actions && !isPreview" class="actions">
+          <slot name="actions" />
+        </div>
       </div>
       <textarea
         v-show="!isPreview"
@@ -172,9 +169,20 @@ const isPreview = ref(false)
 .control {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
   padding: 0 8px;
   height: 48px;
-  background-color: var(--c-bg-elv-3);
+  background-color: var(--c-bg-1);
+}
+
+.preview {
+  flex-grow: 1;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .input,

--- a/stories/components/SInputTextarea.03_Actions.story.vue
+++ b/stories/components/SInputTextarea.03_Actions.story.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import IconLink from '~icons/ph/link-bold'
 import IconYouTubeLogo from '~icons/ph/youtube-logo-bold'
-import SControlActionBar from 'sefirot/components/SControlActionBar.vue'
-import SControlActionBarButton from 'sefirot/components/SControlActionBarButton.vue'
-
+import SButton from 'sefirot/components/SButton.vue'
 import SInputTextarea from 'sefirot/components/SInputTextarea.vue'
 import { useMarkdown } from 'sefirot/composables/Markdown'
 import { ref } from 'vue'
@@ -101,10 +99,8 @@ function alert(message: string) {
           :preview
         >
           <template #actions>
-            <SControlActionBar>
-              <SControlActionBarButton :icon="IconLink" @click="alert('Action link clicked')" />
-              <SControlActionBarButton :icon="IconYouTubeLogo" @click="alert('Action YouTube clicked')" />
-            </SControlActionBar>
+            <SButton type="text" size="sm" mode="mute" :icon="IconLink" @click="alert('Action link clicked')" />
+            <SButton type="text" size="sm" mode="mute" :icon="IconYouTubeLogo" @click="alert('Action YouTube clicked')" />
           </template>
         </SInputTextarea>
       </Board>


### PR DESCRIPTION
From this comment: https://github.com/globalbrain/sefirot/pull/471#issuecomment-1951900164

Couldn't come up with a good UX to add a YouTube video without using an action bar, so I ended up implementing this in Sefirot.

Preview at: https://deploy-preview-655--sefirot-story.netlify.app/story/stories-components-sinputtextarea-03-actions-story-vue?variantId=_default