### PR TITLE
feat: add lens text pattern filters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
         run: pnpm run lint:fail
 
       - name: Test
-        run: pnpm run vitest:run
+        run: pnpm run test:fail

--- a/lib/blocks/lens/FilterOperator.ts
+++ b/lib/blocks/lens/FilterOperator.ts
@@ -6,6 +6,9 @@ export type FilterOperator =
   | '<'
   | '<='
   | 'in'
+  | 'contains'
+  | 'startsWith'
+  | 'endsWith'
 
 export const FilterOperatorLabelDict: Record<FilterOperator, string> = {
   '=': 'is',
@@ -14,5 +17,8 @@ export const FilterOperatorLabelDict: Record<FilterOperator, string> = {
   '>=': 'greater or equal',
   '<': 'less',
   '<=': 'less or equal',
-  'in': 'in'
+  'in': 'in',
+  'contains': 'contains',
+  'startsWith': 'starts with',
+  'endsWith': 'ends with'
 }

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -135,7 +135,7 @@ const queryFilter = computed(() => {
     return []
   }
   return ['$or', props.queryKeys.map((key) => {
-    return [key, 'like', `%${query.value}%`]
+    return [key, 'contains', query.value]
   })]
 })
 

--- a/lib/blocks/lens/fields/TextField.ts
+++ b/lib/blocks/lens/fields/TextField.ts
@@ -20,7 +20,10 @@ export class TextField extends Field<TextFieldData> {
 
     return {
       '=': text,
-      '!=': text
+      '!=': text,
+      'contains': text,
+      'startsWith': text,
+      'endsWith': text
     }
   }
 

--- a/lib/blocks/lens/fields/TextareaField.ts
+++ b/lib/blocks/lens/fields/TextareaField.ts
@@ -20,7 +20,10 @@ export class TextareaField extends Field<TextareaFieldData> {
 
     return {
       '=': text,
-      '!=': text
+      '!=': text,
+      'contains': text,
+      'startsWith': text,
+      'endsWith': text
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -48,11 +48,10 @@
     "type": "vue-tsc --noEmit",
     "lint": "eslint --fix",
     "lint:fail": "eslint --max-warnings 0",
-    "vitest": "vitest",
-    "vitest:run": "vitest run",
-    "coverage": "vitest run --coverage",
-    "test": "pnpm run type && pnpm run lint && pnpm run coverage",
-    "test:fail": "pnpm run type && pnpm run lint:fail && pnpm run coverage",
+    "test": "vitest",
+    "test:fail": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "check": "pnpm run type && pnpm run lint:fail && pnpm run test:fail",
     "release": "pnpm whoami >/dev/null 2>&1 || pnpm login && release-it"
   },
   "dependencies": {


### PR DESCRIPTION
For https://github.com/globalbrain/sefirot/issues/685.
Depends on https://github.com/globalbrain/anima/pull/8 for backend support.

## Summary
- add Lens filter operators for `contains`, `startsWith`, and `endsWith`
- expose those operators on `Text` and `Textarea` fields using the existing text filter input
- send free-text query filters as `contains` instead of the old raw `like` pattern
- simplify test scripts and point CI at the check-only test command

## Validation
- `pnpm run check`
