### PR TITLE
feat(lens): add `url-sync` option to LensCatalog

### DIFF
--- a/docs/composables/url.md
+++ b/docs/composables/url.md
@@ -11,6 +11,7 @@ import { type MaybeRefOrGetter } from 'vue'
 
 interface UseUrlQuerySyncOptions {
   casts?: Record<string, (value: string) => any>
+  serializers?: Record<string, (value: any) => string>
   exclude?: string[]
 }
 
@@ -43,6 +44,25 @@ const options = {
 useUrlQuerySync(options, {
   casts: {
     page: (v) => Number(v)
+  }
+})
+```
+
+### Serialize values
+
+You may use `serializers` option to control how state values get written to the URL query. This is useful when a value cannot be represented as a plain query param, such as nested arrays. Define the matching `casts` option to restore the value from the URL.
+
+```ts
+const options = {
+  filters: [['name', '=', 'foo']]
+}
+
+useUrlQuerySync(options, {
+  casts: {
+    filters: (v) => JSON.parse(v)
+  },
+  serializers: {
+    filters: (v) => JSON.stringify(v)
   }
 })
 ```

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -8,6 +8,7 @@ import { usePower } from '../../../composables/Power'
 import { type FieldData } from '../FieldData'
 import { type LensQuery, type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
+import { useCatalogUrlQuerySync } from '../composables/CatalogUrlQuerySync'
 import LensCatalogControl, { type FilterPresets } from './LensCatalogControl.vue'
 import LensCatalogFooter from './LensCatalogFooter.vue'
 import LensCatalogStateFilter from './LensCatalogStateFilter.vue'
@@ -110,6 +111,17 @@ export interface Props {
   // user add any available column to the view (e.g. a saved-view editor),
   // not just toggle the ones already selected.
   loadSelectable?: boolean
+
+  // Whether to sync the catalog state with the URL query string so that
+  // it survives page reloads and can be shared as a link. The synced
+  // state is the search query (`q`), `filters`, `sort`, and `page`.
+  //
+  // While enabled, the catalog owns the page's entire query string:
+  // query params other than the above are removed whenever the catalog
+  // state is written back to the URL. For the same reason, at most one
+  // catalog per page may enable this option. The option is read once on
+  // setup, so toggling it afterwards has no effect.
+  urlSync?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -207,6 +219,13 @@ const { data: result, execute: refresh, loading } = useQuery(async (http) => {
 })
 
 const doRefresh = useDebounceFn(refresh, 50)
+
+if (props.urlSync) {
+  useCatalogUrlQuerySync(
+    { query, filters: _filters, sort: _sort, page },
+    doRefresh
+  )
+}
 
 const _showEmptyState = computed(() => {
   return props.showEmptyState && !hasInitialResults.value && result.value?.data.length === 0

--- a/lib/blocks/lens/composables/CatalogUrlQuerySync.ts
+++ b/lib/blocks/lens/composables/CatalogUrlQuerySync.ts
@@ -48,9 +48,13 @@ export function useCatalogUrlQuerySync(
   }
 
   // URL params are user-editable, so anything malformed falls back to
-  // the state's initial value, exactly as if the param was absent.
-  const defaultFilters = state.filters.value
-  const defaultSort = state.sort.value
+  // the state's initial value, exactly as if the param was absent. The
+  // snapshots must be deep clones: the refs' arrays are later mutated in
+  // place (inline filter updates `push`/`splice` into `filters`, and the
+  // URL -> state sync splices arrays as well), which would otherwise
+  // silently drift these "initial" values along with the current state.
+  const defaultFilters = cloneDeep(state.filters.value)
+  const defaultSort = cloneDeep(state.sort.value)
   const defaultPage = state.page.value
 
   const urlState = reactive({

--- a/lib/blocks/lens/composables/CatalogUrlQuerySync.ts
+++ b/lib/blocks/lens/composables/CatalogUrlQuerySync.ts
@@ -1,0 +1,142 @@
+import cloneDeep from 'lodash-es/cloneDeep'
+import { type Ref, onScopeDispose, reactive, watch } from 'vue'
+import { useUrlQuerySync } from '../../../composables/Url'
+import { FilterOperatorLabelDict } from '../FilterOperator'
+import { type LensQuerySort } from '../LensQuery'
+
+export interface CatalogUrlQuerySyncState {
+  query: Ref<string | null>
+  filters: Ref<any[]>
+  sort: Ref<LensQuerySort[]>
+  page: Ref<number>
+}
+
+const filterOperators = new Set(Object.keys(FilterOperatorLabelDict))
+
+// The sync owns a fixed set of query param keys (`q`, `filters`, `sort`,
+// and `page`), so two active instances on the same page would overwrite
+// each other's params. Track active instances to warn about this misuse.
+let activeCount = 0
+
+/**
+ * Sync the catalog state with the URL query string via `useUrlQuerySync`.
+ * `filters` and `sort` are carried as JSON since their nested array
+ * structure (with non-string values) cannot survive a flat query string.
+ *
+ * `onChange` is called whenever the synced state changes after the
+ * initial setup. State changes coming from the catalog UI already
+ * trigger a fetch in their own handlers, so the callback is expected to
+ * be debounced; its real purpose is to fetch on URL-driven changes
+ * (browser back/forward, hand-edited URL) which have no other
+ * refresh path.
+ */
+export function useCatalogUrlQuerySync(
+  state: CatalogUrlQuerySyncState,
+  onChange: () => void
+): void {
+  if (import.meta.env.DEV) {
+    activeCount++
+    if (activeCount > 1) {
+      console.warn(
+        '[sefirot] Multiple `LensCatalog` components with `url-sync` enabled'
+        + ' are active at the same time. They will overwrite each other\'s'
+        + ' query params (`q`, `filters`, `sort`, and `page`). Enable'
+        + ' `url-sync` on at most one catalog per page.'
+      )
+    }
+    onScopeDispose(() => { activeCount-- })
+  }
+
+  // URL params are user-editable, so anything malformed falls back to
+  // the state's initial value, exactly as if the param was absent.
+  const defaultFilters = state.filters.value
+  const defaultSort = state.sort.value
+  const defaultPage = state.page.value
+
+  const urlState = reactive({
+    q: state.query,
+    filters: state.filters,
+    sort: state.sort,
+    page: state.page
+  })
+
+  useUrlQuerySync(urlState, {
+    casts: {
+      q: (v) => castQ(v),
+      filters: (v) => castFilters(v) ?? cloneDeep(defaultFilters),
+      sort: (v) => castSort(v) ?? cloneDeep(defaultSort),
+      page: (v) => castPage(v) ?? defaultPage
+    },
+    serializers: {
+      filters: (v) => JSON.stringify(v),
+      sort: (v) => JSON.stringify(v)
+    }
+  })
+
+  // Registered after `useUrlQuerySync` on purpose: the initial URL ->
+  // state application happens synchronously inside it, before this
+  // watcher exists, so the initial fetch (on mounted) is not duplicated.
+  watch(urlState, onChange, { deep: true })
+}
+
+function castQ(value: any): string | null {
+  return typeof value === 'string' && value !== '' ? value : null
+}
+
+function castFilters(value: any): any[] | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(value)
+    return isFilters(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+// Filters are a list of entries where an entry is either a condition
+// tuple `[field, operator, value]` or a group `['$and' | '$or', entries]`.
+// Refer to `groupToLensFilters` in `LensFormFilter.vue`.
+function isFilters(value: unknown): value is any[] {
+  return Array.isArray(value) && value.every(isFilterEntry)
+}
+
+function isFilterEntry(value: unknown): boolean {
+  if (!Array.isArray(value)) {
+    return false
+  }
+  if (value[0] === '$and' || value[0] === '$or') {
+    return value.length === 2 && isFilters(value[1])
+  }
+  return value.length === 3
+    && typeof value[0] === 'string'
+    && typeof value[1] === 'string'
+    && filterOperators.has(value[1])
+}
+
+function castSort(value: any): LensQuerySort[] | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(value)
+    return isSort(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function isSort(value: unknown): value is LensQuerySort[] {
+  return Array.isArray(value) && value.every((entry) => {
+    return Array.isArray(entry)
+      && entry.length === 2
+      && typeof entry[0] === 'string'
+      && (entry[1] === 'asc' || entry[1] === 'desc')
+  })
+}
+
+function castPage(value: any): number | null {
+  const page = Number(value)
+  return Number.isInteger(page) && page >= 1 ? page : null
+}

--- a/lib/composables/Url.ts
+++ b/lib/composables/Url.ts
@@ -4,6 +4,7 @@ import { type LocationQuery, useRoute, useRouter } from 'vue-router'
 
 export interface UseUrlQuerySyncOptions {
   casts?: Record<string, (value: any) => any>
+  serializers?: Record<string, (value: any) => string>
   exclude?: string[]
 }
 
@@ -16,7 +17,7 @@ export interface UseUrlQuerySyncOptions {
  */
 export function useUrlQuerySync(
   state: MaybeRef<Record<string, any>>,
-  { casts = {}, exclude = [] }: UseUrlQuerySyncOptions = {}
+  { casts = {}, serializers = {}, exclude = [] }: UseUrlQuerySyncOptions = {}
 ): void {
   const route = useRoute()
   const router = useRouter()
@@ -78,9 +79,25 @@ export function useUrlQuerySync(
 
     const currentQuery = normalizeQuery(route.query)
 
+    // Both sides of this comparison hold deserialized values: `newQuery`
+    // carries raw state values and `normalizeQuery` runs `casts` on the
+    // URL params. Serialization must therefore only happen on the final
+    // write below — serializing before the comparison would make a
+    // round-tripped value always look different from the state and cause
+    // an endless replace loop.
     if (!isEqual(newQuery, currentQuery)) {
-      await router.replace({ query: unflattenObject(newQuery) })
+      await router.replace({ query: unflattenObject(serializeQuery(newQuery)) })
     }
+  }
+
+  function serializeQuery(query: Record<string, any>): Record<string, any> {
+    const result: Record<string, any> = {}
+
+    for (const key in query) {
+      result[key] = serializers[key] ? serializers[key](query[key]) : query[key]
+    }
+
+    return result
   }
 
   function normalizeQuery(query: LocationQuery): Record<string, any> {

--- a/tests/blocks/lens/composables/CatalogUrlQuerySync.spec.ts
+++ b/tests/blocks/lens/composables/CatalogUrlQuerySync.spec.ts
@@ -1,0 +1,142 @@
+import { type LensQuerySort } from 'sefirot/blocks/lens/LensQuery'
+import { useCatalogUrlQuerySync } from 'sefirot/blocks/lens/composables/CatalogUrlQuerySync'
+import { setupWithWrapper } from 'tests/Utils'
+import { ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+// Pass `null` as `initialQuery` to keep the current query of the shared
+// router untouched.
+function setupCatalog(
+  initialQuery: Record<string, any> | null = {},
+  initialFilters: any[] = []
+) {
+  return setupWithWrapper(() => {
+    const router = useRouter()
+
+    if (initialQuery) {
+      router.replace({ query: initialQuery })
+    }
+
+    const query = ref<string | null>(null)
+    const filters = ref<any[]>(initialFilters)
+    const sort = ref<LensQuerySort[]>([])
+    const page = ref(1)
+
+    const calls = ref(0)
+
+    useCatalogUrlQuerySync({ query, filters, sort, page }, () => {
+      calls.value++
+    })
+
+    const route = useRoute()
+    return { query, filters, sort, page, calls, route, router }
+  })
+}
+
+describe('blocks/lens/composables/CatalogUrlQuerySync', () => {
+  it('syncs the catalog state to the URL', async () => {
+    const { wrapper, vm } = setupCatalog()
+
+    vm.query = 'acme'
+    vm.filters = [['name', '=', 'foo']]
+    vm.sort = [['name', 'desc']]
+    vm.page = 2
+
+    await expect.poll(() => vm.route.query.q).toBe('acme')
+    expect(vm.route.query.filters).toBe('[["name","=","foo"]]')
+    expect(vm.route.query.sort).toBe('[["name","desc"]]')
+    expect(vm.route.query.page).toBe('2')
+
+    // Params should be removed when the state returns to the defaults.
+    vm.query = null
+    vm.filters = []
+    vm.sort = []
+    vm.page = 1
+
+    await expect.poll(() => vm.route.query.q).toBeUndefined()
+    expect(vm.route.query.filters).toBeUndefined()
+    expect(vm.route.query.sort).toBeUndefined()
+    expect(vm.route.query.page).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it('restores the catalog state from the URL on initialization', async () => {
+    const { wrapper, vm } = setupCatalog({
+      q: 'acme',
+      filters: '[["name","=","foo"],["$or",[["age",">",30],["age","<",10]]]]',
+      sort: '[["name","asc"]]',
+      page: '3'
+    })
+
+    await expect.poll(() => vm.query).toBe('acme')
+    expect(vm.filters).toEqual([['name', '=', 'foo'], ['$or', [['age', '>', 30], ['age', '<', 10]]]])
+    expect(vm.sort).toEqual([['name', 'asc']])
+    expect(vm.page).toBe(3)
+
+    wrapper.unmount()
+  })
+
+  it('falls back to the initial state for malformed params', async () => {
+    const { wrapper, vm } = setupCatalog({
+      q: '',
+      filters: 'not-a-json',
+      sort: '[["name","sideways"]]',
+      page: 'NaN'
+    }, [['status', '=', 'open']])
+
+    // Malformed params are dropped from the URL, and the state keeps the
+    // initial values, exactly as if the params were absent.
+    await expect.poll(() => vm.route.query.filters).toBeUndefined()
+    expect(vm.route.query.q).toBeUndefined()
+    expect(vm.route.query.sort).toBeUndefined()
+    expect(vm.route.query.page).toBeUndefined()
+
+    expect(vm.query).toBe(null)
+    expect(vm.filters).toEqual([['status', '=', 'open']])
+    expect(vm.sort).toEqual([])
+    expect(vm.page).toBe(1)
+
+    wrapper.unmount()
+  })
+
+  it('rejects filters with an unknown shape or operator', async () => {
+    const { wrapper, vm } = setupCatalog({
+      filters: '[["name","~","foo"]]'
+    })
+
+    await expect.poll(() => vm.route.query.filters).toBeUndefined()
+    expect(vm.filters).toEqual([])
+
+    wrapper.unmount()
+  })
+
+  it('calls onChange when the URL drives the state', async () => {
+    const { wrapper, vm } = setupCatalog({ q: 'initial' })
+
+    await expect.poll(() => vm.query).toBe('initial')
+
+    const callsAfterInit = vm.calls
+
+    await vm.router.replace({ query: { q: 'updated' } })
+
+    await expect.poll(() => vm.query).toBe('updated')
+    expect(vm.calls).toBeGreaterThan(callsAfterInit)
+
+    wrapper.unmount()
+  })
+
+  it('warns when multiple synced catalogs are active at once', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const first = setupCatalog()
+    expect(warn).not.toHaveBeenCalled()
+
+    const second = setupCatalog(null)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('`url-sync`'))
+
+    first.wrapper.unmount()
+    second.wrapper.unmount()
+    warn.mockRestore()
+  })
+})

--- a/tests/blocks/lens/composables/CatalogUrlQuerySync.spec.ts
+++ b/tests/blocks/lens/composables/CatalogUrlQuerySync.spec.ts
@@ -100,6 +100,29 @@ describe('blocks/lens/composables/CatalogUrlQuerySync', () => {
     wrapper.unmount()
   })
 
+  it('falls back to the initial state even after in-place filter mutations', async () => {
+    const { wrapper, vm } = setupCatalog({}, [['status', '=', 'open']])
+
+    // Mutate the filters in place, as the catalog's inline filter path
+    // does. This must not drift the fallback snapshot of the initial
+    // filters along with it.
+    vm.filters.push(['name', '=', 'foo'])
+
+    await expect.poll(() => vm.route.query.filters)
+      .toBe('[["status","=","open"],["name","=","foo"]]')
+
+    await vm.router.replace({ query: { filters: 'broken' } })
+
+    // The malformed param falls back to the initial filters, not to the
+    // mutated current value, and drops itself from the URL. Note that the
+    // URL is written back after the state is updated, so it must be the
+    // one to poll on.
+    await expect.poll(() => vm.route.query.filters).toBeUndefined()
+    expect(vm.filters).toEqual([['status', '=', 'open']])
+
+    wrapper.unmount()
+  })
+
   it('rejects filters with an unknown shape or operator', async () => {
     const { wrapper, vm } = setupCatalog({
       filters: '[["name","~","foo"]]'

--- a/tests/composables/Url.spec.ts
+++ b/tests/composables/Url.spec.ts
@@ -76,6 +76,77 @@ describe('composables/Url', () => {
       wrapper.unmount()
     })
 
+    it('serializes values to the URL with the serializers option', async () => {
+      const { wrapper, vm } = setupWithWrapper(() => {
+        const router = useRouter()
+
+        // Clear leftovers from previous tests on the shared router.
+        router.replace({ query: {} })
+
+        const data = reactive({
+          filters: [] as any[]
+        })
+
+        useUrlQuerySync(data, {
+          casts: {
+            filters: (v) => JSON.parse(v)
+          },
+          serializers: {
+            filters: (v) => JSON.stringify(v)
+          }
+        })
+
+        const route = useRoute()
+        return { data, route }
+      })
+
+      // Change the state and check the URL holds the serialized value.
+      vm.data.filters = [['name', '=', 1]]
+
+      await expect.poll(() => vm.route.query.filters).toBe('[["name","=",1]]')
+
+      // Reset to default and check the param is removed.
+      vm.data.filters = []
+
+      await expect.poll(() => vm.route.query.filters).toBeUndefined()
+
+      wrapper.unmount()
+    })
+
+    it('restores serialized values from the URL on initialization', async () => {
+      const { wrapper, vm } = setupWithWrapper(() => {
+        const router = useRouter()
+
+        router.replace({ query: { filters: '[["name","=",1]]' } })
+
+        const data = reactive({
+          filters: [] as any[]
+        })
+
+        useUrlQuerySync(data, {
+          casts: {
+            filters: (v) => JSON.parse(v)
+          },
+          serializers: {
+            filters: (v) => JSON.stringify(v)
+          }
+        })
+
+        const route = useRoute()
+        return { data, route }
+      })
+
+      // State should hold the deserialized value.
+      await expect.poll(() => vm.data.filters).toEqual([['name', '=', 1]])
+
+      // The URL should keep holding the serialized value as is. This also
+      // verifies that the state and the URL reached a stable point rather
+      // than replacing each other in a loop.
+      expect(vm.route.query.filters).toBe('[["name","=",1]]')
+
+      wrapper.unmount()
+    })
+
     it('excludes specified keys from URL sync', async () => {
       const { wrapper, vm } = setupWithWrapper(() => {
         const data = reactive({


### PR DESCRIPTION
Closes #706.

Adds an opt-in `url-sync` prop to `LensCatalog` that syncs the catalog state — search query (`q`), `filters`, `sort`, and `page` — with the URL query string, so the state survives page reloads and can be shared as a link.

```html
<LensCatalog endpoint="/api/lens/search" entity="user" url-sync />
```

### How it works

- `q` is carried as a plain string and `page` as a number, while `filters` / `sort` are carried as single JSON params since their nested array structure (with non-string values) cannot survive a flat query string: `?q=acme&filters=[["status","=","open"]]&sort=[["created_at","desc"]]&page=2`
- Only values that differ from the initial state are written to the URL, and params are removed when the state returns to the defaults. Clearing initial filters passed via the `filters` prop is therefore distinguishable from never touching them (`filters=[]`).
- URL params are user-editable, so malformed values (broken JSON, unknown shape or operator, invalid sort direction, non-positive page) are structurally validated and fall back to the initial state, removing themselves from the URL.
- Browser back / forward (and any other URL-driven state change) re-runs the query. UI-driven changes already fetch in their own handlers; the extra trigger collapses into the existing debounce and request memoization.
- `useUrlQuerySync` gains a `serializers` option — the write-direction counterpart of `casts` — to support the JSON round trip. Serialization only applies on the final write so that the state/URL comparison stays in deserialized space (otherwise a round-tripped value would never compare equal and cause an endless replace loop).

### Constraints

- While enabled, the catalog owns the page's entire query string (this follows the existing `useUrlQuerySync` semantics): unrelated query params are removed when the catalog state is written back.
- For the same reason, at most one catalog per page may enable `url-sync`. A dev-mode warning fires when multiple synced catalogs are active at once.

### Testing

- Unit tests for the `serializers` option and the new `useCatalogUrlQuerySync` composable: state → URL, URL → state restoration, nested filter groups, malformed param fallback (with URL self-heal), URL-driven refetch callback, and the multi-instance warning.
- Verified locally in a downstream application: filter / sort / search / pagination round-trip through reloads, back / forward navigation, and hand-edited URLs behave as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)