### PR TITLE
feat(lens): add built-in avatar field type

### DIFF
--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -17,6 +17,7 @@ import { type Rule } from './Rule'
  * }
  */
 export interface FieldDataRegistry {
+  avatar: AvatarFieldData
   boolean: BooleanFieldData
   content: ContentFieldData
   date: DateFieldData
@@ -48,6 +49,18 @@ export interface FieldDataBase {
   width: number
   required: boolean
   rules: Rule[]
+}
+
+export interface AvatarFieldData extends FieldDataBase {
+  type: 'avatar'
+  /**
+   * Optional keys on the record that hold the display name, per language. The
+   * avatar uses the name (resolved against the active language) for the
+   * initials fallback / tooltip when the image is unavailable. The field
+   * value itself is the image URL.
+   */
+  nameEn?: string | null
+  nameJa?: string | null
 }
 
 export interface BooleanFieldData extends FieldDataBase {

--- a/lib/blocks/lens/composables/SetupLens.ts
+++ b/lib/blocks/lens/composables/SetupLens.ts
@@ -1,6 +1,7 @@
 import { type FieldDataType } from '../FieldData'
 import { type FieldDataFor, type FieldProvider, FieldRegistry } from '../FieldRegistry'
 import { provideFieldRegistry } from '../composables/FieldRegistry'
+import { AvatarField } from '../fields/AvatarField'
 import { BooleanField } from '../fields/BooleanField'
 import { ContentField } from '../fields/ContentField'
 import { DateField } from '../fields/DateField'
@@ -34,6 +35,7 @@ export function useSetupLens(): SetupLens {
   registerDefaultFields()
 
   function registerDefaultFields(): void {
+    fieldRegistry.register('avatar', (ctx, field) => new AvatarField(ctx, field))
     fieldRegistry.register('boolean', (ctx, field) => new BooleanField(ctx, field))
     fieldRegistry.register('content', (ctx, field) => new ContentField(ctx, field))
     fieldRegistry.register('date', (ctx, field) => new DateField(ctx, field))

--- a/lib/blocks/lens/fields/AvatarField.ts
+++ b/lib/blocks/lens/fields/AvatarField.ts
@@ -1,0 +1,40 @@
+import { h } from 'vue'
+import SAvatar from '../../../components/SAvatar.vue'
+import { type TableCell } from '../../../composables/Table'
+import { type AvatarFieldData } from '../FieldData'
+import { type FilterOperator } from '../FilterOperator'
+import { type FilterInput } from '../filter-inputs/FilterInput'
+import { Field } from './Field'
+
+export class AvatarField extends Field<AvatarFieldData> {
+  override tableCell(v: any, r: any): TableCell {
+    // The display name lives on a sibling key of the record (resolved by the
+    // active language), not on the field value, which is the image URL.
+    const nameKey = this.ctx.lang === 'ja' ? this.data.nameJa : this.data.nameEn
+    return {
+      type: 'avatar',
+      // The field value is the image URL itself. A missing value renders an
+      // empty cell (both `image` and `name` falsy), unless a name companion
+      // is configured, in which case the avatar falls back to its initials.
+      image: v ?? null,
+      // Empty string (not null) when unset: a null name makes the cell
+      // renderer fall back to the raw row value, which here is the image URL
+      // and would break SAvatar.
+      name: nameKey ? (r?.[nameKey] ?? '') : ''
+    }
+  }
+
+  override availableFilters(): Partial<Record<FilterOperator, FilterInput>> {
+    return {}
+  }
+
+  override dataListItemComponent(): any {
+    return this.defineDataListItemComponent((value) => {
+      return h(SAvatar, { size: 'small', avatar: value ?? null })
+    })
+  }
+
+  override formInputComponent(): any {
+    throw new Error('Not implemented.')
+  }
+}

--- a/lib/blocks/lens/fields/AvatarField.ts
+++ b/lib/blocks/lens/fields/AvatarField.ts
@@ -30,7 +30,10 @@ export class AvatarField extends Field<AvatarFieldData> {
 
   override dataListItemComponent(): any {
     return this.defineDataListItemComponent((value) => {
-      return h(SAvatar, { size: 'small', avatar: value ?? null })
+      // Render nothing for a missing image so SDataListItem shows its empty
+      // placeholder ("—"), matching the empty table cell and the other
+      // data-list fields, instead of an empty bordered avatar.
+      return value ? h(SAvatar, { size: 'small', avatar: value }) : null
     })
   }
 

--- a/tests/blocks/lens/fields/AvatarField.spec.ts
+++ b/tests/blocks/lens/fields/AvatarField.spec.ts
@@ -1,9 +1,24 @@
+import { mount } from '@vue/test-utils'
 import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
 import { type AvatarFieldData } from 'sefirot/blocks/lens/FieldData'
 import { AvatarField } from 'sefirot/blocks/lens/fields/AvatarField'
+import SAvatar from 'sefirot/components/SAvatar.vue'
+import { DataListStateKey } from 'sefirot/composables/DataList'
+import { computed } from 'vue'
 
 function ctx(lang: 'en' | 'ja' = 'en'): FieldContext {
   return { lang }
+}
+
+function mountDataListItem(field: AvatarField, value: any) {
+  return mount(field.dataListItemComponent(), {
+    props: { value },
+    global: {
+      provide: {
+        [DataListStateKey]: { labelWidth: computed(() => '100px') }
+      }
+    }
+  })
 }
 
 function make(
@@ -110,6 +125,19 @@ describe('blocks/lens/fields/AvatarField', () => {
   describe('dataListItemComponent', () => {
     it('returns a component without throwing', () => {
       expect(() => make().dataListItemComponent()).not.toThrow()
+    })
+
+    it('renders the avatar when an image is present', () => {
+      const wrapper = mountDataListItem(make(), 'https://example.com/a.png')
+      expect(wrapper.findComponent(SAvatar).exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('renders the empty placeholder (not an empty avatar) when the value is null', () => {
+      const wrapper = mountDataListItem(make(), null)
+      expect(wrapper.findComponent(SAvatar).exists()).toBe(false)
+      expect(wrapper.find('.empty').exists()).toBe(true)
+      wrapper.unmount()
     })
   })
 

--- a/tests/blocks/lens/fields/AvatarField.spec.ts
+++ b/tests/blocks/lens/fields/AvatarField.spec.ts
@@ -1,0 +1,121 @@
+import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
+import { type AvatarFieldData } from 'sefirot/blocks/lens/FieldData'
+import { AvatarField } from 'sefirot/blocks/lens/fields/AvatarField'
+
+function ctx(lang: 'en' | 'ja' = 'en'): FieldContext {
+  return { lang }
+}
+
+function make(
+  overrides: Partial<AvatarFieldData> = {},
+  lang: 'en' | 'ja' = 'en'
+): AvatarField {
+  const data: AvatarFieldData = {
+    type: 'avatar',
+    key: 'avatar',
+    labelEn: 'Avatar',
+    labelJa: 'アバター',
+    filterKey: 'avatar',
+    sortable: false,
+    freeze: false,
+    width: 0,
+    required: false,
+    rules: [],
+    nameEn: null,
+    nameJa: null,
+    ...overrides
+  }
+  return new AvatarField(ctx(lang), data)
+}
+
+describe('blocks/lens/fields/AvatarField', () => {
+  describe('tableCell', () => {
+    it('renders an avatar cell with the row value as the image', () => {
+      const cell = make().tableCell('https://example.com/a.png', {}) as any
+      expect(cell.type).toBe('avatar')
+      expect(cell.image).toBe('https://example.com/a.png')
+      expect(cell.name).toBe('')
+    })
+
+    it('renders an empty avatar cell when the value is null', () => {
+      const cell = make().tableCell(null, {}) as any
+      expect(cell.type).toBe('avatar')
+      expect(cell.image).toBeNull()
+      expect(cell.name).toBe('')
+    })
+
+    it('renders an empty avatar cell when the value is undefined', () => {
+      const cell = make().tableCell(undefined, {}) as any
+      expect(cell.type).toBe('avatar')
+      expect(cell.image).toBeNull()
+      expect(cell.name).toBe('')
+    })
+
+    it('reads the English display name from the companion key on the record', () => {
+      const cell = make({ nameEn: 'fullNameEn' }).tableCell(
+        'https://example.com/a.png',
+        { fullNameEn: 'Alice', fullNameJa: 'アリス' }
+      ) as any
+      expect(cell.image).toBe('https://example.com/a.png')
+      expect(cell.name).toBe('Alice')
+    })
+
+    it('reads the Japanese display name from the companion key when the language is "ja"', () => {
+      const cell = make(
+        { nameEn: 'fullNameEn', nameJa: 'fullNameJa' },
+        'ja'
+      ).tableCell(
+        'https://example.com/a.png',
+        { fullNameEn: 'Alice', fullNameJa: 'アリス' }
+      ) as any
+      expect(cell.name).toBe('アリス')
+    })
+
+    it('falls back to initials (name with a null image) when the image is missing but a name companion is set', () => {
+      const cell = make({ nameEn: 'fullNameEn' }).tableCell(null, { fullNameEn: 'Alice' }) as any
+      expect(cell.image).toBeNull()
+      expect(cell.name).toBe('Alice')
+    })
+
+    it('uses an empty name (not null) when the companion key is missing on the record', () => {
+      const cell = make({ nameEn: 'fullNameEn' }).tableCell('https://example.com/a.png', {}) as any
+      expect(cell.name).toBe('')
+    })
+
+    it('uses an empty name (not null) when no companion key is configured for the active language', () => {
+      const cell = make({ nameEn: 'fullNameEn' }, 'ja').tableCell(
+        'https://example.com/a.png',
+        { fullNameEn: 'Alice' }
+      ) as any
+      expect(cell.name).toBe('')
+    })
+  })
+
+  describe('availableFilters', () => {
+    it('exposes no filter operators', () => {
+      expect(make().availableFilters()).toEqual({})
+    })
+  })
+
+  describe('tableSortMenu', () => {
+    it('is not sortable by default', () => {
+      expect(make().tableSortMenu(() => {})).toBeNull()
+    })
+
+    it('exposes a sort menu when the field opts in via sortable', () => {
+      expect(make({ sortable: true }).tableSortMenu(() => {})).not.toBeNull()
+    })
+  })
+
+  describe('dataListItemComponent', () => {
+    it('returns a component without throwing', () => {
+      expect(() => make().dataListItemComponent()).not.toThrow()
+    })
+  })
+
+  describe('formInputComponent', () => {
+    it('throws because avatars are display-only', () => {
+      expect(() => make().formInputComponent()).toThrow()
+    })
+  })
+})


### PR DESCRIPTION
Closes #733

Adds a built-in `avatar` field type to Lens, so an image / avatar column can be shown in a `LensCatalog` without registering a custom field via `setupLens.registerField()`.

## What

- New `AvatarField` (`type: 'avatar'`), registered in `SetupLens` alongside the other default fields.
- `tableCell()` returns `{ type: 'avatar', image }` where the field value is the image URL; renders an empty cell when the value is `null`.
- Optional `nameEn` / `nameJa` companion keys — point at a sibling record column holding the display name, resolved by the active language (mirrors the existing `labelEn` / `labelJa` convention). Used for the initials fallback / label, so a row with a missing image still shows initials.
- `dataListItemComponent()` renders the avatar in the record detail view.
- Read-only (no form input, like `RelatedOneField`) and respects the `sortable` flag, which is off by default for avatars.

## Notes

- The `name` companion reads from a sibling key on the row (the field value itself is the image URL), so the name column must be selected for the name to appear — consistent with how the cell renderer resolves `record[nameKey]`.

## Test

- `pnpm test:fail tests/blocks/lens` — 85 passed (13 new in `AvatarField.spec.ts`)
- `pnpm type`, `pnpm lint:fail` — clean

---

Server counterpart (Anima): globalbrain/anima#18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
