### PR TITLE
fix(button): set sm size font-size to 12px

### DIFF
--- a/lib/styles/variables.css
+++ b/lib/styles/variables.css
@@ -421,7 +421,7 @@
 
 :root {
   --button-mini-font-size: 12px;
-  --button-small-font-size: 14px;
+  --button-small-font-size: 12px;
   --button-medium-font-size: 14px;
   --button-large-font-size: 14px;
   --button-jumbo-font-size: 16px;


### PR DESCRIPTION
## Summary

- `SButton` の `sm` (`small`) サイズの `font-size` を 14px から 12px に変更
- `--button-small-font-size: 14px` → `12px`

## 経緯

以前 `sm` サイズの font-size を 12px → 14px に変更したが（#694）、実際に運用してみると、特に日本語テキストでは 14px が大きすぎて、コンパクトなボタンの見た目として違和感があった。

`xs` サイズと同じ 12px に揃えることで、小さめのボタンに期待される視覚的なバランスに戻す。

## Test plan

- [ ] Histoire の `SButton / Sizes` ストーリーで `sm` サイズの font-size が 12px になっていることを確認
- [ ] `SActionListItem` 内の `small` サイズボタンは `--button-font-size: 14px` で明示的に上書きしているため、引き続き 14px で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)