### PR TITLE
feat: auto-fetch and hide the lens indexField column

### DIFF
--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -61,7 +61,18 @@ export interface Props {
   // Whether to hide the condition blocks.
   hideConditions?: boolean
 
-  // Field name to be used as index field for selection.
+  // Field name to be used as the row identifier. When set, the field is
+  // automatically included in the request `select` so every row carries
+  // its value, and the corresponding column is hidden from the rendered
+  // table — *unless* the caller explicitly listed it in `select`, in
+  // which case the caller's intent wins and the column is shown
+  // normally. The value remains accessible via `record[indexField]` in
+  // `cell-clicked` events and through the `selected` model regardless.
+  //
+  // If the caller's `select` is empty or `null` (i.e. "use server
+  // defaults"), the index field is **not** auto-appended — that would
+  // narrow the result to just that single column on backends that treat
+  // an empty `select` as "use defaults".
   indexField?: string
 
   // Fields that are clickable to emit `cell-clicked` event when clicked.
@@ -125,6 +136,11 @@ const hasInitialResults = ref(false)
 let prevFetchInput: LensQuery | null = null
 let prevFetchResult: LensResult | null = null
 
+// `_select` carries the caller's intent. The index field is preserved
+// here if it was listed explicitly so the corresponding column gets
+// rendered, and is only added to the request payload separately (see
+// `withIndexField`). When `_select` is empty, the auto-fetched index
+// field is stripped out of the table's column list further down.
 const _select = ref(props.select ?? [])
 const _selectable = ref(props.selectable ?? props.select ?? [])
 
@@ -152,7 +168,7 @@ const perPage = ref(100)
 const { data: result, execute: refresh, loading } = useQuery(async (http) => {
   const input = {
     entity: props.entity ?? '__no_entity__',
-    select: _select.value,
+    select: withIndexField(_select.value),
     filters: createInputFilters(queryFilter.value, _filters.value),
     sort: _sort.value.length > 0 ? _sort.value : defaultSort.value ?? [],
     page: page.value,
@@ -231,18 +247,54 @@ const tableMaxHeight = computed(() => {
   return `--table-max-height: calc(${props.height} - ${controlHeight} - ${conditionBlocksHeight.value} - ${columnsHeight} - ${footerHeight})`
 })
 
-// Initial setup when the result is loaded for the first time.
+// Initial setup when the result is loaded for the first time. When the
+// caller didn't pass a `select`, we initialise from the response, but
+// we strip out the index field — anything pulled in by `withIndexField`
+// on the way out shouldn't pretend to be caller-declared on the way
+// back in.
 watch(result, (res) => {
   if (!hasInitialResults.value && res!.data.length > 0) {
     hasInitialResults.value = true
   }
   if (_select.value.length === 0) {
-    _select.value = res!.query.select
+    _select.value = withoutIndexField(res!.query.select)
   }
   if (_selectable.value.length === 0) {
-    _selectable.value = res!.query.select
+    _selectable.value = withoutIndexField(res!.query.select)
   }
 }, { once: true })
+
+// Columns to render in the table. We always defer to `_select` (caller
+// or user intent) once we have it; before the first response we use the
+// raw response select with the index field filtered out so an
+// auto-fetched index field doesn't accidentally appear as a column.
+const tableSelect = computed(() => {
+  if (_select.value.length > 0) {
+    return _select.value
+  }
+  return withoutIndexField(result.value?.query.select ?? [])
+})
+
+// The `indexField` is appended to the request `select` so the server
+// returns its value on every row, but it is kept out of the internal
+// `_select` / `_selectable` state so the caller-facing concept of
+// "selected columns" stays clean (the index field is a row identifier,
+// not a column the user picked). The corresponding column is also
+// hidden from the rendered table by `LensTable`.
+//
+// When the caller has no concrete select list, the index field is
+// *not* added either — leaving the request empty lets the server use
+// its own defaults. See `indexField` prop docs above.
+function withIndexField(fields: string[]): string[] {
+  if (fields.length === 0) { return [...fields] }
+  if (!props.indexField || fields.includes(props.indexField)) { return [...fields] }
+  return [...fields, props.indexField]
+}
+
+function withoutIndexField(fields: string[]): string[] {
+  if (!props.indexField) { return [...fields] }
+  return fields.filter((f) => f !== props.indexField)
+}
 
 // Create lens filters option by combining query (free search) filters,
 // user selected filters, and fixed filters.
@@ -313,6 +365,8 @@ function onResetSorts() {
 }
 
 function onViewUpdated(newSelect: string[], newSelectable: string[], overrides: Record<string, Partial<FieldData>>) {
+  // Treat updates from the view form as deliberate user intent: if the
+  // user picked the index field on purpose, surface its column.
   _select.value = newSelect
   _selectable.value = newSelectable
   _overrides.value = overrides
@@ -423,6 +477,7 @@ defineExpose({
           :result
           :loading
           :overrides="_overrides"
+          :select="tableSelect"
           :index-field
           :selected
           :clickable-fields

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -286,7 +286,7 @@ const tableSelect = computed(() => {
 // *not* added either — leaving the request empty lets the server use
 // its own defaults. See `indexField` prop docs above.
 function withIndexField(fields: string[]): string[] {
-  if (fields.length === 0) { return [...fields] }
+  if (fields.length === 0) { return [] }
   if (!props.indexField || fields.includes(props.indexField)) { return [...fields] }
   return [...fields, props.indexField]
 }

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -14,6 +14,11 @@ const props = defineProps<{
   result?: LensResult
   overrides?: Record<string, Partial<FieldData>>
   loading: boolean
+  // The list of field keys to actually render as columns, in order.
+  // Falls back to `result.query.select` if not provided. The catalog
+  // uses this to control whether an auto-fetched `indexField` shows up
+  // as a column.
+  select?: string[]
   selected?: any[]
   indexField?: string
 }>()
@@ -29,8 +34,10 @@ const fieldFactory = useFieldFactory()
 
 const records = computed(() => props.result?.data ?? [])
 
+const columnKeys = computed(() => props.select ?? props.result?.query.select ?? [])
+
 const orders = computed(() => [
-  ...(props.result?.query.select ?? []),
+  ...columnKeys.value,
   '__last_empty__'
 ])
 
@@ -48,9 +55,9 @@ const columns = computedAsync(async () => {
     }
   }
 
-  // Build the lest of columns based on selected fields.
-  for (const i in r.query.select) {
-    const key = r.query.select[i]
+  // Build the lest of columns based on the resolved column key list.
+  for (const i in columnKeys.value) {
+    const key = columnKeys.value[i]
 
     const _fieldData = cloneDeep(r.fields[key])
 

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -55,7 +55,7 @@ const columns = computedAsync(async () => {
     }
   }
 
-  // Build the lest of columns based on the resolved column key list.
+  // Build the list of columns based on the resolved column key list.
   for (const i in columnKeys.value) {
     const key = columnKeys.value[i]
 


### PR DESCRIPTION
Closes #713.

## Background

`LensCatalog` already accepts an `indexField` prop. Today it's only used to feed `useTable`'s `indexField`, so the model behind the table knows which key uniquely identifies a row. But the prop doesn't actually do anything about fetching that field or hiding it from the rendered columns — the caller still has to remember to include it in `select` themselves, and then live with it showing up as a visible column.

That's awkward for one of the most common patterns we see with `LensCatalog`: rows that need an identifier you can hand to a click handler ("open the detail page for this thing"), but where you don't want that identifier as a column. Without first-class support for that pattern, callers end up doing things like:

```vue
<LensCatalog
  :select="['id', 'name', 'status']"
  index-field="id"
  @cell-clicked="(_, r) => router.push(`/things/${r.id}`)"
/>
```

`id` shows up as a redundant column, and there's no clean way to hide it without inventing a generic "hidden columns" override that mixes data-fetching concerns into display concerns.

## What this PR does

`indexField` now does three concrete things on top of its existing role:

1. It is **automatically appended to the request `select`** so every row in `data` carries its value, without the caller having to list it in `select`.
2. It is **excluded from the rendered columns** by default, so it doesn't take up a column the caller didn't ask for.
3. But if the caller **explicitly listed** the index field in `select` (or `selectable`), the column is shown / pickable normally — the explicit intent wins.

So the common case ("fetch but don't display") becomes a one-liner:

```vue
<LensCatalog
  endpoint=\"/api/things\"
  :select=\"['name', 'status']\"
  index-field=\"id\"
  @cell-clicked=\"(_, r) => router.push(`/things/${r.id}`)\"
/>
```

The request body still goes out as `select: ['name', 'status', 'id']` so the server returns the id on every row, but the table only renders `name` and `status`. `r.id` is available in `cell-clicked` and through `selected`.

And callers that *want* the id visible can still get it by saying so:

```vue
<LensCatalog
  :select=\"['id', 'name', 'status']\"
  index-field=\"id\"
/>
```

Now `id` is both the row identifier *and* a rendered column.

## Behavior matrix

The rule is consistent across `select` and `selectable`: caller intent always wins, the catalog only hides things the caller didn't explicitly opt into.

| Caller props | Rendered columns | `LensFormView` (column picker) toggle |
| --- | --- | --- |
| `select=['id', 'name']` | `id`, `name` | Both pickable |
| `select=['name']` | `name` only (`id` auto-fetched & hidden) | `name` only |
| `select=['name'], selectable=['id', 'name']` | `name` | Both pickable — user can add `id` |
| `select` and `selectable` both unset | server defaults minus `id` | server defaults minus `id` |

In other words, the index field is treated as a row identifier by default, but the caller can promote it to a regular column by listing it in `select`, or expose it to the user via the column picker by listing it in `selectable` — exactly the same shape as for any other field.

## Edge case: empty `select`

There's one subtlety. Some backends (we have a real example of this — a saved-view-style endpoint that already has a configured set of default columns) treat an empty `select` as \"use server defaults\". If we naively auto-appended `indexField` even when the caller passed no select at all, the request would go out as `select: ['id']` and the server would happily narrow the result down to just that single column. The catalog would render an empty table.

So the auto-append only kicks in when the caller actually has a concrete select to start with:

```ts
function withIndexField(fields: string[]): string[] {
  if (fields.length === 0) return [...fields]
  if (!props.indexField || fields.includes(props.indexField)) return [...fields]
  return [...fields, props.indexField]
}
```

When `select` is empty, the request body is left empty too, and the server's defaults run unmodified.

## How it's wired

The new behaviour is implemented entirely inside `LensCatalog` and `LensTable`. The wire format and the response shape don't change — `indexField` stays an internal concept of the catalog, not something the server has to know about.

Inside `LensCatalog`:

- `_select` and `_selectable` are now seeded directly from `props.select` (and the response, when the caller doesn't pass one). They represent caller / user intent, including the index field if it was explicitly included.
- The request payload uses `withIndexField(_select.value)` to ensure the row identifier comes back regardless.
- When restoring from the server's response (the case where the caller didn't pass a select), `withoutIndexField` strips the auto-fetched index field out before it gets stored as if the user had asked for it.
- `onViewUpdated` (the LensFormView flow) takes the user's pick at face value — if the user adds the index field through the column picker, the column appears.

Inside `LensTable`:

- A new `select` prop (the resolved column key list, computed by the catalog) drives both the column order and the rendered columns.
- The previous \"`if (key === indexField) continue`\" guard is gone — the catalog decides what to show, the table just renders it.

The catalog computes the table's column list with a small `tableSelect` computed:

```ts
const tableSelect = computed(() => {
  if (_select.value.length > 0) return _select.value
  return withoutIndexField(result.value?.query.select ?? [])
})
```

## Test plan

- [ ] Pass `:select=\"['name']\"` + `index-field=\"id\"`: rows include `id`, only `name` column renders, `cell-clicked` payload has `r.id`.
- [ ] Pass `:select=\"['id', 'name']\"` + `index-field=\"id\"`: both columns render.
- [ ] Pass `:select=\"['name'], :selectable=\"['id', 'name']\"` + `index-field=\"id\"`: only `name` renders initially, but the column picker lists both — adding `id` shows the column.
- [ ] Pass no `select` + `index-field=\"id\"` against an endpoint whose defaults already include `id`: the table renders the server's defaults except `id`, no empty table.
- [ ] Existing pages that use `index-field` purely for `selected` keep working unchanged.