### PR TITLE
feat(lens): add catalog controls for advanced pages

### DIFF
--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -430,6 +430,12 @@ function onNext() {
 // server-side changes — e.g. after a bulk action mutates rows — without
 // remounting the component.
 async function refreshCatalog(): Promise<void> {
+  // A refresh is requested precisely when server-side data may have
+  // changed while the query input did not (e.g. after a bulk action).
+  // Clear the memoized input so the equality shortcut in the fetcher
+  // misses and a real request is issued instead of returning the stale
+  // cached result.
+  prevFetchInput = null
   await doRefresh()
 }
 

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -426,9 +426,8 @@ function onNext() {
 
 // Re-runs the current query against the endpoint, preserving the
 // catalog's in-memory state (select / filters / sort / page). Exposed
-// (and passed to the `selected-actions` slot) so callers can reflect
-// server-side changes — e.g. after a bulk action mutates rows — without
-// remounting the component.
+// so callers can reflect server-side changes — e.g. after a bulk action
+// mutates rows — without remounting the component.
 async function refreshCatalog(): Promise<void> {
   // A refresh is requested precisely when server-side data may have
   // changed while the query input did not (e.g. after a bulk action).
@@ -504,7 +503,7 @@ defineExpose({
           <slot name="controls-sub-right" />
         </template>
         <template v-if="$slots['selected-actions']" #selected-actions>
-          <slot name="selected-actions" :refresh="refreshCatalog" :selected="selected ?? []" />
+          <slot name="selected-actions" />
         </template>
       </LensCatalogControl>
       <div v-else class="control-skeleton" />

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -102,6 +102,13 @@ export interface Props {
   // the catalog will hide entire catalog component and renders the given
   // `#empty-state` slot instead.
   showEmptyState?: boolean
+
+  // Whether to populate the selectable column list from every field the
+  // backend exposes for the entity, rather than only the columns passed
+  // in `selectable` / `select`. Use this when the catalog should let the
+  // user add any available column to the view (e.g. a saved-view editor),
+  // not just toggle the ones already selected.
+  loadSelectable?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -116,6 +123,7 @@ const emit = defineEmits<{
   'select-updated': [select: string[]]
   'selectable-updated': [selectable: string[]]
   'filters-updated': [filters: any[]]
+  'query-filter-updated': [filter: any[]]
   'sort-updated': [sort: LensQuerySort[]]
   'overrides-updated': [overrides: Record<string, Partial<FieldData>>]
   'cell-clicked': [value: any, record: any]
@@ -153,6 +161,13 @@ const queryFilter = computed(() => {
   return ['$or', props.queryKeys.map((key) => {
     return [key, 'contains', query.value]
   })]
+})
+
+// Surface the free-text query filter so callers can fold it into their
+// own export / side-channel requests (the search box lives inside the
+// catalog, so the parent has no other way to observe it).
+watch(queryFilter, (filter) => {
+  emit('query-filter-updated', filter)
 })
 
 const _filters = ref(props.filters ?? [])
@@ -261,6 +276,20 @@ watch(result, (res) => {
   }
   if (_selectable.value.length === 0) {
     _selectable.value = withoutIndexField(res!.query.select)
+  }
+  // When `loadSelectable` is set, widen the selectable column list to
+  // every field the backend exposes for the entity (minus the index
+  // field), so the column picker can offer columns that aren't part of
+  // the current selection. Existing entries are preserved and order is
+  // kept stable by appending only the not-yet-present keys.
+  if (props.loadSelectable && res!.fields) {
+    const present = new Set(_selectable.value)
+    for (const key of withoutIndexField(Object.keys(res!.fields))) {
+      if (!present.has(key)) {
+        _selectable.value.push(key)
+        present.add(key)
+      }
+    }
   }
 }, { once: true })
 
@@ -395,7 +424,18 @@ function onNext() {
   doRefresh()
 }
 
+// Re-runs the current query against the endpoint, preserving the
+// catalog's in-memory state (select / filters / sort / page). Exposed
+// (and passed to the `selected-actions` slot) so callers can reflect
+// server-side changes — e.g. after a bulk action mutates rows — without
+// remounting the component.
+async function refreshCatalog(): Promise<void> {
+  await doRefresh()
+}
+
 defineExpose({
+  refresh: refreshCatalog,
+
   /**
    * Retrieve the current records in the catalog. This method is required when
    * the parent component needs to access the records directly, for example, to
@@ -456,6 +496,9 @@ defineExpose({
         </template>
         <template v-if="$slots['controls-sub-right']" #sub-right>
           <slot name="controls-sub-right" />
+        </template>
+        <template v-if="$slots['selected-actions']" #selected-actions>
+          <slot name="selected-actions" :refresh="refreshCatalog" :selected="selected ?? []" />
         </template>
       </LensCatalogControl>
       <div v-else class="control-skeleton" />

--- a/lib/blocks/lens/components/LensCatalogControl.vue
+++ b/lib/blocks/lens/components/LensCatalogControl.vue
@@ -138,6 +138,9 @@ function createFilterPresetOptions(): ActionList {
             <IconX class="selected-reset-icon" />
           </button>
         </div>
+        <div v-if="$slots['selected-actions']" class="selected-actions">
+          <slot name="selected-actions" />
+        </div>
       </div>
     </template>
   </div>
@@ -160,6 +163,12 @@ function createFilterPresetOptions(): ActionList {
 }
 
 .selected {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.selected-actions {
   display: flex;
   align-items: center;
   gap: 8px;


### PR DESCRIPTION
## Summary

Adds `LensCatalog` capabilities needed to host saved-view editors and bulk-action pages on top of the catalog:

- **`loadSelectable`** prop — populate the column picker from every field the backend exposes for the entity, not just the currently-selected columns (for "manage view" editors).
- **`#selected-actions`** slot — render bulk-action buttons when rows are selected; receives `refresh` and `selected` as slot props.
- **`refresh()`** exposed via `defineExpose` — refetch with the current state without remounting (e.g. after a bulk action mutates rows).
- **`query-filter-updated`** event — surface the free-text query filter so callers can fold it into their own export / side-channel requests.

## Notable changes

- The `selected-actions` slot is routed through `LensCatalogControl`'s existing selected-state bar.
- Independent of the field-type and table-fix Lens PRs (no shared files); reviewable on its own.

## Test plan

- [ ] `pnpm run check` passes