### PR TITLE
fix(lens): table/filter rendering parity fixes

### DIFF
--- a/lib/blocks/lens/components/LensCatalogStateFilter.vue
+++ b/lib/blocks/lens/components/LensCatalogStateFilter.vue
@@ -53,12 +53,6 @@ function lensFiltersToGroup(filters: any[], connector: '$and' | '$or', count: Co
     const [fieldOrConnector, operatorOrFilters, value] = filter
 
     if (!isConnector(fieldOrConnector)) {
-      // Skip a condition whose field is absent from the current field set
-      // (e.g. a stale saved filter). It has no definition to render and
-      // would crash `fieldFactory.make(undefined)` in the state chip.
-      if (!props.fields[fieldOrConnector]) {
-        continue
-      }
       group.conditions.push({
         field: fieldOrConnector,
         operator: operatorOrFilters,

--- a/lib/blocks/lens/components/LensCatalogStateFilter.vue
+++ b/lib/blocks/lens/components/LensCatalogStateFilter.vue
@@ -53,6 +53,12 @@ function lensFiltersToGroup(filters: any[], connector: '$and' | '$or', count: Co
     const [fieldOrConnector, operatorOrFilters, value] = filter
 
     if (!isConnector(fieldOrConnector)) {
+      // Skip a condition whose field is absent from the current field set
+      // (e.g. a stale saved filter). It has no definition to render and
+      // would crash `fieldFactory.make(undefined)` in the state chip.
+      if (!props.fields[fieldOrConnector]) {
+        continue
+      }
       group.conditions.push({
         field: fieldOrConnector,
         operator: operatorOrFilters,

--- a/lib/blocks/lens/components/LensCatalogStateFilterCondition.vue
+++ b/lib/blocks/lens/components/LensCatalogStateFilterCondition.vue
@@ -21,15 +21,21 @@ const props = defineProps<Props>()
 const fieldFactory = useFieldFactory()
 
 const field = computed(() => {
-  return fieldFactory.make(props.fields[props.condition.field])
+  const fieldData = props.fields[props.condition.field]
+  // A still-applied filter can reference a field that's no longer in the
+  // field set (e.g. a stale saved filter). Keep the chip rendering rather
+  // than crashing on `make(undefined)`, so the active filter stays
+  // visible and counted instead of silently filtering the table.
+  return fieldData ? fieldFactory.make(fieldData) : null
 })
 
 const input = computed(() => {
-  return field.value.filterInputByOperator(props.condition.operator)
+  return field.value?.filterInputByOperator(props.condition.operator) ?? null
 })
 
 const fieldText = computed(() => {
-  return field.value.label()
+  // Fall back to the raw field key when the field has no definition.
+  return field.value ? field.value.label() : props.condition.field
 })
 
 const operatorText = computed(() => {
@@ -37,6 +43,9 @@ const operatorText = computed(() => {
 })
 
 const valueText = computedAsync(async () => {
+  if (!input.value) {
+    return String(props.condition.value ?? '')
+  }
   return input.value.valueToText(props.condition.value)
 }, '...')
 </script>
@@ -45,10 +54,7 @@ const valueText = computedAsync(async () => {
   <div class="LensCatalogStateFilterCondition">
     <div class="field">{{ fieldText }}</div>
     <div class="operator">{{ operatorText }}</div>
-    <div v-if="input === null" class="value">
-      ...
-    </div>
-    <div v-else class="value">
+    <div class="value">
       {{ valueText }}
     </div>
   </div>

--- a/lib/blocks/lens/components/LensFormFilter.vue
+++ b/lib/blocks/lens/components/LensFormFilter.vue
@@ -95,12 +95,25 @@ const fieldOptions = computed(() => {
 //   ]
 // }
 function lensFiltersToGroup() {
+  const conditions = props.filters.length > 0
+    ? pruneMissingFields(props.filters.map(lensConditionToCondition))
+    : []
+
   return {
     connector: '$and' as const,
-    conditions: props.filters.length > 0
-      ? props.filters.map(lensConditionToCondition)
-      : [createEmptyCondition()]
+    conditions: conditions.length > 0 ? conditions : [createEmptyCondition()]
   }
+}
+
+// Drop conditions that reference a field absent from `props.fields` (for
+// example a stale saved filter pointing at a field that no longer
+// exists). Such a condition can't be rendered or edited, and would
+// otherwise pass validation with a null input and silently re-emit the
+// stale filter on Apply. Groups left empty by pruning are removed too.
+function pruneMissingFields(conditions: any[]): any[] {
+  return conditions
+    .map((c) => ('connector' in c ? { ...c, conditions: pruneMissingFields(c.conditions) } : c))
+    .filter((c) => ('connector' in c ? c.conditions.length > 0 : c.field === null || props.fields[c.field]))
 }
 
 function lensConditionToCondition(filter: any[]) {

--- a/lib/blocks/lens/components/LensFormFilter.vue
+++ b/lib/blocks/lens/components/LensFormFilter.vue
@@ -57,6 +57,12 @@ const { validateAndNotify } = useValidation()
 const fieldOptions = computed(() => {
   return props.filterable.filter((key) => {
     const fieldData = props.fields[key]
+    // Skip keys with no field definition — e.g. `__empty__` spacer
+    // columns that appear in `select` / `selectable` but carry no field
+    // metadata. Without this guard `make(undefined)` throws.
+    if (!fieldData) {
+      return false
+    }
     const field = fieldFactory.make(fieldData)
     return field.availableFilterOperators().length > 0
   }).map((key) => {

--- a/lib/blocks/lens/components/LensFormFilterCondition.vue
+++ b/lib/blocks/lens/components/LensFormFilterCondition.vue
@@ -48,6 +48,12 @@ const field = computed(() => {
     return null
   }
   const fieldData = props.fields[model.value.field]
+  // Guard against a condition referencing a key with no field
+  // definition (e.g. a stale saved filter, or a spacer key) so
+  // `make(undefined)` doesn't throw.
+  if (!fieldData) {
+    return null
+  }
   return fieldFactory.make(fieldData)
 })
 

--- a/lib/blocks/lens/components/LensFormView.vue
+++ b/lib/blocks/lens/components/LensFormView.vue
@@ -92,12 +92,17 @@ useDraggable(el, selectOptions, {
 })
 
 function createSelectOptions(): SelectOption[] {
+  // Spacer columns all share the `__empty__` key, so `_selectDict` can't
+  // distinguish them. Mark spacer rows selected positionally — as many as
+  // `select` actually contains — rather than all-or-nothing.
+  let remainingEmpty = _select.value.filter((s) => s === '__empty__').length
   return _selectable.value.map((s) => {
+    const isEmpty = s === '__empty__'
     return {
       uid: _uid++,
       key: s,
-      value: _selectDict.value[s],
-      isEmpty: s === '__empty__',
+      value: isEmpty ? remainingEmpty-- > 0 : !!_selectDict.value[s],
+      isEmpty,
       field: props.fields[s],
       override: _overrides[s] || {}
     }

--- a/lib/blocks/lens/components/LensFormView.vue
+++ b/lib/blocks/lens/components/LensFormView.vue
@@ -92,16 +92,31 @@ useDraggable(el, selectOptions, {
 })
 
 function createSelectOptions(): SelectOption[] {
-  // Spacer columns all share the `__empty__` key, so `_selectDict` can't
-  // distinguish them. Mark spacer rows selected positionally — as many as
-  // `select` actually contains — rather than all-or-nothing.
-  let remainingEmpty = _select.value.filter((s) => s === '__empty__').length
+  // `select` is a subsequence of `selectable` (the editor derives both
+  // from the same ordered list), so we walk them in lockstep to recover
+  // which specific `__empty__` spacer was selected. Real fields are keyed
+  // by membership (order-robust); spacers, which share the `__empty__`
+  // key and can't be told apart by `_selectDict`, are matched positionally
+  // via the shared cursor.
+  let cursor = 0
   return _selectable.value.map((s) => {
     const isEmpty = s === '__empty__'
+    let value: boolean
+    if (isEmpty) {
+      value = _select.value[cursor] === '__empty__'
+      if (value) {
+        cursor++
+      }
+    } else {
+      value = !!_selectDict.value[s]
+      if (_select.value[cursor] === s) {
+        cursor++
+      }
+    }
     return {
       uid: _uid++,
       key: s,
-      value: isEmpty ? remainingEmpty-- > 0 : !!_selectDict.value[s],
+      value,
       isEmpty,
       field: props.fields[s],
       override: _overrides[s] || {}

--- a/lib/blocks/lens/components/LensFormView.vue
+++ b/lib/blocks/lens/components/LensFormView.vue
@@ -52,14 +52,16 @@ const { t } = useTrans({
     a_select_all: 'Select all',
     a_clear_all: 'Clear all',
     a_cancel: 'Cancel',
-    a_apply: 'Apply changes'
+    a_apply: 'Apply changes',
+    empty_column: '(Empty column)'
   },
   ja: {
     title: 'テーブルの表示を更新する',
     a_select_all: 'すべて選択',
     a_clear_all: 'すべて解除',
     a_cancel: 'キャンセル',
-    a_apply: '変更を適用'
+    a_apply: '変更を適用',
+    empty_column: '(空列)'
   }
 })
 
@@ -103,6 +105,11 @@ function createSelectOptions(): SelectOption[] {
 }
 
 function getName(s: SelectOption): string {
+  // Empty spacer columns carry no field definition; show a localized
+  // placeholder label so the row is identifiable in the view editor.
+  if (s.isEmpty) {
+    return t.empty_column
+  }
   return lang === 'ja'
     ? s.override.labelJa || s.field?.labelJa || ''
     : s.override.labelEn || s.field?.labelEn || ''

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -43,11 +43,16 @@ const records = computed(() => props.result?.data ?? [])
 const columnKeys = computed(() => {
   const requested = props.select ?? props.result?.query.select ?? []
   const fetched = props.result?.query.select
-  if (!fetched) {
-    return requested
-  }
-  const fetchedSet = new Set(fetched)
-  return requested.filter((k) => fetchedSet.has(k))
+  const fetchedSet = fetched ? new Set(fetched) : null
+  const visible = fetchedSet
+    ? requested.filter((k) => fetchedSet.has(k))
+    : requested
+  // Give each `__empty__` spacer a unique render key. The select can
+  // contain several `__empty__` entries (blank spacer columns, also used
+  // to inject empty columns into Excel exports); without unique keys they
+  // would collide on the same `columns` map entry and only render once.
+  let emptyIndex = 0
+  return visible.map((k) => (k === '__empty__' ? `__empty__::${emptyIndex++}` : k))
 })
 
 const orders = computed(() => [
@@ -79,6 +84,14 @@ const columns = computedAsync(async () => {
 
   // Build the list of columns based on the resolved column key list.
   for (const key of keys) {
+    // Render `__empty__` spacer keys (uniquified to `__empty__::N`) as
+    // blank columns, matching the empty columns the backend injects into
+    // Excel exports. These carry no field definition.
+    if (key.startsWith('__empty__')) {
+      columns[key] = { width: '128px', cell: { type: 'empty' } }
+      continue
+    }
+
     const _fieldData = cloneDeep(r.fields[key])
 
     if (!_fieldData) {

--- a/lib/blocks/lens/fields/DateField.ts
+++ b/lib/blocks/lens/fields/DateField.ts
@@ -20,9 +20,17 @@ export class DateField extends Field<DateFieldData> {
   override availableFilters(): Partial<Record<FilterOperator, FilterInput>> {
     const text = new TextFilterInput()
 
+    // Comparison operators (`>`, `>=`, `<`, `<=`) back date-range filters
+    // such as `invested_date >= X` AND `invested_date < Y`. The value is
+    // an ISO date string, edited as text — same input the `=` / `!=`
+    // operators already use for this field.
     return {
       '=': text,
-      '!=': text
+      '!=': text,
+      '>': text,
+      '>=': text,
+      '<': text,
+      '<=': text
     }
   }
 

--- a/lib/blocks/lens/fields/DatetimeField.ts
+++ b/lib/blocks/lens/fields/DatetimeField.ts
@@ -17,9 +17,16 @@ export class DatetimeField extends Field<DatetimeFieldData> {
   override availableFilters(): Partial<Record<FilterOperator, FilterInput>> {
     const text = new TextFilterInput()
 
+    // Comparison operators (`>`, `>=`, `<`, `<=`) back datetime-range
+    // filters. The value is an ISO datetime string, edited as text — the
+    // same input the `=` / `!=` operators already use for this field.
     return {
       '=': text,
-      '!=': text
+      '!=': text,
+      '>': text,
+      '>=': text,
+      '<': text,
+      '<=': text
     }
   }
 

--- a/lib/blocks/lens/fields/Field.ts
+++ b/lib/blocks/lens/fields/Field.ts
@@ -11,6 +11,12 @@ import LensFormOverrideBase from '../components/LensFormOverrideBase.vue'
 import { type FilterInput } from '../filter-inputs/FilterInput'
 import * as RuleMapper from '../validation/RuleMapper'
 
+/**
+ * Fallback column width (px) used when a field's definition does not
+ * specify one (i.e. `width` is 0). Keeps columns visible by default.
+ */
+const DEFAULT_COLUMN_WIDTH = 168
+
 export abstract class Field<T extends FieldData> {
   /**
    * The field context, that holds global app context
@@ -66,7 +72,11 @@ export abstract class Field<T extends FieldData> {
     return {
       label: this.label(),
       freeze: this.data.freeze,
-      width: `${this.data.width}px`,
+      // A width of 0 means "unset" — fall back to a sensible default so
+      // the column stays visible. Without this, fields whose backend
+      // definition omits an explicit width would render as a 0px (hidden)
+      // column until the user manually drag-resizes it.
+      width: `${this.data.width || DEFAULT_COLUMN_WIDTH}px`,
       cell: (v, r) => this.tableCell(v, r)
     }
   }


### PR DESCRIPTION
## Summary

Fixes rendering gaps that surface when a backend omits or varies field metadata — restoring parity with the previous catalog behavior:

- **Column width**: default to 168px when a field definition reports width `0` (was rendering a hidden 0px column until the user drag-resized it).
- **Date operators**: `DateField` / `DatetimeField` now expose `>`, `>=`, `<`, `<=` so saved date-range filters (e.g. `date >= X` AND `date < Y`) resolve instead of throwing "operator not available".
- **Filter form guard**: the advanced-filter form no longer throws when `select` / `selectable` contains a key with no field definition (e.g. `__empty__` spacers).
- **Empty columns**: render `__empty__` keys as blank spacer columns in the table, and show a localized "(Empty column)" / "(空列)" label for them in the view editor.

## Notable changes

- Multiple `__empty__` entries are given unique render keys (`__empty__::N`) inside `LensTable` so several spacer columns coexist without colliding on the columns map.
- Independent of the field-type and catalog-controls Lens PRs (no shared files).

## Test plan

- [ ] `pnpm run check` passes
- [ ] A saved view with a date-range filter and `__empty__` spacer columns renders without errors and the filter dialog opens