### PR TITLE
fix(lens): stabilize LensTable columns against in-flight refresh

### DIFF
--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -34,7 +34,21 @@ const fieldFactory = useFieldFactory()
 
 const records = computed(() => props.result?.data ?? [])
 
-const columnKeys = computed(() => props.select ?? props.result?.query.select ?? [])
+// Resolve the list of columns to render. We intersect the caller's
+// requested `select` with what the latest response actually fetched so
+// that toggling a column on through "Manage table view" doesn't surface
+// a new column synchronously against still-stale records. Without this,
+// fields like `SelectField` blow up trying to render `undefined` for
+// the brand-new column before the refresh response lands.
+const columnKeys = computed(() => {
+  const requested = props.select ?? props.result?.query.select ?? []
+  const fetched = props.result?.query.select
+  if (!fetched) {
+    return requested
+  }
+  const fetchedSet = new Set(fetched)
+  return requested.filter((k) => fetchedSet.has(k))
+})
 
 const orders = computed(() => [
   ...columnKeys.value,
@@ -48,6 +62,14 @@ const columns = computedAsync(async () => {
     return {}
   }
 
+  // Snapshot the column keys at the start of the run. `columnKeys` is a
+  // computed off reactive props; if it changes mid-await (e.g. the user
+  // toggles a column off in "Manage table view"), subsequent reads
+  // through the live ref would jump to the new, shorter array and
+  // produce `undefined` for indices past the new length — crashing
+  // `Object.assign(_fieldData, ...)` below.
+  const keys = [...columnKeys.value]
+
   // Prepare base columns that has `__last_empty__` to fill the end space.
   const columns: TableColumns<any, any, any> = {
     __last_empty__: {
@@ -56,10 +78,12 @@ const columns = computedAsync(async () => {
   }
 
   // Build the list of columns based on the resolved column key list.
-  for (const i in columnKeys.value) {
-    const key = columnKeys.value[i]
-
+  for (const key of keys) {
     const _fieldData = cloneDeep(r.fields[key])
+
+    if (!_fieldData) {
+      continue
+    }
 
     const overriddenFieldData = Object.assign(
       _fieldData,


### PR DESCRIPTION
## Summary

`LensTable` derives its column list from `props.select` and reads that array reactively inside an async loop. Two race conditions can crash the table when the user reshuffles columns via **Manage table view**:

### 1. `columnKeys` re-read across `await` in `computedAsync`

The `columns` computed runs `await field.tableFilterMenu(...)` inside `for (const i in columnKeys.value) { const key = columnKeys.value[i] }`. If the user shortens the select list while a prior run is still awaiting, the next iteration re-reads `columnKeys.value` — now the new, shorter array — and `columnKeys.value[i]` returns `undefined` for indices past the new length. `Object.assign(_fieldData, ...)` then throws:

```
Uncaught (in promise) TypeError: Cannot convert undefined or null to object
    at Function.assign (<anonymous>)
    at LensTable.vue:64
```

Reproduction: open Manage table view, uncheck a column, click Apply.

### 2. `columnKeys` surfaces a column before the refresh response lands

`columnKeys` returned `props.select` synchronously regardless of what was actually fetched. When a user re-checks a column they previously removed:

- `_select` in `LensCatalog` updates synchronously to include the column again.
- `LensTable.columnKeys` immediately includes it too.
- But `props.result.data` is still the prior response, whose records don't carry that field.
- The new column renders against records where `record[key]` is `undefined`, and a field like `SelectField` throws:

```
Error: Option with value "undefined" not found in select field options.
    at SelectField.optionForValue
```

Reproduction: uncheck a `SelectField` column (e.g. a status field) → Apply → reopen → check it again → Apply.

## Fix

- **Snapshot `columnKeys.value` at the start of the `computedAsync` run.** A late re-read can no longer jump to a newer, shorter array.
- **Gate the column list on the latest fetched `result.query.select`.** Toggling a column on now waits until the refresh response actually carries that field before the column appears, so cells never render against records that lack the data.
- **Skip keys whose field data is missing** instead of crashing. A stray mismatch (a registered field that wasn't returned, an unknown key in `select`, etc.) now degrades gracefully to a hidden column rather than taking the whole table down.
- Loop body migrated from `for...in` to `for...of` over the snapshot for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)