### PR TITLE
feat(lens): include the active language in catalog search requests

### DIFF
--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -3,6 +3,7 @@ import { useDebounceFn, useElementSize } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 import SDivider from '../../../components/SDivider.vue'
 import { useQuery } from '../../../composables/Api'
+import { useLang } from '../../../composables/Lang'
 import { usePower } from '../../../composables/Power'
 import { type FieldData } from '../FieldData'
 import { type LensQuery, type LensQuerySort } from '../LensQuery'
@@ -180,12 +181,15 @@ const _overrides = ref(props.overrides ?? {})
 const page = ref(1)
 const perPage = ref(100)
 
+const lang = useLang()
+
 const { data: result, execute: refresh, loading } = useQuery(async (http) => {
   const input = {
     entity: props.entity ?? '__no_entity__',
     select: withIndexField(_select.value),
     filters: createInputFilters(queryFilter.value, _filters.value),
     sort: _sort.value.length > 0 ? _sort.value : defaultSort.value ?? [],
+    settings: { lang },
     page: page.value,
     perPage: perPage.value
   }


### PR DESCRIPTION
## Summary

`LensCatalog` now includes the active display language in the payload it sends with every search request — `settings.lang`, read once from `useLang()`. This lets a backend localize values it has to resolve on its own (for example, the title shown for a related-record column) to the language the user is currently viewing.

`settings.lang` is already part of the `LensQuery` type (`LensQuerySettings`), so this only populates an existing field — there are no type or schema changes, and backends that ignore it are unaffected.

## Notable changes

- The language is read once at setup via `const lang = useLang()` and passed into the request input as `settings: { lang }`, rather than read inline.

## Test plan

- [ ] In a non-default locale, verify that a backend which localizes server-resolved strings (e.g. related-field titles) receives the language and renders them in the active locale.
