### PR TITLE
fix(table): consistently use values as fallbacks in cells

### DIFF
--- a/lib/components/STableCell.vue
+++ b/lib/components/STableCell.vue
@@ -37,7 +37,7 @@ const computedCell = computed<TableCell | undefined>(() =>
       :record
       :align="computedCell?.align"
       :icon="computedCell?.icon"
-      :text="computedCell?.value"
+      :text="computedCell?.value ?? value"
       :link="computedCell?.link"
       :color="computedCell?.color"
       :icon-color="computedCell?.iconColor"
@@ -49,7 +49,7 @@ const computedCell = computed<TableCell | undefined>(() =>
       :record
       :align="computedCell.align"
       :icon="computedCell.icon"
-      :number="computedCell.value"
+      :number="computedCell.value ?? value"
       :separator="computedCell.separator"
       :link="computedCell.link"
       :color="computedCell.color"
@@ -58,47 +58,47 @@ const computedCell = computed<TableCell | undefined>(() =>
     />
     <STableCellPath
       v-else-if="computedCell.type === 'path'"
-      :segments="computedCell.segments"
+      :segments="computedCell.segments ?? value"
     />
     <STableCellDay
       v-else-if="computedCell.type === 'day'"
       :align="computedCell.align"
-      :day="computedCell.value"
+      :day="computedCell.value ?? value"
       :format="computedCell.format"
       :color="computedCell.color"
     />
     <STableCellPill
       v-else-if="computedCell.type === 'pill'"
-      :pill="computedCell.value"
+      :pill="computedCell.value ?? value"
       :color="computedCell.color"
     />
     <STableCellPills
       v-else-if="computedCell.type === 'pills'"
-      :pills="computedCell.pills"
+      :pills="computedCell.pills ?? value"
     />
     <STableCellState
       v-else-if="computedCell.type === 'state'"
-      :state="computedCell.label"
+      :state="computedCell.label ?? value"
       :mode="computedCell.mode"
     />
     <STableCellIndicator
       v-else-if="computedCell.type === 'indicator'"
-      :state="computedCell.state"
+      :state="computedCell.state ?? value"
       :label="computedCell.label"
     />
     <STableCellAvatar
       v-else-if="computedCell.type === 'avatar'"
       :value
       :record
-      :image="computedCell.image"
-      :name="computedCell.name"
+      :image="computedCell.image ?? (value as string).includes('/') ? value : null"
+      :name="computedCell.name ?? (value as string).includes('/') ? null : value"
       :link="computedCell.link"
       :color="computedCell.color"
       :on-click="computedCell.onClick"
     />
     <STableCellAvatars
       v-else-if="computedCell.type === 'avatars'"
-      :avatars="computedCell.avatars"
+      :avatars="computedCell.avatars ?? value"
       :color="computedCell.color"
       :avatar-count="computedCell.avatarCount"
       :name-count="computedCell.nameCount"
@@ -107,7 +107,7 @@ const computedCell = computed<TableCell | undefined>(() =>
     <STableCellActions
       v-else-if="computedCell.type === 'actions'"
       :record
-      :actions="computedCell.actions"
+      :actions="computedCell.actions ?? value"
     />
     <STableCellCustom
       v-else-if="computedCell.type === 'custom'"

--- a/lib/components/STableCellNumber.vue
+++ b/lib/components/STableCellNumber.vue
@@ -17,7 +17,6 @@ const props = defineProps<{
   onClick?(value: any, record: any): void
 }>()
 
-const _value = computed(() => props.number ?? props.value)
 const _color = computed(() => props.color ?? 'neutral')
 const _iconColor = computed(() => props.iconColor ?? _color.value)
 
@@ -31,7 +30,7 @@ const classes = computed(() => [
 <template>
   <div class="STableCellNumber" :class="classes">
     <SLink
-      v-if="_value != null"
+      v-if="number != null"
       class="container"
       :href="link"
       :role="onClick ? 'button' : null"
@@ -41,7 +40,7 @@ const classes = computed(() => [
         <component :is="icon" class="svg" />
       </div>
       <div class="value" :class="_color">
-        {{ separator ? format(_value) : _value }}
+        {{ separator ? format(number) : number }}
       </div>
     </SLink>
   </div>

--- a/lib/components/STableCellText.vue
+++ b/lib/components/STableCellText.vue
@@ -15,7 +15,6 @@ const props = defineProps<{
   onClick?(value: any, record: any): void
 }>()
 
-const _value = computed(() => props.text ?? props.value)
 const _color = computed(() => props.color ?? 'neutral')
 const _iconColor = computed(() => props.iconColor ?? _color.value)
 
@@ -29,7 +28,7 @@ const classes = computed(() => [
 <template>
   <div class="STableCellText" :class="classes">
     <SLink
-      v-if="_value != null"
+      v-if="text != null"
       class="container"
       :href="link"
       :role="onClick ? 'button' : null"
@@ -39,7 +38,7 @@ const classes = computed(() => [
         <component :is="icon" class="svg" />
       </div>
       <div class="text" :class="_color">
-        {{ _value }}
+        {{ text }}
       </div>
     </SLink>
   </div>


### PR DESCRIPTION
It was broken in the v4 PR.

The "Created at" column was empty here:

<img width="782" height="460" alt="image" src="https://github.com/user-attachments/assets/4e0579ee-b012-460f-8ea4-edad8c26e03f" />

\
With this PR:

<img width="719" height="380" alt="image" src="https://github.com/user-attachments/assets/2a517685-eb29-42ff-83c1-49a6d76acd7a" />
