### PR TITLE
feat: add before/after date rules to lens RuleMapper

### DIFF
--- a/lib/blocks/lens/Rule.ts
+++ b/lib/blocks/lens/Rule.ts
@@ -1,6 +1,10 @@
 export type Rule =
   | MaxLengthRule
   | RequiredRule
+  | BeforeRule
+  | BeforeOrEqualRule
+  | AfterRule
+  | AfterOrEqualRule
 
 export interface MaxLengthRule {
   type: 'max_length'
@@ -9,4 +13,24 @@ export interface MaxLengthRule {
 
 export interface RequiredRule {
   type: 'required'
+}
+
+export interface BeforeRule {
+  type: 'before'
+  date: string
+}
+
+export interface BeforeOrEqualRule {
+  type: 'before_or_equal'
+  date: string
+}
+
+export interface AfterRule {
+  type: 'after'
+  date: string
+}
+
+export interface AfterOrEqualRule {
+  type: 'after_or_equal'
+  date: string
 }

--- a/lib/blocks/lens/validation/RuleMapper.ts
+++ b/lib/blocks/lens/validation/RuleMapper.ts
@@ -27,6 +27,10 @@ function mapRule(rule: Rule): ValidationRuleWithParams {
       return after(resolveDate(rule.date))
     case 'after_or_equal':
       return afterOrEqual(resolveDate(rule.date))
+    default: {
+      const _exhaustive: never = rule
+      throw new Error(`Unsupported rule type: ${(_exhaustive as Rule).type}`)
+    }
   }
 }
 
@@ -45,7 +49,12 @@ function resolveDate(date: string): Day {
       return day().add(1, 'day').startOf('day')
     case 'yesterday':
       return day().subtract(1, 'day').startOf('day')
-    default:
-      return day(date)
+    default: {
+      const parsed = day(date)
+      if (!parsed.isValid()) {
+        throw new Error(`Invalid date string in validation rule: "${date}"`)
+      }
+      return parsed
+    }
   }
 }

--- a/lib/blocks/lens/validation/RuleMapper.ts
+++ b/lib/blocks/lens/validation/RuleMapper.ts
@@ -1,5 +1,6 @@
 import { type ValidationArgs, type ValidationRuleWithParams } from '@vuelidate/core'
-import { maxLength, required } from '../../../validation/rules'
+import { type Day, day } from '../../../support/Day'
+import { after, afterOrEqual, before, beforeOrEqual, maxLength, required } from '../../../validation/rules'
 import { type Rule } from '../Rule'
 
 /**
@@ -18,5 +19,33 @@ function mapRule(rule: Rule): ValidationRuleWithParams {
       return maxLength(rule.length)
     case 'required':
       return required()
+    case 'before':
+      return before(resolveDate(rule.date))
+    case 'before_or_equal':
+      return beforeOrEqual(resolveDate(rule.date))
+    case 'after':
+      return after(resolveDate(rule.date))
+    case 'after_or_equal':
+      return afterOrEqual(resolveDate(rule.date))
+  }
+}
+
+/**
+ * Resolves a date string from the backend rule definition into a `Day`. The
+ * keywords mirror the relative date strings accepted by Laravel's `before`
+ * and `after` validators.
+ */
+function resolveDate(date: string): Day {
+  switch (date) {
+    case 'now':
+      return day()
+    case 'today':
+      return day().startOf('day')
+    case 'tomorrow':
+      return day().add(1, 'day').startOf('day')
+    case 'yesterday':
+      return day().subtract(1, 'day').startOf('day')
+    default:
+      return day(date)
   }
 }

--- a/tests/blocks/lens/validation/RuleMapper.spec.ts
+++ b/tests/blocks/lens/validation/RuleMapper.spec.ts
@@ -43,24 +43,53 @@ describe('blocks/lens/validation/RuleMapper', () => {
     expect(args.after_or_equal.$validator(day('2026-01-01'), null, null)).toBe(false)
   })
 
-  it('resolves the today keyword to the start of the current day', () => {
-    const args = map([{ type: 'after_or_equal', date: 'today' }]) as any
-    const startOfToday = day().startOf('day')
+  describe('relative date keywords', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-06-15T12:34:56Z'))
+    })
 
-    expect(args.after_or_equal.$validator(startOfToday, null, null)).toBe(true)
-    expect(args.after_or_equal.$validator(startOfToday.subtract(1, 'day'), null, null)).toBe(false)
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('resolves the now keyword to the current instant', () => {
+      const args = map([{ type: 'after', date: 'now' }]) as any
+      const now = day()
+
+      expect(args.after.$validator(now.add(1, 'day'), null, null)).toBe(true)
+      expect(args.after.$validator(now.subtract(1, 'day'), null, null)).toBe(false)
+    })
+
+    it('resolves the today keyword to the start of the current day', () => {
+      const args = map([{ type: 'after_or_equal', date: 'today' }]) as any
+      const startOfToday = day().startOf('day')
+
+      expect(args.after_or_equal.$validator(startOfToday, null, null)).toBe(true)
+      expect(args.after_or_equal.$validator(startOfToday.subtract(1, 'day'), null, null)).toBe(false)
+    })
+
+    it('resolves tomorrow and yesterday keywords', () => {
+      const tomorrow = map([{ type: 'after_or_equal', date: 'tomorrow' }]) as any
+      const yesterday = map([{ type: 'before', date: 'yesterday' }]) as any
+
+      const startOfToday = day().startOf('day')
+
+      expect(tomorrow.after_or_equal.$validator(startOfToday.add(1, 'day'), null, null)).toBe(true)
+      expect(tomorrow.after_or_equal.$validator(startOfToday, null, null)).toBe(false)
+
+      expect(yesterday.before.$validator(startOfToday.subtract(2, 'day'), null, null)).toBe(true)
+      expect(yesterday.before.$validator(startOfToday.subtract(1, 'day'), null, null)).toBe(false)
+    })
   })
 
-  it('resolves tomorrow and yesterday keywords', () => {
-    const tomorrow = map([{ type: 'after_or_equal', date: 'tomorrow' }]) as any
-    const yesterday = map([{ type: 'before', date: 'yesterday' }]) as any
+  it('throws on an invalid date string', () => {
+    expect(() => map([{ type: 'before', date: 'not-a-date' }]))
+      .toThrow('Invalid date string in validation rule: "not-a-date"')
+  })
 
-    const startOfToday = day().startOf('day')
-
-    expect(tomorrow.after_or_equal.$validator(startOfToday.add(1, 'day'), null, null)).toBe(true)
-    expect(tomorrow.after_or_equal.$validator(startOfToday, null, null)).toBe(false)
-
-    expect(yesterday.before.$validator(startOfToday.subtract(2, 'day'), null, null)).toBe(true)
-    expect(yesterday.before.$validator(startOfToday.subtract(1, 'day'), null, null)).toBe(false)
+  it('throws on an unsupported rule type', () => {
+    expect(() => map([{ type: 'unknown_rule' } as any]))
+      .toThrow('Unsupported rule type: unknown_rule')
   })
 })

--- a/tests/blocks/lens/validation/RuleMapper.spec.ts
+++ b/tests/blocks/lens/validation/RuleMapper.spec.ts
@@ -1,0 +1,66 @@
+import { map } from 'sefirot/blocks/lens/validation/RuleMapper'
+import { day } from 'sefirot/support/Day'
+
+describe('blocks/lens/validation/RuleMapper', () => {
+  it('maps required and max_length rules', () => {
+    const args = map([
+      { type: 'required' },
+      { type: 'max_length', length: 10 }
+    ]) as any
+
+    expect(Object.keys(args)).toEqual(['required', 'max_length'])
+    expect(args.required.$validator('value', null, null)).toBe(true)
+    expect(args.required.$validator('', null, null)).toBe(false)
+    expect(args.max_length.$validator('1234567890', null, null)).toBe(true)
+    expect(args.max_length.$validator('12345678901', null, null)).toBe(false)
+  })
+
+  it('maps before rule with an absolute date', () => {
+    const args = map([{ type: 'before', date: '2026-01-02' }]) as any
+
+    expect(args.before.$validator(day('2026-01-01'), null, null)).toBe(true)
+    expect(args.before.$validator(day('2026-01-02'), null, null)).toBe(false)
+  })
+
+  it('maps before_or_equal rule with an absolute date', () => {
+    const args = map([{ type: 'before_or_equal', date: '2026-01-02' }]) as any
+
+    expect(args.before_or_equal.$validator(day('2026-01-02'), null, null)).toBe(true)
+    expect(args.before_or_equal.$validator(day('2026-01-03'), null, null)).toBe(false)
+  })
+
+  it('maps after rule with an absolute date', () => {
+    const args = map([{ type: 'after', date: '2026-01-02' }]) as any
+
+    expect(args.after.$validator(day('2026-01-03'), null, null)).toBe(true)
+    expect(args.after.$validator(day('2026-01-02'), null, null)).toBe(false)
+  })
+
+  it('maps after_or_equal rule with an absolute date', () => {
+    const args = map([{ type: 'after_or_equal', date: '2026-01-02' }]) as any
+
+    expect(args.after_or_equal.$validator(day('2026-01-02'), null, null)).toBe(true)
+    expect(args.after_or_equal.$validator(day('2026-01-01'), null, null)).toBe(false)
+  })
+
+  it('resolves the today keyword to the start of the current day', () => {
+    const args = map([{ type: 'after_or_equal', date: 'today' }]) as any
+    const startOfToday = day().startOf('day')
+
+    expect(args.after_or_equal.$validator(startOfToday, null, null)).toBe(true)
+    expect(args.after_or_equal.$validator(startOfToday.subtract(1, 'day'), null, null)).toBe(false)
+  })
+
+  it('resolves tomorrow and yesterday keywords', () => {
+    const tomorrow = map([{ type: 'after_or_equal', date: 'tomorrow' }]) as any
+    const yesterday = map([{ type: 'before', date: 'yesterday' }]) as any
+
+    const startOfToday = day().startOf('day')
+
+    expect(tomorrow.after_or_equal.$validator(startOfToday.add(1, 'day'), null, null)).toBe(true)
+    expect(tomorrow.after_or_equal.$validator(startOfToday, null, null)).toBe(false)
+
+    expect(yesterday.before.$validator(startOfToday.subtract(2, 'day'), null, null)).toBe(true)
+    expect(yesterday.before.$validator(startOfToday.subtract(1, 'day'), null, null)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Extends `lib/blocks/lens/Rule.ts` with `BeforeRule`, `BeforeOrEqualRule`, `AfterRule`, `AfterOrEqualRule`.
- Wires those rule types into `lib/blocks/lens/validation/RuleMapper.ts` by delegating to the existing `before` / `beforeOrEqual` / `after` / `afterOrEqual` rule helpers.
- Adds a small `resolveDate` helper inside the mapper that recognises Laravel-style relative date keywords (`now`, `today`, `tomorrow`, `yesterday`) so callers can express things like `Rule::afterOrEqual('today')` on the backend without any extra plumbing.

## Notes
- Granularity stays at `'day'` — same as the rest of the existing date rule helpers — so behaviour matches Laravel for `DateField` values. Datetime-precision comparison would require a separate, larger change.
- Backwards compatible: only adds new union members and switch cases.

## Test plan
- [x] `pnpm run check` (vue-tsc, eslint, vitest) — 1059 tests pass, including 7 new specs in `tests/blocks/lens/validation/RuleMapper.spec.ts` covering each rule type and the relative date keywords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)