### PR TITLE
feat(day): register the ja locale on the bundled Day.js instance

### DIFF
--- a/lib/support/Day.ts
+++ b/lib/support/Day.ts
@@ -2,6 +2,7 @@ import dayjs, { type ConfigType, type Dayjs } from 'dayjs/esm'
 import PluginRelativeTime from 'dayjs/esm/plugin/relativeTime'
 import PluginTimezone from 'dayjs/esm/plugin/timezone'
 import PluginUtc from 'dayjs/esm/plugin/utc'
+import 'dayjs/esm/locale/ja'
 
 dayjs.extend(PluginUtc)
 dayjs.extend(PluginTimezone)

--- a/tests/support/Day.spec.ts
+++ b/tests/support/Day.spec.ts
@@ -26,6 +26,14 @@ describe('support/Day', () => {
     })
   })
 
+  describe('locale', () => {
+    it('registers the ja locale on the bundled instance', () => {
+      // 2024-06-02 is a Sunday. Proves `dayjs/esm/locale/ja` is registered
+      // on Sefirot's instance, so `.locale('ja')` works on its dates.
+      expect(Day.day('2024-06-02').locale('ja').format('dddd')).toBe('日曜日')
+    })
+  })
+
   describe('createYmd', () => {
     it('creates a new ymd object', () => {
       const expected = {


### PR DESCRIPTION
## Summary

Sefirot bundles its own Day.js instance (`support/Day` imports from `dayjs/esm`, and the build inlines it via `noExternal`). Because of that, a consuming app that registers a locale on *its* Day.js — `import 'dayjs/locale/ja'` or `dayjs.locale(...)` — targets a different instance, so the registration never reaches the dates Sefirot renders and `.locale('ja')` on a Sefirot date is a no-op (falls back to the default locale).

This registers the `ja` locale inside Sefirot via `import 'dayjs/esm/locale/ja'`, so it's available on Sefirot's instance:

```ts
import { day } from 'sefirot/support/Day'

day('2024-06-02').locale('ja').format('dddd') // '日曜日'
```

The active locale is still chosen per call (`.locale(lang)`), which is the existing pattern — this only makes the registration land on the right instance.

## Notable changes

- A side-effect `import 'dayjs/esm/locale/ja'` in `support/Day`. This bundles the (small) `ja` locale for every consumer, which we accept rather than exposing a registration API that each app has to wire up.

## Test plan

- [ ] `day(sunday).locale('ja').format('dddd')` returns the Japanese weekday name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)