### PR TITLE
feat(lens): add text field unit options and Slack channel name rule

### DIFF
--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -147,6 +147,8 @@ export interface TextFieldData extends FieldDataBase {
   placeholderJa: string | null
   helpEn: string | null
   helpJa: string | null
+  unitBefore: string | null
+  unitAfter: string | null
 }
 
 export interface TextareaFieldData extends FieldDataBase {

--- a/lib/blocks/lens/Rule.ts
+++ b/lib/blocks/lens/Rule.ts
@@ -1,6 +1,7 @@
 export type Rule =
   | MaxLengthRule
   | RequiredRule
+  | SlackChannelNameRule
   | BeforeRule
   | BeforeOrEqualRule
   | AfterRule
@@ -13,6 +14,11 @@ export interface MaxLengthRule {
 
 export interface RequiredRule {
   type: 'required'
+}
+
+export interface SlackChannelNameRule {
+  type: 'slack_channel_name'
+  offset: number
 }
 
 export interface BeforeRule {

--- a/lib/blocks/lens/fields/TextField.ts
+++ b/lib/blocks/lens/fields/TextField.ts
@@ -38,6 +38,8 @@ export class TextField extends Field<TextFieldData> {
         'label': this.formInputLabel(),
         'placeholder': this.placeholder() || undefined,
         'help': this.help() || undefined,
+        'unitBefore': this.data.unitBefore || undefined,
+        'unitAfter': this.data.unitAfter || undefined,
         'modelValue': props.modelValue,
         'validation': props.validation,
         'onUpdate:modelValue': (value: any) => {

--- a/lib/blocks/lens/validation/RuleMapper.ts
+++ b/lib/blocks/lens/validation/RuleMapper.ts
@@ -1,6 +1,6 @@
 import { type ValidationArgs, type ValidationRuleWithParams } from '@vuelidate/core'
 import { type Day, day } from '../../../support/Day'
-import { after, afterOrEqual, before, beforeOrEqual, maxLength, required } from '../../../validation/rules'
+import { after, afterOrEqual, before, beforeOrEqual, maxLength, required, slackChannelName } from '../../../validation/rules'
 import { type Rule } from '../Rule'
 
 /**
@@ -19,6 +19,8 @@ function mapRule(rule: Rule): ValidationRuleWithParams {
       return maxLength(rule.length)
     case 'required':
       return required()
+    case 'slack_channel_name':
+      return slackChannelName({ offset: rule.offset })
     case 'before':
       return before(resolveDate(rule.date))
     case 'before_or_equal':

--- a/tests/blocks/lens/validation/RuleMapper.spec.ts
+++ b/tests/blocks/lens/validation/RuleMapper.spec.ts
@@ -15,6 +15,20 @@ describe('blocks/lens/validation/RuleMapper', () => {
     expect(args.max_length.$validator('12345678901', null, null)).toBe(false)
   })
 
+  it('maps slack_channel_name rule', () => {
+    const args = map([{ type: 'slack_channel_name', offset: 0 }]) as any
+
+    expect(args.slack_channel_name.$validator('my-channel', null, null)).toBe(true)
+    expect(args.slack_channel_name.$validator('Invalid Channel', null, null)).toBe(false)
+  })
+
+  it('applies the offset when mapping slack_channel_name rule', () => {
+    const args = map([{ type: 'slack_channel_name', offset: 2 }]) as any
+
+    expect(args.slack_channel_name.$validator('a'.repeat(78), null, null)).toBe(true)
+    expect(args.slack_channel_name.$validator('a'.repeat(79), null, null)).toBe(false)
+  })
+
   it('maps before rule with an absolute date', () => {
     const args = map([{ type: 'before', date: '2026-01-02' }]) as any
 


### PR DESCRIPTION
## Summary

Client-side mirror of the anima Lens additions:

- `TextFieldData` gains `unitBefore` / `unitAfter`; the text field's form input forwards them to `SInputText`, which already renders unit slots.
- Adds the `slack_channel_name` rule type and maps it in `RuleMapper` to the existing `slackChannelName` validator, honoring the `offset` option.

## Test plan

- [ ] `pnpm check` — `RuleMapper.spec.ts` covers the new rule mapping