### PR TITLE
feat(file-upload): accept already-uploaded files as File | string

### DIFF
--- a/lib/components/SInputFileUpload.vue
+++ b/lib/components/SInputFileUpload.vue
@@ -17,7 +17,14 @@ export type Size = 'mini' | 'small' | 'medium'
 export type { Color }
 
 export type ModelType = 'file' | 'object'
-export type ModelValue<T extends ModelType> = T extends 'file' ? File : FileObject
+
+/**
+ * In `file` mode an item is either a freshly selected `File` or a `string`
+ * referencing a file that was already uploaded (e.g. its stored path or
+ * basename) — mirroring `SInputImage`'s `File | string` model. `object`
+ * mode wraps a `File` with display metadata.
+ */
+export type ModelValue<T extends ModelType> = T extends 'file' ? File | string : FileObject
 
 export interface FileObject {
   file: File
@@ -103,7 +110,15 @@ const totalFileCountText = computed(() => {
 })
 
 const totalFileSizeText = computed(() => {
-  const files = _value.value.map((file) => (file instanceof File ? file : file.file))
+  // Only locally selected files contribute to the total size. Already
+  // uploaded files (plain `string` references) have no known size on the
+  // client, so the displayed total under-counts when the list mixes
+  // uploaded references with newly selected files. Accepted for now —
+  // surfacing accurate sizes would require the size to travel with the
+  // reference (or an extra lookup).
+  const files = _value.value
+    .map((file) => (file instanceof File ? file : typeof file === 'string' ? null : file.file))
+    .filter((file): file is File => file instanceof File)
   return formatSize(files)
 })
 

--- a/lib/components/SInputFileUpload.vue
+++ b/lib/components/SInputFileUpload.vue
@@ -227,7 +227,7 @@ function toFileObjects(files: File[]) {
             v-for="(file, i) in _value"
             :key="i"
             :file
-            :rules
+            :rules="typeof file === 'string' ? undefined : rules"
             @remove="() => { onRemove(i) }"
           />
         </template>

--- a/lib/components/SInputFileUpload.vue
+++ b/lib/components/SInputFileUpload.vue
@@ -227,7 +227,7 @@ function toFileObjects(files: File[]) {
             v-for="(file, i) in _value"
             :key="i"
             :file
-            :rules="typeof file === 'string' ? undefined : rules"
+            :rules
             @remove="() => { onRemove(i) }"
           />
         </template>

--- a/lib/components/SInputFileUploadItem.vue
+++ b/lib/components/SInputFileUploadItem.vue
@@ -2,7 +2,7 @@
 import IconFileText from '~icons/ph/file-text'
 import IconTrash from '~icons/ph/trash'
 import { type ValidationRuleWithParams } from '@vuelidate/core'
-import { type Component, computed } from 'vue'
+import { type Component, computed, watch } from 'vue'
 import { useValidation } from '../composables/Validation'
 import { formatSize } from '../support/File'
 import SButton, { type Mode as ButtonMode } from './SButton.vue'
@@ -75,13 +75,24 @@ const _file = computed(() => {
   }
 })
 
+// Rules are passed as a getter so validation reacts when the item's
+// identity changes — the parent keys items by index, so a single instance
+// can be reused for a different item after a removal. Per-file rules apply
+// to newly selected `File`s only; an already-uploaded `string` reference
+// has no local file to validate, so it's skipped (the server validates it).
 const { validation } = useValidation(() => ({
   file: _file.value.file
-}), {
-  file: props.rules ?? {}
-})
+}), () => ({
+  file: typeof props.file === 'string' ? {} : (props.rules ?? {})
+}))
 
-validation.value.$touch()
+// Surface validation immediately, and re-touch whenever the item changes:
+// when an index-keyed instance is reused for a different item, switching
+// rules resets the dirty state, so a post-flush re-touch is needed to keep
+// the new item's errors visible.
+watch(() => props.file, () => {
+  validation.value.$touch()
+}, { immediate: true, flush: 'post' })
 </script>
 
 <template>

--- a/lib/components/SInputFileUploadItem.vue
+++ b/lib/components/SInputFileUploadItem.vue
@@ -27,7 +27,7 @@ export interface Action {
 }
 
 const props = defineProps<{
-  file: File | FileObject
+  file: File | FileObject | string
   rules?: Record<string, ValidationRuleWithParams>
 }>()
 
@@ -35,15 +35,45 @@ defineEmits<{
   remove: []
 }>()
 
-const _file = computed(() => ({
-  name: props.file instanceof File ? props.file.name : props.file.file.name,
-  file: props.file instanceof File ? props.file : props.file.file,
-  size: formatSize(props.file instanceof File ? props.file : props.file.file),
-  indicatorState: props.file instanceof File ? null : props.file.indicatorState,
-  canRemove: props.file instanceof File ? true : (props.file.canRemove ?? true),
-  action: props.file instanceof File ? null : props.file.action,
-  errorMessage: props.file instanceof File ? null : props.file.errorMessage
-}))
+const _file = computed(() => {
+  const value = props.file
+
+  if (value instanceof File) {
+    return {
+      name: value.name,
+      file: value as File | null,
+      size: formatSize(value) as string | null,
+      indicatorState: null as IndicatorState | null,
+      canRemove: true,
+      action: null as Action | null,
+      errorMessage: null as string | null
+    }
+  }
+
+  // A plain string references an already-uploaded file: show its basename
+  // and skip the size (unknown for server-side files).
+  if (typeof value === 'string') {
+    return {
+      name: value.split('/').pop() || value,
+      file: null,
+      size: null,
+      indicatorState: null,
+      canRemove: true,
+      action: null,
+      errorMessage: null
+    }
+  }
+
+  return {
+    name: value.file.name,
+    file: value.file as File | null,
+    size: formatSize(value.file) as string | null,
+    indicatorState: value.indicatorState ?? null,
+    canRemove: value.canRemove ?? true,
+    action: value.action ?? null,
+    errorMessage: value.errorMessage ?? null
+  }
+})
 
 const { validation } = useValidation(() => ({
   file: _file.value.file
@@ -84,7 +114,7 @@ validation.value.$touch()
       />
     </div>
     <div class="meta">
-      <div class="size">
+      <div v-if="_file.size" class="size">
         {{ _file.size }}
       </div>
       <div class="delete">

--- a/lib/validation/validators/maxTotalFileSize.ts
+++ b/lib/validation/validators/maxTotalFileSize.ts
@@ -1,8 +1,16 @@
 export function maxTotalFileSize(value: unknown, size: string): boolean {
-  if (!Array.isArray(value) || !value.every((v) => v instanceof File)) { return false }
+  // The model may mix freshly selected `File`s with `string` references to
+  // already-uploaded files (see `SInputFileUpload`). Reject anything else,
+  // but allow string references through — only `File`s contribute to the
+  // total, since an already-uploaded file has no client-side size (the
+  // server validates its real size). This means the total under-counts kept
+  // files, which is accepted for now.
+  if (!Array.isArray(value) || !value.every((v) => v instanceof File || typeof v === 'string')) {
+    return false
+  }
 
   const factor = /gb/i.test(size) ? 1e9 : /mb/i.test(size) ? 1e6 : /kb/i.test(size) ? 1e3 : 1
-  const total = value.reduce((total, file) => total + file.size, 0)
+  const total = value.reduce((total, file) => total + (file instanceof File ? file.size : 0), 0)
 
   return total <= factor * Number.parseFloat(size.replace(/[^\d.]/g, ''))
 }

--- a/tests/components/SInputFileUpload.spec.ts
+++ b/tests/components/SInputFileUpload.spec.ts
@@ -1,0 +1,51 @@
+import { mount } from '@vue/test-utils'
+import SInputFileUpload from 'sefirot/components/SInputFileUpload.vue'
+import { assertEmitted } from 'tests/Utils'
+
+describe('components/SInputFileUpload', () => {
+  it('renders a freshly selected File by its name', () => {
+    const file = new File(['x'], 'new.pdf')
+
+    const wrapper = mount(SInputFileUpload, {
+      props: { modelValue: [file] }
+    })
+
+    expect(wrapper.find('.SInputFileUploadItem .name-text').text()).toBe('new.pdf')
+  })
+
+  it('renders an already-uploaded file (string) by its basename without a size', () => {
+    const wrapper = mount(SInputFileUpload, {
+      props: { modelValue: ['uploads/2024/report.pdf'] }
+    })
+
+    const items = wrapper.findAll('.SInputFileUploadItem')
+
+    expect(items).toHaveLength(1)
+    expect(items[0].find('.name-text').text()).toBe('report.pdf')
+    expect(items[0].find('.size').exists()).toBe(false)
+  })
+
+  it('renders a mix of uploaded references and new files', () => {
+    const file = new File(['x'], 'new.pdf')
+
+    const wrapper = mount(SInputFileUpload, {
+      props: { modelValue: ['a.pdf', file] }
+    })
+
+    const names = wrapper.findAll('.SInputFileUploadItem .name-text').map((n) => n.text())
+
+    expect(names).toEqual(['a.pdf', 'new.pdf'])
+  })
+
+  it('removes an uploaded reference while keeping the rest', async () => {
+    const file = new File(['x'], 'new.pdf')
+
+    const wrapper = mount(SInputFileUpload, {
+      props: { modelValue: ['a.pdf', file] }
+    })
+
+    await wrapper.findAll('.SInputFileUploadItem .delete button')[0].trigger('click')
+
+    assertEmitted(wrapper, 'update:model-value', 1, [file])
+  })
+})

--- a/tests/components/SInputFileUpload.spec.ts
+++ b/tests/components/SInputFileUpload.spec.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import SInputFileUpload from 'sefirot/components/SInputFileUpload.vue'
+import { required } from 'sefirot/validation/rules'
 import { assertEmitted } from 'tests/Utils'
 
 describe('components/SInputFileUpload', () => {
@@ -47,5 +48,19 @@ describe('components/SInputFileUpload', () => {
     await wrapper.findAll('.SInputFileUploadItem .delete button')[0].trigger('click')
 
     assertEmitted(wrapper, 'update:model-value', 1, [file])
+  })
+
+  it('does not validate uploaded references against per-file rules', () => {
+    // A string reference is an already-uploaded file; per-file rules such as
+    // `required` apply to newly selected files only and must not flag it.
+    const wrapper = mount(SInputFileUpload, {
+      props: {
+        modelValue: ['a.pdf'],
+        rules: { required: required() }
+      }
+    })
+
+    expect(wrapper.find('.SInputFileUploadItem').exists()).toBe(true)
+    expect(wrapper.find('.SInputFileUploadItem .error').exists()).toBe(false)
   })
 })

--- a/tests/components/SInputFileUpload.spec.ts
+++ b/tests/components/SInputFileUpload.spec.ts
@@ -1,6 +1,6 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import SInputFileUpload from 'sefirot/components/SInputFileUpload.vue'
-import { required } from 'sefirot/validation/rules'
+import { maxFileSize, required } from 'sefirot/validation/rules'
 import { assertEmitted } from 'tests/Utils'
 
 describe('components/SInputFileUpload', () => {
@@ -62,5 +62,31 @@ describe('components/SInputFileUpload', () => {
 
     expect(wrapper.find('.SInputFileUploadItem').exists()).toBe(true)
     expect(wrapper.find('.SInputFileUploadItem .error').exists()).toBe(false)
+  })
+
+  it('keeps validating a file that shifts into a reused index slot', async () => {
+    // Items are keyed by index, so removing the leading string reference
+    // reuses its component instance for the File that shifts down. The
+    // File must still be validated (rules react to the identity change).
+    const big = new File([new ArrayBuffer(2_000_000)], 'big.pdf')
+
+    const wrapper = mount(SInputFileUpload, {
+      props: {
+        modelValue: ['a.pdf', big],
+        rules: { maxFileSize: maxFileSize('1mb') }
+      }
+    })
+
+    let items = wrapper.findAll('.SInputFileUploadItem')
+    expect(items[0].find('.error').exists()).toBe(false) // string ref: skipped
+    expect(items[1].find('.error').exists()).toBe(true) // oversized File
+
+    // Remove the string; the File moves into index 0's reused instance.
+    await wrapper.setProps({ modelValue: [big] })
+    await flushPromises()
+
+    items = wrapper.findAll('.SInputFileUploadItem')
+    expect(items).toHaveLength(1)
+    expect(items[0].find('.error').exists()).toBe(true)
   })
 })

--- a/tests/validation/rules/maxTotalFileSize.spec.ts
+++ b/tests/validation/rules/maxTotalFileSize.spec.ts
@@ -10,13 +10,17 @@ describe('validation/rules/maxTotalFileSize', () => {
     expect(rule.$validator([], null, null)).toBe(true)
     expect(rule.$validator([file1mb, file1mb], null, null)).toBe(true)
 
+    // String references to already-uploaded files are allowed; only Files
+    // count toward the total, so a 1mb File plus a reference is still 1mb.
+    expect(rule.$validator([file1mb, 'file1mb'], null, null)).toBe(true)
+
     expect(rule.$validator(true, null, null)).toBe(false)
     expect(rule.$validator(false, null, null)).toBe(false)
     expect(rule.$validator(1, null, null)).toBe(false)
     expect(rule.$validator('abc', null, null)).toBe(false)
     expect(rule.$validator({}, null, null)).toBe(false)
     expect(rule.$validator([file1mb, file1mb, file1mb], null, null)).toBe(false)
-    expect(rule.$validator([file1mb, 'file1mb'], null, null)).toBe(false)
+    expect(rule.$validator([file1mb, {}], null, null)).toBe(false)
   })
 
   it('shows the default error message', () => {

--- a/tests/validation/validators/maxTotalFileSize.spec.ts
+++ b/tests/validation/validators/maxTotalFileSize.spec.ts
@@ -42,4 +42,16 @@ describe('validation/validators/maxTotalFileSize', () => {
     expect(maxTotalFileSize([], 'abc')).toBe(false)
     expect(maxTotalFileSize([f(10)], 'abc')).toBe(false)
   })
+
+  it('allows string references to already-uploaded files', () => {
+    // Only Files count toward the total; string references contribute 0.
+    expect(maxTotalFileSize(['old.pdf'], '1MB')).toBe(true)
+    expect(maxTotalFileSize([f(900_000), 'old.pdf'], '1MB')).toBe(true) // 900k <= 1e6
+    expect(maxTotalFileSize([f(1_100_000), 'old.pdf'], '1MB')).toBe(false) // 1.1M > 1e6
+  })
+
+  it('still rejects arrays with elements that are neither File nor string', () => {
+    expect(maxTotalFileSize([f(100), {}], '1MB')).toBe(false)
+    expect(maxTotalFileSize([f(100), 123], '1MB')).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

`SInputFileUpload` (in `file` mode) now accepts `string` items alongside `File`, mirroring how `SInputImage` already accepts `File | string`. A `string` represents an **already-uploaded file** — referenced by its stored path or basename rather than a local `File`:

- it renders by its basename,
- shows no size (the size isn't known on the client),
- and is removable like any other item.

This lets forms round-trip existing uploads — display them, keep them, or remove them — instead of only handling freshly selected `File` objects. The lens `FileUploadField` benefits without extra work: the `(File | string)[]` model maps directly to its `File | reference` payload, so kept files come back as their reference and new ones as `File`.

## Notable changes

- `FileObject.file` stays required; the "already uploaded" case is represented by a plain `string` in `file` mode (`ModelValue<'file'> = File | string`), keeping `object` mode unchanged.
- `SInputFileUploadItem` renders a `string` item by its basename and omits the size/validation that only apply to a real `File`.

## Known limitation

The footer's **total file size under-counts when the list mixes uploaded references with newly selected files**, because an uploaded reference carries no size on the client. This is accepted for now — surfacing an accurate total would require the size to travel with the reference (or an extra lookup). Noted in a comment on `totalFileSizeText`.

## Test plan

- [ ] A `string` item renders by its basename with no size and can be removed.
- [ ] A mix of `string` references and `File` objects renders and round-trips correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)