### PR TITLE
feat(lens): add boolean and related-one field types

### DIFF
--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -141,19 +141,25 @@ export interface SelectFieldDataOption {
 export interface RelatedManyFieldData extends FieldDataBase {
   type: 'related_many'
   title: string
+  image: string | null
   resourceEndpointMethod: 'get' | 'post'
   resourceEndpointPath: string
   resourceEndpointDataKey: string | null
   resourceTitle: string
+  resourceImage: string | null
+  displayAs: 'pills' | 'avatars' | null
 }
 
 export interface RelatedOneFieldData extends FieldDataBase {
   type: 'related_one'
   title: string
+  image: string | null
   resourceEndpointMethod: 'get' | 'post'
   resourceEndpointPath: string
   resourceEndpointDataKey: string | null
   resourceTitle: string
+  resourceImage: string | null
+  displayAs: 'text' | 'avatar' | null
 }
 
 export interface SlackMessageFieldData extends FieldDataBase {

--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -17,6 +17,7 @@ import { type Rule } from './Rule'
  * }
  */
 export interface FieldDataRegistry {
+  boolean: BooleanFieldData
   content: ContentFieldData
   date: DateFieldData
   datetime: DatetimeFieldData
@@ -46,6 +47,14 @@ export interface FieldDataBase {
   width: number
   required: boolean
   rules: Rule[]
+}
+
+export interface BooleanFieldData extends FieldDataBase {
+  type: 'boolean'
+  labelTrueEn: string | null
+  labelTrueJa: string | null
+  labelFalseEn: string | null
+  labelFalseJa: string | null
 }
 
 export interface ContentFieldData extends FieldDataBase {

--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -141,25 +141,25 @@ export interface SelectFieldDataOption {
 export interface RelatedManyFieldData extends FieldDataBase {
   type: 'related_many'
   title: string
-  image: string | null
+  image?: string | null
   resourceEndpointMethod: 'get' | 'post'
   resourceEndpointPath: string
   resourceEndpointDataKey: string | null
   resourceTitle: string
-  resourceImage: string | null
-  displayAs: 'pills' | 'avatars' | null
+  resourceImage?: string | null
+  displayAs?: 'pills' | 'avatars' | null
 }
 
 export interface RelatedOneFieldData extends FieldDataBase {
   type: 'related_one'
   title: string
-  image: string | null
+  image?: string | null
   resourceEndpointMethod: 'get' | 'post'
   resourceEndpointPath: string
   resourceEndpointDataKey: string | null
   resourceTitle: string
-  resourceImage: string | null
-  displayAs: 'text' | 'avatar' | null
+  resourceImage?: string | null
+  displayAs?: 'text' | 'avatar' | null
 }
 
 export interface SlackMessageFieldData extends FieldDataBase {

--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -27,6 +27,7 @@ export interface FieldDataRegistry {
   link: LinkFieldData
   number: NumberFieldData
   related_many: RelatedManyFieldData
+  related_one: RelatedOneFieldData
   select: SelectFieldData
   slack_message: SlackMessageFieldData
   text: TextFieldData
@@ -139,6 +140,15 @@ export interface SelectFieldDataOption {
 
 export interface RelatedManyFieldData extends FieldDataBase {
   type: 'related_many'
+  title: string
+  resourceEndpointMethod: 'get' | 'post'
+  resourceEndpointPath: string
+  resourceEndpointDataKey: string | null
+  resourceTitle: string
+}
+
+export interface RelatedOneFieldData extends FieldDataBase {
+  type: 'related_one'
   title: string
   resourceEndpointMethod: 'get' | 'post'
   resourceEndpointPath: string

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -328,14 +328,21 @@ function onInlineFilterUpdated(filter: any[]) {
   emit('filters-updated', _filters.value)
 }
 
+// A filter value "clears" the filter when it's nullish or an empty
+// array. Scalar operators (e.g. a boolean `=`) carry a single value, so
+// `false` is a real value to keep — only `null` clears.
+function isEmptyFilterValue(value: any): boolean {
+  return value == null || (Array.isArray(value) && value.length === 0)
+}
+
 function applyNewFilter(filter: any[]) {
-  if (filter[2].length > 0) {
+  if (!isEmptyFilterValue(filter[2])) {
     _filters.value.push(filter)
   }
 }
 
 function replaceFilter(index: number, filter: any[]) {
-  if (filter[2].length === 0) {
+  if (isEmptyFilterValue(filter[2])) {
     _filters.value.splice(index, 1)
     return
   }

--- a/lib/blocks/lens/composables/SetupLens.ts
+++ b/lib/blocks/lens/composables/SetupLens.ts
@@ -11,6 +11,7 @@ import { IdField } from '../fields/IdField'
 import { LinkField } from '../fields/LinkField'
 import { NumberField } from '../fields/NumberField'
 import { RelatedManyField } from '../fields/RelatedManyField'
+import { RelatedOneField } from '../fields/RelatedOneField'
 import { SelectField } from '../fields/SelectField'
 import { SlackMessageField } from '../fields/SlackMessageField'
 import { TextField } from '../fields/TextField'
@@ -43,6 +44,7 @@ export function useSetupLens(): SetupLens {
     fieldRegistry.register('number', (ctx, field) => new NumberField(ctx, field))
     fieldRegistry.register('id', (ctx, field) => new IdField(ctx, field))
     fieldRegistry.register('related_many', (ctx, field) => new RelatedManyField(ctx, field, resourceFetcher))
+    fieldRegistry.register('related_one', (ctx, field) => new RelatedOneField(ctx, field, resourceFetcher))
     fieldRegistry.register('select', (ctx, field) => new SelectField(ctx, field))
     fieldRegistry.register('slack_message', (ctx, field) => new SlackMessageField(ctx, field))
     fieldRegistry.register('text', (ctx, field) => new TextField(ctx, field))

--- a/lib/blocks/lens/composables/SetupLens.ts
+++ b/lib/blocks/lens/composables/SetupLens.ts
@@ -1,6 +1,7 @@
 import { type FieldDataType } from '../FieldData'
 import { type FieldDataFor, type FieldProvider, FieldRegistry } from '../FieldRegistry'
 import { provideFieldRegistry } from '../composables/FieldRegistry'
+import { BooleanField } from '../fields/BooleanField'
 import { ContentField } from '../fields/ContentField'
 import { DateField } from '../fields/DateField'
 import { DatetimeField } from '../fields/DatetimeField'
@@ -32,6 +33,7 @@ export function useSetupLens(): SetupLens {
   registerDefaultFields()
 
   function registerDefaultFields(): void {
+    fieldRegistry.register('boolean', (ctx, field) => new BooleanField(ctx, field))
     fieldRegistry.register('content', (ctx, field) => new ContentField(ctx, field))
     fieldRegistry.register('date', (ctx, field) => new DateField(ctx, field))
     fieldRegistry.register('datetime', (ctx, field) => new DatetimeField(ctx, field))

--- a/lib/blocks/lens/fields/BooleanField.ts
+++ b/lib/blocks/lens/fields/BooleanField.ts
@@ -1,0 +1,71 @@
+import { xor } from 'lodash-es'
+import { type DropdownSection } from '../../../composables/Dropdown'
+import { type TableCell } from '../../../composables/Table'
+import { type BooleanFieldData } from '../FieldData'
+import { type FilterOperator } from '../FilterOperator'
+import { type FilterInput } from '../filter-inputs/FilterInput'
+import { SelectFilterInput } from '../filter-inputs/SelectFilterInput'
+import { Field } from './Field'
+
+const DEFAULTS = {
+  en: { true: 'Yes', false: 'No' },
+  ja: { true: 'はい', false: 'いいえ' }
+} as const
+
+export class BooleanField extends Field<BooleanFieldData> {
+  override tableCell(v: any, _r: any): TableCell {
+    return {
+      type: 'text',
+      value: this.formatValue(v)
+    }
+  }
+
+  override async tableFilterMenu(filters: any[], onFilterUpdated: (filters: any[]) => void): Promise<DropdownSection | null> {
+    const selected = this.inFilterValueFor(this.data.key, filters)
+
+    return {
+      type: 'filter',
+      search: false,
+      selected,
+      options: this.filterOptions(),
+      onClick: (v) => { onFilterUpdated?.([this.data.key, 'in', xor(selected, [v])]) }
+    }
+  }
+
+  override availableFilters(): Partial<Record<FilterOperator, FilterInput>> {
+    const selectOne = new SelectFilterInput().options(() => Promise.resolve(this.filterOptions()))
+    return {
+      '=': selectOne,
+      '!=': selectOne
+    }
+  }
+
+  override dataListItemComponent(): any {
+    return this.defineDataListItemComponent((value) => this.formatValue(value))
+  }
+
+  override formInputComponent(): any {
+    throw new Error('Not implemented.')
+  }
+
+  protected filterOptions(): Array<{ value: boolean; label: string }> {
+    return [
+      { value: true, label: this.formatValue(true)! },
+      { value: false, label: this.formatValue(false)! }
+    ]
+  }
+
+  protected formatValue(v: any): string | null {
+    if (v === null || v === undefined) {
+      return null
+    }
+    if (v) {
+      return this.ctx.lang === 'ja'
+        ? (this.data.labelTrueJa ?? DEFAULTS.ja.true)
+        : (this.data.labelTrueEn ?? DEFAULTS.en.true)
+    }
+    return this.ctx.lang === 'ja'
+      ? (this.data.labelFalseJa ?? DEFAULTS.ja.false)
+      : (this.data.labelFalseEn ?? DEFAULTS.en.false)
+  }
+}

--- a/lib/blocks/lens/fields/BooleanField.ts
+++ b/lib/blocks/lens/fields/BooleanField.ts
@@ -1,4 +1,3 @@
-import { xor } from 'lodash-es'
 import { type DropdownSection } from '../../../composables/Dropdown'
 import { type TableCell } from '../../../composables/Table'
 import { type BooleanFieldData } from '../FieldData'
@@ -21,25 +20,28 @@ export class BooleanField extends Field<BooleanFieldData> {
   }
 
   override async tableFilterMenu(filters: any[], onFilterUpdated: (filters: any[]) => void): Promise<DropdownSection | null> {
-    const selected = this.inFilterValueFor(this.data.key, filters)
+    // A boolean has exactly two states, so the inline menu is a single
+    // select on `=`. Re-clicking the active value clears the filter.
+    const selected = this.eqFilterValueFor(this.data.key, filters)
 
     return {
       type: 'filter',
       search: false,
       selected,
       options: this.filterOptions(),
-      onClick: (v) => { onFilterUpdated?.([this.data.key, 'in', xor(selected, [v])]) }
+      onClick: (v) => { onFilterUpdated?.([this.data.key, '=', selected === v ? null : v]) }
     }
   }
 
   override availableFilters(): Partial<Record<FilterOperator, FilterInput>> {
-    // Use `in` to match the operator the inline column menu emits, and
-    // `.multiple()` so the value stays a boolean array — the single-value
-    // cast would stringify `true` to `'true'`, breaking option matching
-    // and the backend boolean comparison.
-    const selectMany = new SelectFilterInput().options(() => Promise.resolve(this.filterOptions())).multiple()
+    // A boolean is a two-state value, so `=` / `!=` express the filter
+    // more naturally than set membership. The single-value cast preserves
+    // the boolean (it no longer stringifies), so option matching and the
+    // backend comparison stay correct.
+    const selectOne = new SelectFilterInput().options(() => Promise.resolve(this.filterOptions()))
     return {
-      in: selectMany
+      '=': selectOne,
+      '!=': selectOne
     }
   }
 

--- a/lib/blocks/lens/fields/BooleanField.ts
+++ b/lib/blocks/lens/fields/BooleanField.ts
@@ -33,10 +33,13 @@ export class BooleanField extends Field<BooleanFieldData> {
   }
 
   override availableFilters(): Partial<Record<FilterOperator, FilterInput>> {
-    const selectOne = new SelectFilterInput().options(() => Promise.resolve(this.filterOptions()))
+    // Use `in` to match the operator the inline column menu emits, and
+    // `.multiple()` so the value stays a boolean array — the single-value
+    // cast would stringify `true` to `'true'`, breaking option matching
+    // and the backend boolean comparison.
+    const selectMany = new SelectFilterInput().options(() => Promise.resolve(this.filterOptions())).multiple()
     return {
-      '=': selectOne,
-      '!=': selectOne
+      in: selectMany
     }
   }
 

--- a/lib/blocks/lens/fields/Field.ts
+++ b/lib/blocks/lens/fields/Field.ts
@@ -121,6 +121,19 @@ export abstract class Field<T extends FieldData> {
   }
 
   /**
+   * Returns the "=" filter value for the given key from the filters
+   * array, or `null` when there is none.
+   */
+  protected eqFilterValueFor(key: string, filters: any[]): any {
+    for (const f of filters) {
+      if (f[0] === key && f[1] === '=') {
+        return f[2]
+      }
+    }
+    return null
+  }
+
+  /**
    * Returns the table cell definition for the field.
    */
   abstract tableCell(v: any, r: any): TableCell

--- a/lib/blocks/lens/fields/RelatedManyField.ts
+++ b/lib/blocks/lens/fields/RelatedManyField.ts
@@ -30,10 +30,19 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
     const res = await this.fetcher(method, url)
     const data = key ? res[key] : res
 
-    const options = data.map((item: any) => ({
-      label: item[this.data.resourceTitle],
-      value: item[this.data.filterKey]
-    }))
+    const isAvatar = this.data.displayAs === 'avatars'
+
+    const options = data.map((item: any) => isAvatar
+      ? {
+          type: 'avatar' as const,
+          label: item[this.data.resourceTitle],
+          image: this.data.resourceImage ? item[this.data.resourceImage] : null,
+          value: item[this.data.filterKey]
+        }
+      : {
+          label: item[this.data.resourceTitle],
+          value: item[this.data.filterKey]
+        })
 
     return {
       type: 'filter',
@@ -45,9 +54,24 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
   }
 
   override tableCell(v: any, _r: any): TableCell {
+    const items = (v ?? []) as any[]
+
+    if (this.data.displayAs === 'avatars') {
+      return {
+        type: 'avatars',
+        avatars: items.map((item) => ({
+          image: this.data.image ? item[this.data.image] : null,
+          name: item[this.data.title]
+        })),
+        avatarCount: 6,
+        nameCount: 0,
+        tooltip: true
+      }
+    }
+
     return {
       type: 'pills',
-      pills: v.map((item: any) => ({
+      pills: items.map((item) => ({
         label: item[this.data.title],
         value: item[this.data.filterKey]
       }))

--- a/lib/blocks/lens/fields/RelatedOneField.ts
+++ b/lib/blocks/lens/fields/RelatedOneField.ts
@@ -56,7 +56,7 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
   override tableCell(v: any, _r: any): TableCell {
     if (v === null || v === undefined) {
       if (this.data.displayAs === 'avatar') {
-        return { type: 'avatar', image: null, name: null }
+        return { type: 'avatar', image: null, name: '' }
       }
       return { type: 'text', value: null }
     }
@@ -65,7 +65,10 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
       return {
         type: 'avatar',
         image: this.data.image ? (v[this.data.image] ?? null) : null,
-        name: v[this.data.title] ?? null
+        // Empty string (not null) for the same reason as the text branch
+        // below — a null name falls back to the raw row value in the cell
+        // renderer and breaks SAvatar.
+        name: v[this.data.title] ?? ''
       }
     }
 

--- a/lib/blocks/lens/fields/RelatedOneField.ts
+++ b/lib/blocks/lens/fields/RelatedOneField.ts
@@ -71,7 +71,10 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
 
     return {
       type: 'text',
-      value: v[this.data.title] ?? null
+      // Empty string (not null) when the title is missing: the table
+      // renderer falls back to the raw row value on a null cell value,
+      // which would render the relation object as `[object Object]`.
+      value: v[this.data.title] ?? ''
     }
   }
 

--- a/lib/blocks/lens/fields/RelatedOneField.ts
+++ b/lib/blocks/lens/fields/RelatedOneField.ts
@@ -1,0 +1,92 @@
+import { xor } from 'lodash-es'
+import { type DropdownSection } from '../../../composables/Dropdown'
+import { type TableCell } from '../../../composables/Table'
+import { type RelatedOneFieldData } from '../FieldData'
+import { type FilterOperator } from '../FilterOperator'
+import { type ResourceFetcher } from '../ResourceFetcher'
+import { type FilterInput } from '../filter-inputs/FilterInput'
+import { SelectFilterInput } from '../filter-inputs/SelectFilterInput'
+import { Field } from './Field'
+
+export class RelatedOneField extends Field<RelatedOneFieldData> {
+  fetcher: ResourceFetcher
+
+  constructor(ctx: any, data: RelatedOneFieldData, fetcher: ResourceFetcher) {
+    super(ctx, data)
+    this.fetcher = fetcher
+  }
+
+  override async tableFilterMenu(filters: any[], onFilterUpdated: (filters: any[]) => void): Promise<DropdownSection | null> {
+    const method = this.data.resourceEndpointMethod
+    const url = this.data.resourceEndpointPath
+    const key = this.data.resourceEndpointDataKey
+
+    if (!url) {
+      return null
+    }
+
+    const selected = this.inFilterValueFor(this.data.key, filters)
+
+    const res = await this.fetcher(method, url)
+    const data = key ? res[key] : res
+
+    const options = data.map((item: any) => ({
+      label: item[this.data.resourceTitle],
+      value: item[this.data.filterKey]
+    }))
+
+    return {
+      type: 'filter',
+      search: true,
+      selected,
+      options,
+      onClick: (v) => { onFilterUpdated?.([this.data.key, 'in', xor(selected, [v])]) }
+    }
+  }
+
+  override tableCell(v: any, _r: any): TableCell {
+    if (v === null || v === undefined) {
+      return { type: 'text', value: null }
+    }
+    return {
+      type: 'text',
+      value: v[this.data.title] ?? null
+    }
+  }
+
+  override availableFilters(): Partial<Record<FilterOperator, FilterInput>> {
+    const method = this.data.resourceEndpointMethod
+    const url = this.data.resourceEndpointPath
+    const key = this.data.resourceEndpointDataKey
+
+    if (!url) {
+      return {}
+    }
+
+    const optionsResolver = async () => {
+      const res = await this.fetcher(method, url)
+      const data = key ? res[key] : res
+      return data.map((item: any) => ({
+        value: item[this.data.filterKey],
+        label: item[this.data.resourceTitle]
+      }))
+    }
+
+    const selectOne = new SelectFilterInput().options(optionsResolver)
+    const selectMany = new SelectFilterInput().options(optionsResolver).multiple()
+
+    return {
+      '=': selectOne,
+      '!=': selectOne,
+      'in': selectMany
+    }
+  }
+
+  override dataListItemComponent(): any {
+    throw new Error('Not implemented.')
+  }
+
+  override formInputComponent() {
+    throw new Error('Not implemented.')
+  }
+}

--- a/lib/blocks/lens/fields/RelatedOneField.ts
+++ b/lib/blocks/lens/fields/RelatedOneField.ts
@@ -30,10 +30,19 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
     const res = await this.fetcher(method, url)
     const data = key ? res[key] : res
 
-    const options = data.map((item: any) => ({
-      label: item[this.data.resourceTitle],
-      value: item[this.data.filterKey]
-    }))
+    const isAvatar = this.data.displayAs === 'avatar'
+
+    const options = data.map((item: any) => isAvatar
+      ? {
+          type: 'avatar' as const,
+          label: item[this.data.resourceTitle],
+          image: this.data.resourceImage ? item[this.data.resourceImage] : null,
+          value: item[this.data.filterKey]
+        }
+      : {
+          label: item[this.data.resourceTitle],
+          value: item[this.data.filterKey]
+        })
 
     return {
       type: 'filter',
@@ -46,8 +55,20 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
 
   override tableCell(v: any, _r: any): TableCell {
     if (v === null || v === undefined) {
+      if (this.data.displayAs === 'avatar') {
+        return { type: 'avatar', image: null, name: null }
+      }
       return { type: 'text', value: null }
     }
+
+    if (this.data.displayAs === 'avatar') {
+      return {
+        type: 'avatar',
+        image: this.data.image ? (v[this.data.image] ?? null) : null,
+        name: v[this.data.title] ?? null
+      }
+    }
+
     return {
       type: 'text',
       value: v[this.data.title] ?? null

--- a/lib/blocks/lens/filter-inputs/SelectFilterInput.ts
+++ b/lib/blocks/lens/filter-inputs/SelectFilterInput.ts
@@ -35,7 +35,11 @@ export class SelectFilterInput extends FilterInput {
     if (Array.isArray(value)) {
       return value[0]
     }
-    return this.castValueToStringOrNull(value)
+    // Preserve the value's type. Option values can be non-string (e.g.
+    // numeric related-record ids); stringifying here would break strict
+    // option matching in the dropdown summary and send the wrong type to
+    // the backend.
+    return value ?? null
   }
 
   protected castValueMany(value: any): any {

--- a/tests/blocks/lens/fields/BooleanField.spec.ts
+++ b/tests/blocks/lens/fields/BooleanField.spec.ts
@@ -82,9 +82,9 @@ describe('blocks/lens/fields/BooleanField', () => {
   })
 
   describe('availableFilters', () => {
-    it('exposes the "in" operator (matching the inline filter menu)', () => {
+    it('exposes the "=" and "!=" operators', () => {
       const filters = make().availableFilters()
-      expect(Object.keys(filters)).toEqual(['in'])
+      expect(Object.keys(filters).sort()).toEqual(['!=', '='])
     })
   })
 
@@ -99,24 +99,30 @@ describe('blocks/lens/fields/BooleanField', () => {
       ])
     })
 
-    it('passes the current selection through from the filter list', async () => {
-      const filters = [['active', 'in', [true]]]
+    it('passes the current "=" selection through from the filter list', async () => {
+      const filters = [['active', '=', true]]
       const menu = (await make().tableFilterMenu(filters, () => {})) as any
-      expect(menu.selected).toEqual([true])
+      expect(menu.selected).toBe(true)
     })
 
-    it('toggles the selection via xor on click', async () => {
+    it('sets the "=" filter to the clicked value', async () => {
       const captured: any[] = []
-      const onFilterUpdated = (f: any) => { captured.push(f) }
+      const menu = (await make().tableFilterMenu([], (f: any) => { captured.push(f) })) as any
 
-      const filters = [['active', 'in', [true]]]
-      const menu = (await make().tableFilterMenu(filters, onFilterUpdated)) as any
+      menu.onClick(true)
+      expect(captured[0]).toEqual(['active', '=', true])
 
-      menu.onClick(true) // remove true
-      expect(captured[0]).toEqual(['active', 'in', []])
+      menu.onClick(false)
+      expect(captured[1]).toEqual(['active', '=', false])
+    })
 
-      menu.onClick(false) // add false
-      expect(captured[1]).toEqual(['active', 'in', [true, false]])
+    it('clears the filter when the active value is clicked again', async () => {
+      const captured: any[] = []
+      const filters = [['active', '=', true]]
+      const menu = (await make().tableFilterMenu(filters, (f: any) => { captured.push(f) })) as any
+
+      menu.onClick(true)
+      expect(captured[0]).toEqual(['active', '=', null])
     })
   })
 

--- a/tests/blocks/lens/fields/BooleanField.spec.ts
+++ b/tests/blocks/lens/fields/BooleanField.spec.ts
@@ -82,9 +82,9 @@ describe('blocks/lens/fields/BooleanField', () => {
   })
 
   describe('availableFilters', () => {
-    it('exposes "=" and "!=" operators', () => {
+    it('exposes the "in" operator (matching the inline filter menu)', () => {
       const filters = make().availableFilters()
-      expect(Object.keys(filters).sort()).toEqual(['!=', '='])
+      expect(Object.keys(filters)).toEqual(['in'])
     })
   })
 

--- a/tests/blocks/lens/fields/BooleanField.spec.ts
+++ b/tests/blocks/lens/fields/BooleanField.spec.ts
@@ -1,0 +1,130 @@
+import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
+import { type BooleanFieldData } from 'sefirot/blocks/lens/FieldData'
+import { BooleanField } from 'sefirot/blocks/lens/fields/BooleanField'
+
+function ctx(lang: 'en' | 'ja' = 'en'): FieldContext {
+  return { lang }
+}
+
+function make(
+  overrides: Partial<BooleanFieldData> = {},
+  lang: 'en' | 'ja' = 'en'
+): BooleanField {
+  const data: BooleanFieldData = {
+    type: 'boolean',
+    key: 'active',
+    labelEn: 'Active',
+    labelJa: 'アクティブ',
+    filterKey: 'active',
+    sortable: true,
+    freeze: false,
+    width: 0,
+    required: false,
+    rules: [],
+    labelTrueEn: null,
+    labelTrueJa: null,
+    labelFalseEn: null,
+    labelFalseJa: null,
+    ...overrides
+  }
+  return new BooleanField(ctx(lang), data)
+}
+
+describe('blocks/lens/fields/BooleanField', () => {
+  describe('tableCell', () => {
+    it('renders the default "Yes" / "No" labels in English', () => {
+      expect((make().tableCell(true, {}) as any)).toEqual({ type: 'text', value: 'Yes' })
+      expect((make().tableCell(false, {}) as any)).toEqual({ type: 'text', value: 'No' })
+    })
+
+    it('renders the default 「はい」/「いいえ」 labels in Japanese', () => {
+      expect((make({}, 'ja').tableCell(true, {}) as any).value).toBe('はい')
+      expect((make({}, 'ja').tableCell(false, {}) as any).value).toBe('いいえ')
+    })
+
+    it('uses the configured custom labels when provided', () => {
+      const field = make({
+        labelTrueEn: 'Won',
+        labelTrueJa: '受注',
+        labelFalseEn: 'Lost',
+        labelFalseJa: '失注'
+      })
+      expect((field.tableCell(true, {}) as any).value).toBe('Won')
+      expect((field.tableCell(false, {}) as any).value).toBe('Lost')
+
+      const fieldJa = make(
+        {
+          labelTrueEn: 'Won',
+          labelTrueJa: '受注',
+          labelFalseEn: 'Lost',
+          labelFalseJa: '失注'
+        },
+        'ja'
+      )
+      expect((fieldJa.tableCell(true, {}) as any).value).toBe('受注')
+      expect((fieldJa.tableCell(false, {}) as any).value).toBe('失注')
+    })
+
+    it('falls back to the default in the other language when only one custom label is set', () => {
+      const field = make({ labelTrueJa: '受注' }, 'en')
+      // English caller, only JA override → fall back to default "Yes".
+      expect((field.tableCell(true, {}) as any).value).toBe('Yes')
+
+      const fieldJa = make({ labelTrueEn: 'Won' }, 'ja')
+      // JA caller, only EN override → fall back to default 「はい」.
+      expect((fieldJa.tableCell(true, {}) as any).value).toBe('はい')
+    })
+
+    it('keeps null and undefined as null', () => {
+      expect((make().tableCell(null, {}) as any).value).toBeNull()
+      expect((make().tableCell(undefined, {}) as any).value).toBeNull()
+    })
+  })
+
+  describe('availableFilters', () => {
+    it('exposes "=" and "!=" operators', () => {
+      const filters = make().availableFilters()
+      expect(Object.keys(filters).sort()).toEqual(['!=', '='])
+    })
+  })
+
+  describe('tableFilterMenu', () => {
+    it('emits a filter dropdown with both options', async () => {
+      const menu = (await make().tableFilterMenu([], () => {})) as any
+      expect(menu.type).toBe('filter')
+      expect(menu.search).toBe(false)
+      expect(menu.options).toEqual([
+        { value: true, label: 'Yes' },
+        { value: false, label: 'No' }
+      ])
+    })
+
+    it('passes the current selection through from the filter list', async () => {
+      const filters = [['active', 'in', [true]]]
+      const menu = (await make().tableFilterMenu(filters, () => {})) as any
+      expect(menu.selected).toEqual([true])
+    })
+
+    it('toggles the selection via xor on click', async () => {
+      const captured: any[] = []
+      const onFilterUpdated = (f: any) => { captured.push(f) }
+
+      const filters = [['active', 'in', [true]]]
+      const menu = (await make().tableFilterMenu(filters, onFilterUpdated)) as any
+
+      menu.onClick(true) // remove true
+      expect(captured[0]).toEqual(['active', 'in', []])
+
+      menu.onClick(false) // add false
+      expect(captured[1]).toEqual(['active', 'in', [true, false]])
+    })
+  })
+
+  describe('dataListItemComponent', () => {
+    it('returns a component that the test can read via the rendered Vue node', () => {
+      // The component is wrapped in `defineComponent`; we only verify
+      // here that the factory is callable without throwing.
+      expect(() => make().dataListItemComponent()).not.toThrow()
+    })
+  })
+})

--- a/tests/blocks/lens/fields/RelatedManyField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedManyField.spec.ts
@@ -1,0 +1,155 @@
+import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
+import { type RelatedManyFieldData } from 'sefirot/blocks/lens/FieldData'
+import { type ResourceFetcher } from 'sefirot/blocks/lens/ResourceFetcher'
+import { RelatedManyField } from 'sefirot/blocks/lens/fields/RelatedManyField'
+
+function ctx(lang: 'en' | 'ja' = 'en'): FieldContext {
+  return { lang }
+}
+
+function makeFetcher(response: any): ResourceFetcher {
+  return (async () => response) as unknown as ResourceFetcher
+}
+
+function make(
+  overrides: Partial<RelatedManyFieldData> = {},
+  fetcher: ResourceFetcher = makeFetcher([])
+): RelatedManyField {
+  const data: RelatedManyFieldData = {
+    type: 'related_many',
+    key: 'members',
+    labelEn: 'Members',
+    labelJa: 'メンバー',
+    filterKey: 'id',
+    sortable: false,
+    freeze: false,
+    width: 0,
+    required: false,
+    rules: [],
+    title: 'name',
+    image: null,
+    resourceEndpointMethod: 'get',
+    resourceEndpointPath: '/api/members',
+    resourceEndpointDataKey: null,
+    resourceTitle: 'name',
+    resourceImage: null,
+    displayAs: null,
+    ...overrides
+  }
+  return new RelatedManyField(ctx(), data, fetcher)
+}
+
+describe('blocks/lens/fields/RelatedManyField', () => {
+  describe('tableCell (pills mode — default)', () => {
+    it('renders pills with the title property of each row item', () => {
+      const cell = make().tableCell(
+        [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }],
+        {}
+      ) as any
+      expect(cell.type).toBe('pills')
+      expect(cell.pills).toEqual([
+        { label: 'Alice', value: 1 },
+        { label: 'Bob', value: 2 }
+      ])
+    })
+
+    it('honors a custom title key', () => {
+      const cell = make({ title: 'shortName' }).tableCell(
+        [{ id: 1, shortName: 'JP' }, { id: 2, shortName: 'US' }],
+        {}
+      ) as any
+      expect(cell.pills.map((p: any) => p.label)).toEqual(['JP', 'US'])
+    })
+
+    it('keeps null / undefined as an empty list of pills', () => {
+      expect((make().tableCell(null, {}) as any).pills).toEqual([])
+      expect((make().tableCell(undefined, {}) as any).pills).toEqual([])
+    })
+
+    it('renders pills when displayAs is explicitly "pills"', () => {
+      const cell = make({ displayAs: 'pills' }).tableCell(
+        [{ id: 1, name: 'Alice' }],
+        {}
+      ) as any
+      expect(cell.type).toBe('pills')
+    })
+  })
+
+  describe('tableCell (avatars mode)', () => {
+    it('renders an avatars cell when displayAs is "avatars"', () => {
+      const cell = make({
+        displayAs: 'avatars',
+        image: 'avatarUrl'
+      }).tableCell(
+        [
+          { id: 1, name: 'Alice', avatarUrl: 'https://example.com/a.png' },
+          { id: 2, name: 'Bob', avatarUrl: 'https://example.com/b.png' }
+        ],
+        {}
+      ) as any
+      expect(cell.type).toBe('avatars')
+      expect(cell.avatars).toEqual([
+        { image: 'https://example.com/a.png', name: 'Alice' },
+        { image: 'https://example.com/b.png', name: 'Bob' }
+      ])
+      expect(cell.avatarCount).toBe(6)
+      expect(cell.nameCount).toBe(0)
+      expect(cell.tooltip).toBe(true)
+    })
+
+    it('falls back to null image when the `image` data field is not set', () => {
+      const cell = make({ displayAs: 'avatars' }).tableCell(
+        [{ id: 1, name: 'Alice', avatarUrl: 'https://example.com/a.png' }],
+        {}
+      ) as any
+      expect(cell.avatars[0].image).toBeNull()
+      expect(cell.avatars[0].name).toBe('Alice')
+    })
+  })
+
+  describe('availableFilters', () => {
+    it('exposes "=", "!=", and "in" operators when an endpoint is configured', () => {
+      const filters = make().availableFilters()
+      expect(Object.keys(filters).sort()).toEqual(['!=', '=', 'in'])
+    })
+
+    it('returns no filters when the resource endpoint is empty', () => {
+      const filters = make({ resourceEndpointPath: '' }).availableFilters()
+      expect(filters).toEqual({})
+    })
+  })
+
+  describe('tableFilterMenu', () => {
+    it('returns null when no endpoint is configured', async () => {
+      const menu = await make({ resourceEndpointPath: '' }).tableFilterMenu([], () => {})
+      expect(menu).toBeNull()
+    })
+
+    it('builds text-style options from the fetched resource list by default', async () => {
+      const fetcher = makeFetcher([
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' }
+      ])
+      const menu = (await make({}, fetcher).tableFilterMenu([], () => {})) as any
+      expect(menu.options).toEqual([
+        { label: 'Alice', value: 1 },
+        { label: 'Bob', value: 2 }
+      ])
+    })
+
+    it('builds avatar-style options when displayAs is "avatars"', async () => {
+      const fetcher = makeFetcher([
+        { id: 1, name: 'Alice', avatarUrl: 'https://example.com/a.png' },
+        { id: 2, name: 'Bob', avatarUrl: 'https://example.com/b.png' }
+      ])
+      const menu = (await make(
+        { displayAs: 'avatars', resourceImage: 'avatarUrl' },
+        fetcher
+      ).tableFilterMenu([], () => {})) as any
+      expect(menu.options).toEqual([
+        { type: 'avatar', label: 'Alice', image: 'https://example.com/a.png', value: 1 },
+        { type: 'avatar', label: 'Bob', image: 'https://example.com/b.png', value: 2 }
+      ])
+    })
+  })
+})

--- a/tests/blocks/lens/fields/RelatedOneField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedOneField.spec.ts
@@ -27,17 +27,20 @@ function make(
     required: false,
     rules: [],
     title: 'name',
+    image: null,
     resourceEndpointMethod: 'get',
     resourceEndpointPath: '/api/countries',
     resourceEndpointDataKey: null,
     resourceTitle: 'name',
+    resourceImage: null,
+    displayAs: null,
     ...overrides
   }
   return new RelatedOneField(ctx(), data, fetcher)
 }
 
 describe('blocks/lens/fields/RelatedOneField', () => {
-  describe('tableCell', () => {
+  describe('tableCell (text mode — default)', () => {
     it('renders the title property of the row value', () => {
       const cell = make().tableCell({ id: 1, name: 'Japan' }, {}) as any
       expect(cell.type).toBe('text')
@@ -61,6 +64,43 @@ describe('blocks/lens/fields/RelatedOneField', () => {
       const cell = make().tableCell({ id: 1 }, {}) as any
       expect(cell.value).toBeNull()
     })
+
+    it('renders a text cell when displayAs is explicitly "text"', () => {
+      const cell = make({ displayAs: 'text' }).tableCell({ name: 'Japan' }, {}) as any
+      expect(cell.type).toBe('text')
+      expect(cell.value).toBe('Japan')
+    })
+  })
+
+  describe('tableCell (avatar mode)', () => {
+    it('renders an avatar cell with name and image when displayAs is "avatar"', () => {
+      const cell = make({
+        displayAs: 'avatar',
+        image: 'avatarUrl'
+      }).tableCell(
+        { id: 1, name: 'Alice', avatarUrl: 'https://example.com/a.png' },
+        {}
+      ) as any
+      expect(cell.type).toBe('avatar')
+      expect(cell.name).toBe('Alice')
+      expect(cell.image).toBe('https://example.com/a.png')
+    })
+
+    it('emits a null avatar cell when the row value is null', () => {
+      const cell = make({ displayAs: 'avatar', image: 'avatarUrl' }).tableCell(null, {}) as any
+      expect(cell.type).toBe('avatar')
+      expect(cell.image).toBeNull()
+      expect(cell.name).toBeNull()
+    })
+
+    it('falls back to null image when the `image` data field is not set', () => {
+      const cell = make({ displayAs: 'avatar' }).tableCell(
+        { id: 1, name: 'Alice', avatarUrl: 'https://example.com/a.png' },
+        {}
+      ) as any
+      expect(cell.image).toBeNull()
+      expect(cell.name).toBe('Alice')
+    })
   })
 
   describe('availableFilters', () => {
@@ -81,17 +121,30 @@ describe('blocks/lens/fields/RelatedOneField', () => {
       expect(menu).toBeNull()
     })
 
-    it('builds options from the fetched resource list', async () => {
+    it('builds text-style options from the fetched resource list by default', async () => {
       const fetcher = makeFetcher([
         { id: 1, name: 'Japan' },
         { id: 2, name: 'USA' }
       ])
       const menu = (await make({}, fetcher).tableFilterMenu([], () => {})) as any
-      expect(menu.type).toBe('filter')
-      expect(menu.search).toBe(true)
       expect(menu.options).toEqual([
         { label: 'Japan', value: 1 },
         { label: 'USA', value: 2 }
+      ])
+    })
+
+    it('builds avatar-style options when displayAs is "avatar"', async () => {
+      const fetcher = makeFetcher([
+        { id: 1, name: 'Alice', avatarUrl: 'https://example.com/a.png' },
+        { id: 2, name: 'Bob', avatarUrl: 'https://example.com/b.png' }
+      ])
+      const menu = (await make(
+        { displayAs: 'avatar', resourceImage: 'avatarUrl' },
+        fetcher
+      ).tableFilterMenu([], () => {})) as any
+      expect(menu.options).toEqual([
+        { type: 'avatar', label: 'Alice', image: 'https://example.com/a.png', value: 1 },
+        { type: 'avatar', label: 'Bob', image: 'https://example.com/b.png', value: 2 }
       ])
     })
 

--- a/tests/blocks/lens/fields/RelatedOneField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedOneField.spec.ts
@@ -1,0 +1,124 @@
+import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
+import { type RelatedOneFieldData } from 'sefirot/blocks/lens/FieldData'
+import { type ResourceFetcher } from 'sefirot/blocks/lens/ResourceFetcher'
+import { RelatedOneField } from 'sefirot/blocks/lens/fields/RelatedOneField'
+
+function ctx(lang: 'en' | 'ja' = 'en'): FieldContext {
+  return { lang }
+}
+
+function makeFetcher(response: any): ResourceFetcher {
+  return (async () => response) as unknown as ResourceFetcher
+}
+
+function make(
+  overrides: Partial<RelatedOneFieldData> = {},
+  fetcher: ResourceFetcher = makeFetcher([])
+): RelatedOneField {
+  const data: RelatedOneFieldData = {
+    type: 'related_one',
+    key: 'country',
+    labelEn: 'Country',
+    labelJa: '国',
+    filterKey: 'id',
+    sortable: false,
+    freeze: false,
+    width: 0,
+    required: false,
+    rules: [],
+    title: 'name',
+    resourceEndpointMethod: 'get',
+    resourceEndpointPath: '/api/countries',
+    resourceEndpointDataKey: null,
+    resourceTitle: 'name',
+    ...overrides
+  }
+  return new RelatedOneField(ctx(), data, fetcher)
+}
+
+describe('blocks/lens/fields/RelatedOneField', () => {
+  describe('tableCell', () => {
+    it('renders the title property of the row value', () => {
+      const cell = make().tableCell({ id: 1, name: 'Japan' }, {}) as any
+      expect(cell.type).toBe('text')
+      expect(cell.value).toBe('Japan')
+    })
+
+    it('honors a custom title key', () => {
+      const cell = make({ title: 'shortName' }).tableCell(
+        { id: 1, shortName: 'JP', name: 'Japan' },
+        {}
+      ) as any
+      expect(cell.value).toBe('JP')
+    })
+
+    it('keeps null / undefined as null', () => {
+      expect((make().tableCell(null, {}) as any).value).toBeNull()
+      expect((make().tableCell(undefined, {}) as any).value).toBeNull()
+    })
+
+    it('renders null when the title property is missing on the row value', () => {
+      const cell = make().tableCell({ id: 1 }, {}) as any
+      expect(cell.value).toBeNull()
+    })
+  })
+
+  describe('availableFilters', () => {
+    it('exposes "=", "!=", and "in" operators when an endpoint is configured', () => {
+      const filters = make().availableFilters()
+      expect(Object.keys(filters).sort()).toEqual(['!=', '=', 'in'])
+    })
+
+    it('returns no filters when the resource endpoint is empty', () => {
+      const filters = make({ resourceEndpointPath: '' }).availableFilters()
+      expect(filters).toEqual({})
+    })
+  })
+
+  describe('tableFilterMenu', () => {
+    it('returns null when no endpoint is configured', async () => {
+      const menu = await make({ resourceEndpointPath: '' }).tableFilterMenu([], () => {})
+      expect(menu).toBeNull()
+    })
+
+    it('builds options from the fetched resource list', async () => {
+      const fetcher = makeFetcher([
+        { id: 1, name: 'Japan' },
+        { id: 2, name: 'USA' }
+      ])
+      const menu = (await make({}, fetcher).tableFilterMenu([], () => {})) as any
+      expect(menu.type).toBe('filter')
+      expect(menu.search).toBe(true)
+      expect(menu.options).toEqual([
+        { label: 'Japan', value: 1 },
+        { label: 'USA', value: 2 }
+      ])
+    })
+
+    it('unwraps the response via resourceEndpointDataKey when set', async () => {
+      const fetcher = makeFetcher({
+        data: [{ id: 9, name: 'Korea' }]
+      })
+      const menu = (await make(
+        { resourceEndpointDataKey: 'data' },
+        fetcher
+      ).tableFilterMenu([], () => {})) as any
+      expect(menu.options).toEqual([{ label: 'Korea', value: 9 }])
+    })
+
+    it('toggles the selection via xor on click', async () => {
+      const captured: any[] = []
+      const onFilterUpdated = (f: any) => { captured.push(f) }
+      const fetcher = makeFetcher([
+        { id: 1, name: 'Japan' },
+        { id: 2, name: 'USA' }
+      ])
+      const filters = [['country', 'in', [1]]]
+      const menu = (await make({}, fetcher).tableFilterMenu(filters, onFilterUpdated)) as any
+      menu.onClick(1) // remove
+      expect(captured[0]).toEqual(['country', 'in', []])
+      menu.onClick(2) // add
+      expect(captured[1]).toEqual(['country', 'in', [1, 2]])
+    })
+  })
+})

--- a/tests/blocks/lens/fields/RelatedOneField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedOneField.spec.ts
@@ -86,11 +86,21 @@ describe('blocks/lens/fields/RelatedOneField', () => {
       expect(cell.image).toBe('https://example.com/a.png')
     })
 
-    it('emits a null avatar cell when the row value is null', () => {
+    it('emits an empty avatar cell when the row value is null', () => {
       const cell = make({ displayAs: 'avatar', image: 'avatarUrl' }).tableCell(null, {}) as any
       expect(cell.type).toBe('avatar')
       expect(cell.image).toBeNull()
-      expect(cell.name).toBeNull()
+      expect(cell.name).toBe('')
+    })
+
+    it('uses an empty name (not null) when the title is missing', () => {
+      const cell = make({ displayAs: 'avatar', image: 'avatarUrl' }).tableCell(
+        { id: 1, avatarUrl: 'https://example.com/a.png' },
+        {}
+      ) as any
+      expect(cell.type).toBe('avatar')
+      expect(cell.name).toBe('')
+      expect(cell.image).toBe('https://example.com/a.png')
     })
 
     it('falls back to null image when the `image` data field is not set', () => {

--- a/tests/blocks/lens/fields/RelatedOneField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedOneField.spec.ts
@@ -60,9 +60,9 @@ describe('blocks/lens/fields/RelatedOneField', () => {
       expect((make().tableCell(undefined, {}) as any).value).toBeNull()
     })
 
-    it('renders null when the title property is missing on the row value', () => {
+    it('renders an empty string (not null) when the title is missing, so the table does not fall back to the raw object', () => {
       const cell = make().tableCell({ id: 1 }, {}) as any
-      expect(cell.value).toBeNull()
+      expect(cell.value).toBe('')
     })
 
     it('renders a text cell when displayAs is explicitly "text"', () => {


### PR DESCRIPTION
## Summary

Adds three field-type capabilities to the Lens catalog:

- **`BooleanField`** — renders truthy/falsy values as localized labels (default Yes/No・はい/いいえ, overridable per field) with a `=` / `!=` filter offering both values.
- **`RelatedOneField`** — the single-value counterpart to `RelatedManyField`; renders a related record's title and offers a resource-backed filter dropdown.
- **Avatar display mode** for `RelatedOneField` / `RelatedManyField` — a `displayAs` option plus `image` / `resourceImage` accessors render related records as avatar cells and avatar filter options instead of text / pills.

## Notable changes

- `RelatedManyField` cell rendering now branches on `displayAs`; existing consumers that don't set it keep the `pills` default.
- All three are registered as built-in field types in `SetupLens`.

## Test plan

- [ ] `pnpm run check` passes