### PR TITLE
chore: require PR descriptions to be in English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@
 - Keep commit subjects short, imperative, and focused on the user-visible change.
 - When asked to open or create a PR, create it as a draft PR unless your human explicitly asks for a ready PR.
 - Use a conventional commit style for the PR title as well, for example `feat: did this and that` or `fix: make that and this`.
+- Always write PR descriptions in English, even if the conversation with your human is in another language.


### PR DESCRIPTION
## Summary

- Add a rule to `AGENTS.md` requiring PR descriptions to always be written in English, regardless of the language used in conversation with the human.

## Test plan

- [x] Confirm the new bullet appears under the `Git Workflow` section of `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)