### PR TITLE
feat(lens): catalog editing (optimistic create/update/delete)

### DIFF
--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -49,6 +49,18 @@ export interface FieldDataBase {
   width: number
   required: boolean
   rules: Rule[]
+  /**
+   * Per-context visibility, mirroring the backend field definition. The
+   * catalog renders `showOnIndex` columns; the record sheet shows
+   * `showOnDetail` rows; the create form shows `showOnCreate` fields; and
+   * `showOnUpdate` marks a field editable (inline in the table and in the
+   * sheet) for an existing record. Optional so read-only catalogs whose
+   * backend predates these flags keep working (treated as index+detail only).
+   */
+  showOnIndex?: boolean
+  showOnDetail?: boolean
+  showOnCreate?: boolean
+  showOnUpdate?: boolean
 }
 
 export interface AvatarFieldData extends FieldDataBase {
@@ -157,6 +169,7 @@ export interface RelatedManyFieldData extends FieldDataBase {
   image?: string | null
   resourceEndpointMethod: 'get' | 'post'
   resourceEndpointPath: string
+  resourceEndpointBody?: Record<string, any> | null
   resourceEndpointDataKey: string | null
   resourceTitle: string
   resourceImage?: string | null
@@ -169,6 +182,7 @@ export interface RelatedOneFieldData extends FieldDataBase {
   image?: string | null
   resourceEndpointMethod: 'get' | 'post'
   resourceEndpointPath: string
+  resourceEndpointBody?: Record<string, any> | null
   resourceEndpointDataKey: string | null
   resourceTitle: string
   resourceImage?: string | null

--- a/lib/blocks/lens/ResourceFetcher.ts
+++ b/lib/blocks/lens/ResourceFetcher.ts
@@ -1,3 +1,7 @@
-export type ResourceFetcher = (method: ResourceFetchMethod, url: string, body?: Record<string, any> | null) => Promise<any>
+export type ResourceFetcher = (
+  method: ResourceFetchMethod,
+  url: string,
+  body?: Record<string, any> | null
+) => Promise<any>
 
 export type ResourceFetchMethod = 'get' | 'post'

--- a/lib/blocks/lens/ResourceFetcher.ts
+++ b/lib/blocks/lens/ResourceFetcher.ts
@@ -1,3 +1,3 @@
-export type ResourceFetcher = (method: ResourceFetchMethod, url: string) => Promise<any>
+export type ResourceFetcher = (method: ResourceFetchMethod, url: string, body?: Record<string, any> | null) => Promise<any>
 
 export type ResourceFetchMethod = 'get' | 'post'

--- a/lib/blocks/lens/Rule.ts
+++ b/lib/blocks/lens/Rule.ts
@@ -1,6 +1,7 @@
 export type Rule =
   | MaxLengthRule
   | RequiredRule
+  | UniqueRule
   | SlackChannelLinkRule
   | SlackChannelNameRule
   | BeforeRule
@@ -15,6 +16,10 @@ export interface MaxLengthRule {
 
 export interface RequiredRule {
   type: 'required'
+}
+
+export interface UniqueRule {
+  type: 'unique'
 }
 
 export interface SlackChannelLinkRule {

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -213,6 +213,12 @@ const latestState = ref<LensResult | null>(null)
 // for the full optimistic-write strategy this is part of.
 const pendingWrites = ref(0)
 
+// Whether a (blocking) create POST is in flight. Not part of `busy` — the create
+// sheet covers the controls — but it arms the unload guard, and the debounced
+// refetch consults it (declared here for that reason), since a search issued
+// before the new row exists must not assign its rows over the just-created record.
+const creating = ref(false)
+
 let prevFetchInput: LensQuery | null = null
 let prevFetchResult: LensResult | null = null
 
@@ -306,12 +312,14 @@ const { data: result, execute: refresh, loading } = useQuery(async (http) => {
 watch(result, (r) => { currentResult = r ?? undefined }, { immediate: true })
 
 const doRefresh = useDebounceFn(() => {
-  // A write may have started during the debounce window: the busy lock guards the
-  // query handlers at click time, but not this deferred fetch. Bail if so —
-  // reading now would return stale pre-write rows and overwrite the optimistic
-  // edit. The post-batch reconcile refetches the (new) query state once writes
-  // settle, surfacing it behind the refresh banner.
-  if (pendingWrites.value > 0) { return }
+  // A write or a blocking create may have started during the debounce window: the
+  // busy lock guards the query handlers at click time, but not this deferred
+  // fetch. Bail if so — reading now would return pre-write / pre-create rows and
+  // overwrite the optimistic edit or the just-created record. The post-batch
+  // reconcile / create path surfaces the canonical state once things settle.
+  // (Deliberate refreshes go through `forceRefresh`, which calls `refresh`
+  // directly to bypass this guard.)
+  if (pendingWrites.value > 0 || creating.value) { return }
   return refresh()
 }, 50)
 
@@ -632,11 +640,6 @@ const sheetError = ref(false)
 const reconciling = ref(false)
 const busy = computed(() => pendingWrites.value > 0 || reconciling.value)
 
-// Whether a (blocking) create POST is in flight. Not part of `busy` — the
-// create sheet covers the controls — but it arms the unload guard, since the
-// create write is just as slow and shouldn't be lost to a tab close/reload.
-const creating = ref(false)
-
 // Whether any write in the current in-flight batch failed; when so the reconcile
 // is skipped (the snackbar already told the user to reload).
 let batchErrored = false
@@ -788,14 +791,16 @@ function rebindOpenSheet(): void {
 
 // Core force-refetch: drop the memoized input + any stash, invalidate an in-flight
 // reconcile (its request may predate the change being surfaced), refetch the
-// current query, then rebind an open sheet to the fresh rows. Bypasses the busy
-// guard — callers (the exposed refresh, the create path) gate it themselves.
+// current query, then rebind an open sheet to the fresh rows. Calls `refresh`
+// directly (not the debounced `doRefresh`) so it bypasses the pending-write /
+// creating bail — callers (the exposed refresh, the create path) gate it
+// themselves, and create deliberately refreshes while `creating` is still true.
 async function forceRefresh(): Promise<void> {
   reconcileToken++
   reconciling.value = false
   prevFetchInput = null
   latestState.value = null
-  await doRefresh()
+  await refresh()
   rebindOpenSheet()
 }
 
@@ -911,6 +916,12 @@ function prependCreated(data: Record<string, any>): void {
 
 async function create(values: Record<string, any>): Promise<Record<string, any>> {
   creating.value = true
+  // Invalidate any main search already in flight (issued before this create) so
+  // its pre-create rows can't assign over the just-created record when it
+  // resolves — mirrors trackWrite. New searches can't start during the create
+  // (doRefresh bails on `creating`); create's own forceRefresh bypasses that by
+  // calling refresh directly.
+  searchToken++
   try {
     const res = await executeCreate(values)
     // The POST succeeded — the record exists. From here a refresh failure must

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { useDebounceFn, useElementSize } from '@vueuse/core'
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import SButton from '../../../components/SButton.vue'
 import SDivider from '../../../components/SDivider.vue'
 import { useMutation, useQuery } from '../../../composables/Api'
-import { useLang } from '../../../composables/Lang'
+import { useLang, useTrans } from '../../../composables/Lang'
 import { usePower } from '../../../composables/Power'
+import { useSnackbars } from '../../../stores/Snackbars'
 import { type FieldData } from '../FieldData'
 import { type LensQuery, type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
@@ -164,6 +166,23 @@ const emit = defineEmits<{
   'cell-clicked': [value: any, record: any]
 }>()
 
+const { t } = useTrans({
+  en: {
+    write_error: 'Your latest changes might not be saved. Please reload the page, and contact support if the problem persists.',
+    busy_warning: 'A save is still in progress — changes you make now may not be saved.',
+    refresh_text: 'Newer results are available.',
+    refresh_action: 'Refresh'
+  },
+  ja: {
+    write_error: '最新の変更が保存されていない可能性があります。ページを再読み込みし、問題が解決しない場合はサポートにお問い合わせください。',
+    busy_warning: '保存処理中です。ここでの変更は保存されない可能性があります。',
+    refresh_text: '新しい結果があります。',
+    refresh_action: '更新'
+  }
+})
+
+const snackbars = useSnackbars()
+
 const filterDialog = usePower()
 const viewDialog = usePower()
 
@@ -175,6 +194,12 @@ const conditionBlocksEl = ref<HTMLElement | null>(null)
 // after some data has been loaded once and then resulted in no data
 // due to user filtering.
 const hasInitialResults = ref(false)
+
+// A fresher server result fetched after the optimistic writes settled, awaiting
+// the user's explicit opt-in via the refresh button — never auto-applied (that
+// would momentarily revert the optimistic edits to stale data). Declared here
+// (ahead of the query handlers that clear it) so they can reference it.
+const latestState = ref<LensResult | null>(null)
 
 let prevFetchInput: LensQuery | null = null
 let prevFetchResult: LensResult | null = null
@@ -217,8 +242,10 @@ const perPage = ref(100)
 
 const lang = useLang()
 
-const { data: result, execute: refresh, loading } = useQuery(async (http) => {
-  const input = {
+// Build the search request from the catalog's current state. Shared by the
+// main search and the background reconcile fetch so both query identically.
+function buildSearchInput(): LensQuery {
+  return {
     entity: props.entity ?? '__no_entity__',
     select: withIndexField(_select.value),
     filters: createInputFilters(queryFilter.value, _filters.value),
@@ -227,6 +254,10 @@ const { data: result, execute: refresh, loading } = useQuery(async (http) => {
     page: page.value,
     perPage: perPage.value
   }
+}
+
+const { data: result, execute: refresh, loading } = useQuery(async (http) => {
+  const input = buildSearchInput()
 
   if (prevFetchInput && JSON.stringify(prevFetchInput) === JSON.stringify(input)) {
     return prevFetchResult!
@@ -243,9 +274,12 @@ const { data: result, execute: refresh, loading } = useQuery(async (http) => {
 const doRefresh = useDebounceFn(refresh, 50)
 
 if (props.urlSync) {
+  // Route URL-driven changes (back/forward, shared links) through `refetch` so
+  // they clear any stashed reconcile result, just like the in-app controls — a
+  // refresh button must never apply data fetched for a previous query.
   useCatalogUrlQuerySync(
     { query, filters: _filters, sort: _sort, page },
-    doRefresh
+    refetch
   )
 }
 
@@ -356,13 +390,16 @@ const tableSelect = computed(() => {
 // not a column the user picked). The corresponding column is also
 // hidden from the rendered table by `LensTable`.
 //
-// When the caller has no concrete select list, the index field is
-// *not* added either — leaving the request empty lets the server use
-// its own defaults. See `indexField` prop docs above.
+// Editable catalogs must carry a row identifier so updates / deletes can
+// address each row; when no `indexField` is configured the identifier
+// defaults to `id`. When the caller has no concrete select list, nothing
+// is added either — leaving the request empty lets the server use its own
+// defaults. See `indexField` prop docs above.
 function withIndexField(fields: string[]): string[] {
   if (fields.length === 0) { return [] }
-  if (!props.indexField || fields.includes(props.indexField)) { return [...fields] }
-  return [...fields, props.indexField]
+  const field = props.indexField ?? (props.editable ? 'id' : null)
+  if (!field || fields.includes(field)) { return [...fields] }
+  return [...fields, field]
 }
 
 function withoutIndexField(fields: string[]): string[] {
@@ -380,25 +417,35 @@ function createInputFilters(queryFilters: any[], filters: any[]) {
   ].filter((f) => f?.length > 0)
 }
 
-function onQuery(value: string | null) {
-  query.value = value
-  page.value = 1
+// Re-run the search for the new query state, dropping any stashed
+// reconcile result (the refreshed state supersedes it).
+function refetch(): void {
+  latestState.value = null
   doRefresh()
 }
 
+function onQuery(value: string | null) {
+  if (guardBusy()) { return }
+  query.value = value
+  page.value = 1
+  refetch()
+}
+
 function onFiltersUpdated(filters: any[]) {
+  if (guardBusy()) { return }
   _filters.value = filters
   page.value = 1
-  doRefresh()
+  refetch()
   filterDialog.off()
   emit('filters-updated', _filters.value)
 }
 
 function onInlineFilterUpdated(filter: any[]) {
+  if (guardBusy()) { return }
   const sameFilterIndex = _filters.value.findIndex((f) => f[0] === filter[0])
   sameFilterIndex === -1 ? applyNewFilter(filter) : replaceFilter(sameFilterIndex, filter)
   page.value = 1
-  doRefresh()
+  refetch()
   emit('filters-updated', _filters.value)
 }
 
@@ -424,34 +471,38 @@ function replaceFilter(index: number, filter: any[]) {
 }
 
 function onResetFilters() {
+  if (guardBusy()) { return }
   _filters.value = []
   query.value = null
   page.value = 1
-  doRefresh()
+  refetch()
   emit('filters-updated', _filters.value)
 }
 
 function onSortUpdated(sort: LensQuerySort) {
+  if (guardBusy()) { return }
   _sort.value = [sort]
   page.value = 1
-  doRefresh()
+  refetch()
   emit('sort-updated', _sort.value)
 }
 
 function onResetSorts() {
+  if (guardBusy()) { return }
   _sort.value = []
   page.value = 1
-  doRefresh()
+  refetch()
   emit('sort-updated', _sort.value)
 }
 
 function onViewUpdated(newSelect: string[], newSelectable: string[], overrides: Record<string, Partial<FieldData>>) {
+  if (guardBusy()) { return }
   // Treat updates from the view form as deliberate user intent: if the
   // user picked the index field on purpose, surface its column.
   _select.value = newSelect
   _selectable.value = newSelectable
   _overrides.value = overrides
-  doRefresh()
+  refetch()
   viewDialog.off()
   emit('select-updated', _select.value)
   emit('selectable-updated', _selectable.value)
@@ -467,13 +518,15 @@ function onResetSelection() {
 }
 
 function onPrev() {
+  if (guardBusy()) { return }
   page.value--
-  doRefresh()
+  refetch()
 }
 
 function onNext() {
+  if (guardBusy()) { return }
   page.value++
-  doRefresh()
+  refetch()
 }
 
 // Re-runs the current query against the endpoint, preserving the
@@ -487,6 +540,7 @@ async function refreshCatalog(): Promise<void> {
   // misses and a real request is issued instead of returning the stale
   // cached result.
   prevFetchInput = null
+  latestState.value = null
   await doRefresh()
 }
 
@@ -500,6 +554,28 @@ const sheet = usePower()
 const sheetMode = ref<'view' | 'create'>('view')
 const sheetRecord = ref<Record<string, any> | null>(null)
 
+// The slow target API can take a long time to sync a write, and a read during
+// that window returns stale (pre-write) data. So updates and deletes are
+// applied to the in-memory result immediately and persisted in the background;
+// the server is never re-read to reconcile until the write settles. While any
+// write is in flight the catalog is "busy": query controls and the refresh
+// affordance are locked and an unload guard is armed.
+const pendingWrites = ref(0)
+const reconciling = ref(false)
+const busy = computed(() => pendingWrites.value > 0 || reconciling.value)
+
+// Whether any write in the current in-flight batch failed; when so the reconcile
+// is skipped (the snackbar already told the user to reload).
+let batchErrored = false
+
+// Monotonic token for the in-flight `/show` request, so a slow detail fetch
+// that predates an edit (or a record switch) can't overwrite newer data.
+let showRequestSeq = 0
+
+// Monotonic token for the in-flight reconcile fetch, so a newer batch's
+// reconcile supersedes an older one still in flight.
+let reconcileToken = 0
+
 // Resolve a record's identifier, unwrapping the id field's object shape
 // (`{ value, display, path }`) when present.
 function resolveId(record: Record<string, any>): any {
@@ -508,14 +584,14 @@ function resolveId(record: Record<string, any>): any {
 }
 
 const { execute: executeUpdate } = useMutation((http, id: any, values: Record<string, any>) =>
-  http.post<LensResult & { data: Record<string, any> }>(`${endpointBase.value}/update`, {
-    entity: props.entity, id, values
+  http.post(`${endpointBase.value}/update`, {
+    entity: props.entity, id, values, settings: { lang }
   })
 )
 
 const { execute: executeCreate } = useMutation((http, values: Record<string, any>) =>
   http.post<LensResult & { data: Record<string, any> }>(`${endpointBase.value}/create`, {
-    entity: props.entity, values
+    entity: props.entity, values, settings: { lang }
   })
 )
 
@@ -528,52 +604,144 @@ const { execute: executeDelete } = useMutation((http, id: any) =>
 // catalog doesn't render as columns (e.g. long-form descriptions).
 const { execute: executeShow } = useMutation((http, id: any) =>
   http.post<LensResult & { data: Record<string, any> }>(`${endpointBase.value}/show`, {
-    entity: props.entity, id
+    entity: props.entity, id, settings: { lang }
   })
 )
 
-async function save(record: Record<string, any>, values: Record<string, any>): Promise<void> {
-  const res = await executeUpdate(resolveId(record), values)
-  // Patch the row in place so the table and sheet reflect the server's
-  // re-serialized values without a full refetch.
-  Object.assign(record, res.data)
+// Re-run the search without touching the displayed state. Used by the
+// background reconcile so its result can be stashed behind the refresh button
+// rather than replacing the optimistic view.
+const { execute: executeReconcile } = useMutation((http, input: LensQuery) =>
+  http.post<LensResult>(props.endpoint, input)
+)
+
+function guardBusy(): boolean {
+  if (busy.value) {
+    snackbars.push({ mode: 'warning', text: t.busy_warning })
+    return true
+  }
+  return false
 }
 
+// Value-level comparison (rows in order + total) — decides whether a reconcile
+// actually surfaced anything newer than the optimistic state on screen.
+function isSameResult(a: LensResult | null, b: LensResult | null): boolean {
+  if (!a || !b) { return a === b }
+  return a.pagination.total === b.pagination.total
+    && JSON.stringify(a.data) === JSON.stringify(b.data)
+}
+
+// After the last in-flight write settles, fetch the canonical state for the
+// current query and, only if it differs from what's shown, stash it behind the
+// refresh button. The server is fresh by now (the write completed).
+async function reconcile(): Promise<void> {
+  const token = ++reconcileToken
+  reconciling.value = true
+  try {
+    const fresh = await executeReconcile(buildSearchInput())
+    // Drop the result if a newer write batch already kicked off its own
+    // reconcile while this one was in flight.
+    if (token !== reconcileToken) {
+      return
+    }
+    if (result.value && !isSameResult(fresh, result.value)) {
+      latestState.value = fresh
+    }
+  } catch {
+    // Ignore — keep the optimistic state, offer no refresh.
+  } finally {
+    if (token === reconcileToken) {
+      reconciling.value = false
+    }
+  }
+}
+
+function applyLatest(): void {
+  if (!latestState.value) { return }
+  result.value = latestState.value
+  latestState.value = null
+  prevFetchInput = null
+}
+
+// Track an optimistic background write: count it as pending, surface a snackbar
+// on failure, and once the whole batch settles (with no failures) reconcile.
+function trackWrite(run: () => Promise<unknown>): void {
+  pendingWrites.value++
+  run()
+    .catch(() => {
+      batchErrored = true
+      snackbars.push({ mode: 'danger', text: t.write_error })
+    })
+    .finally(() => {
+      pendingWrites.value--
+      if (pendingWrites.value === 0) {
+        const errored = batchErrored
+        batchErrored = false
+        if (!errored) {
+          reconcile()
+        }
+      }
+    })
+}
+
+// Update — optimistic. Reflect the change in memory immediately (the catalog
+// row and the open sheet share this object), then persist in the background.
+function save(record: Record<string, any>, values: Record<string, any>): void {
+  // A pending `/show` for this record predates the edit; invalidate it so it
+  // can't overwrite the optimistic value when it lands.
+  if (sheetRecord.value === record) {
+    showRequestSeq++
+  }
+  Object.assign(record, values)
+  trackWrite(() => executeUpdate(resolveId(record), values))
+}
+
+// Create — blocking. The slow POST runs to completion, then the catalog is
+// refreshed with the now-synced canonical state (preserving the active query).
+// The create sheet shows a button spinner meanwhile.
 async function create(values: Record<string, any>): Promise<Record<string, any>> {
   const res = await executeCreate(values)
-  if (result.value?.data) {
-    result.value.data.unshift(res.data)
-  }
-  if (result.value?.pagination) {
-    result.value.pagination.total++
+  await refreshCatalog()
+  if (!hasInitialResults.value && (result.value?.data.length ?? 0) > 0) {
+    hasInitialResults.value = true
   }
   return res.data
 }
 
-async function remove(record: Record<string, any>): Promise<void> {
+// Delete — optimistic. Remove from the UI immediately, persist in the
+// background.
+function remove(record: Record<string, any>): void {
   const id = resolveId(record)
-  await executeDelete(id)
   if (result.value?.data) {
     const index = result.value.data.findIndex((r) => resolveId(r) === id)
     if (index !== -1) {
       result.value.data.splice(index, 1)
+      // Only adjust the total when a row was actually removed from the current
+      // page, so a not-found delete can't drift the count below the rows shown.
+      if (result.value.pagination) {
+        result.value.pagination.total--
+      }
     }
   }
-  if (result.value?.pagination) {
-    result.value.pagination.total--
-  }
+  trackWrite(() => executeDelete(id))
 }
 
 async function openSheet(record: Record<string, any>): Promise<void> {
   sheetRecord.value = record
   sheetMode.value = 'view'
   sheet.on()
-  // Pull the full record so detail-only fields (not selected as columns)
-  // are populated and editable in the sheet. Patch the row in place so the
-  // values persist on the shared record object. Failures are non-fatal: the
-  // sheet falls back to the fields already present on the row.
+  const seq = ++showRequestSeq
+  // Pull the full record so detail-only fields (not selected as columns) are
+  // populated and editable in the sheet. Failures are non-fatal: the sheet
+  // falls back to the columns already on the row.
   try {
     const res = await executeShow(resolveId(record))
+    // Drop the response if it has been superseded — by a record switch, the
+    // create form, or an edit to this record (which bumps the token) — so a
+    // stale detail fetch can't overwrite newer optimistic data.
+    if (seq !== showRequestSeq || sheetRecord.value !== record) {
+      return
+    }
     Object.assign(record, res.data)
   } catch {
     // Ignore — keep showing the columns the catalog already fetched.
@@ -581,14 +749,22 @@ async function openSheet(record: Record<string, any>): Promise<void> {
 }
 
 function openCreate(): void {
+  // `creatable` is the prop that enables creation. Honor it here even though
+  // this method is exposed (and provided to children).
+  if (!props.creatable) {
+    return
+  }
   sheetRecord.value = null
   sheetMode.value = 'create'
   sheet.on()
 }
 
 provideLensEdit({
-  editable: !!props.editable,
-  creatable: !!props.creatable,
+  // Getters so the injected context tracks prop changes after mount (e.g.
+  // permissions resolving async, or a flag toggling `editable` off): LensTable
+  // gates inline editing and the id-cell sheet on `edit.editable`.
+  get editable() { return !!props.editable },
+  get creatable() { return !!props.creatable },
   entity: props.entity ?? '',
   indexField: props.indexField ?? 'id',
   resolveId,
@@ -598,6 +774,18 @@ provideLensEdit({
   openSheet,
   openCreate
 })
+
+// Warn the user (native prompt) if they try to leave while a write is still
+// syncing, since that change might not have been persisted yet.
+function onBeforeUnload(event: BeforeUnloadEvent): void {
+  if (pendingWrites.value > 0) {
+    event.preventDefault()
+    event.returnValue = ''
+  }
+}
+
+onMounted(() => window.addEventListener('beforeunload', onBeforeUnload))
+onBeforeUnmount(() => window.removeEventListener('beforeunload', onBeforeUnload))
 
 defineExpose({
   refresh: refreshCatalog,
@@ -641,6 +829,7 @@ defineExpose({
     <div v-else class="container">
       <LensCatalogControl
         v-if="result"
+        :class="{ 'is-busy': busy }"
         :query
         :query-ph
         :filter-presets
@@ -674,7 +863,7 @@ defineExpose({
         </template>
       </LensCatalogControl>
       <div v-else class="control-skeleton" />
-      <div v-if="!hideConditions && result && (_filters.length > 0 || _sort.length > 0)" ref="conditionBlocksEl" class="condition-blocks">
+      <div v-if="!hideConditions && result && (_filters.length > 0 || _sort.length > 0)" ref="conditionBlocksEl" class="condition-blocks" :class="{ 'is-busy': busy }">
         <template v-if="_filters.length > 0">
           <SDivider />
           <LensCatalogStateFilter
@@ -693,6 +882,10 @@ defineExpose({
         </template>
       </div>
       <SDivider />
+      <div v-if="latestState && !busy" class="refresh-banner">
+        <span class="refresh-banner-text">{{ t.refresh_text }}</span>
+        <SButton size="mini" mode="info" :label="t.refresh_action" @click="applyLatest" />
+      </div>
       <div class="list" :style="tableMaxHeight">
         <LensTable
           :result
@@ -710,6 +903,7 @@ defineExpose({
         />
         <LensCatalogFooter
           v-if="result && result?.pagination.total > 0"
+          :class="{ 'is-busy': busy }"
           :result
           :loading
           @prev="onPrev"
@@ -794,6 +988,29 @@ defineExpose({
   flex-direction: column;
   flex-grow: 1;
   min-height: 100%;
+}
+
+/* While a background write is syncing, lock the query controls so the user
+   can't change filters/sort/page (a refetch then would be stale and would
+   drop the optimistic edits). Editing the rows stays available. */
+.is-busy {
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.refresh-banner {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--c-gutter);
+  background-color: var(--c-bg-2);
+}
+
+.refresh-banner-text {
+  font-size: 13px;
+  color: var(--c-text-2);
 }
 
 .list {

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -588,6 +588,11 @@ const pendingWrites = ref(0)
 const reconciling = ref(false)
 const busy = computed(() => pendingWrites.value > 0 || reconciling.value)
 
+// Whether a (blocking) create POST is in flight. Not part of `busy` — the
+// create sheet covers the controls — but it arms the unload guard, since the
+// create write is just as slow and shouldn't be lost to a tab close/reload.
+const creating = ref(false)
+
 // Whether any write in the current in-flight batch failed; when so the reconcile
 // is skipped (the snackbar already told the user to reload).
 let batchErrored = false
@@ -768,32 +773,48 @@ function save(record: Record<string, any>, values: Record<string, any>): void {
 // Create — blocking. The slow POST runs to completion, then the catalog is
 // refreshed with the now-synced canonical state (preserving the active query).
 // The create sheet shows a button spinner meanwhile.
+function prependCreated(data: Record<string, any>): void {
+  if (result.value?.data) {
+    result.value.data.unshift(data)
+  }
+  if (result.value?.pagination) {
+    result.value.pagination.total++
+  }
+}
+
 async function create(values: Record<string, any>): Promise<Record<string, any>> {
-  const res = await executeCreate(values)
-  if (pendingWrites.value > 0) {
-    // Other optimistic writes are still syncing; a refetch now would read the
-    // backend before they're visible and clobber those rows. Prepend the new
-    // record optimistically instead — the pending writes' reconcile refreshes
-    // the full list (via the refresh banner) once they settle.
-    if (result.value?.data) {
-      result.value.data.unshift(res.data)
+  creating.value = true
+  try {
+    const res = await executeCreate(values)
+    // The POST succeeded — the record exists. From here a refresh failure must
+    // not reject (the caller would treat the create as failed and re-submit a
+    // duplicate); fall back to showing the new record optimistically.
+    if (pendingWrites.value > 0) {
+      // Other optimistic writes are still syncing; a refetch now would read the
+      // backend before they're visible and clobber those rows. Prepend the new
+      // record optimistically — the pending writes' reconcile refreshes the
+      // full list (via the refresh banner) once they settle.
+      prependCreated(res.data)
+    } else {
+      // A write batch may have settled during the (slow) POST and kicked off a
+      // reconcile; invalidate it (token bump + busy-flag reset, mirroring
+      // trackWrite) so its possibly-pre-create snapshot can't land behind the
+      // refresh banner after this fresh refetch.
+      reconcileToken++
+      reconciling.value = false
+      try {
+        await refreshCatalog()
+      } catch {
+        prependCreated(res.data)
+      }
     }
-    if (result.value?.pagination) {
-      result.value.pagination.total++
+    if (!hasInitialResults.value && (result.value?.data.length ?? 0) > 0) {
+      hasInitialResults.value = true
     }
-  } else {
-    // A write batch may have settled during the (slow) POST and kicked off a
-    // reconcile; invalidate it (token bump + busy-flag reset, mirroring
-    // trackWrite) so its possibly-pre-create snapshot can't land behind the
-    // refresh banner after this fresh refetch.
-    reconcileToken++
-    reconciling.value = false
-    await refreshCatalog()
+    return res.data
+  } finally {
+    creating.value = false
   }
-  if (!hasInitialResults.value && (result.value?.data.length ?? 0) > 0) {
-    hasInitialResults.value = true
-  }
-  return res.data
 }
 
 // Delete — optimistic. Remove from the UI immediately, persist in the
@@ -894,7 +915,7 @@ provideLensEdit({
 // Warn the user (native prompt) if they try to leave while a write is still
 // syncing, since that change might not have been persisted yet.
 function onBeforeUnload(event: BeforeUnloadEvent): void {
-  if (pendingWrites.value > 0) {
+  if (pendingWrites.value > 0 || creating.value) {
     event.preventDefault()
     event.returnValue = ''
   }

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -592,6 +592,16 @@ const busy = computed(() => pendingWrites.value > 0 || reconciling.value)
 // is skipped (the snackbar already told the user to reload).
 let batchErrored = false
 
+// In-flight write chains keyed by record+field, so repeated writes to the same
+// cell are serialized (sent in edit order — the last edit wins — even though
+// the UI already shows the latest value optimistically). Writes to different
+// cells run concurrently; the backend persists only the changed columns.
+const writeChains = new Map<string, Promise<unknown>>()
+
+// Count of in-flight writes per record id, so `/show` for a record that's
+// mid-write can avoid overwriting its optimistic values with stale data.
+const pendingByRecord = new Map<any, number>()
+
 // Monotonic token for the in-flight `openSheet` `/show` request, so a newer
 // open (another row, or the create form) supersedes an older one and the stale
 // detail fetch doesn't open over it when it resolves.
@@ -691,17 +701,46 @@ function applyLatest(): void {
 
 // Track an optimistic background write: count it as pending, surface a snackbar
 // on failure, and once the whole batch settles (with no failures) reconcile.
-function trackWrite(run: () => Promise<unknown>): void {
-  // A new write changes the displayed state, so any stashed reconcile result is
-  // now potentially stale; clear it (the post-batch reconcile re-derives it).
+function hasPendingWrite(recordId: any): boolean {
+  return pendingByRecord.has(recordId)
+}
+
+// Track an optimistic background write for `recordId`, serialized per `key` so
+// writes to the same cell reach the server in edit order.
+function trackWrite(recordId: any, key: string, run: () => Promise<unknown>): void {
+  // A new write changes the displayed state. Clear any stashed reconcile result
+  // and invalidate an in-flight reconcile (advance the token so its result is
+  // dropped; clear its busy flag — `pendingWrites` keeps us busy), so neither
+  // can later repopulate the refresh banner with pre-edit data. The post-batch
+  // reconcile re-derives it.
   latestState.value = null
+  reconcileToken++
+  reconciling.value = false
   pendingWrites.value++
-  run()
+  pendingByRecord.set(recordId, (pendingByRecord.get(recordId) ?? 0) + 1)
+
+  // Chain after any in-flight write for the same cell so the requests reach the
+  // server in order (a prior failure must not block the next write).
+  const prev = writeChains.get(key) ?? Promise.resolve()
+  const current = prev.catch(() => {}).then(run)
+  writeChains.set(key, current)
+
+  current
     .catch(() => {
       batchErrored = true
       snackbars.push({ mode: 'danger', text: t.write_error })
     })
     .finally(() => {
+      // Only drop the chain entry if a newer write hasn't replaced it.
+      if (writeChains.get(key) === current) {
+        writeChains.delete(key)
+      }
+      const remaining = (pendingByRecord.get(recordId) ?? 1) - 1
+      if (remaining > 0) {
+        pendingByRecord.set(recordId, remaining)
+      } else {
+        pendingByRecord.delete(recordId)
+      }
       pendingWrites.value--
       if (pendingWrites.value === 0) {
         const errored = batchErrored
@@ -716,8 +755,14 @@ function trackWrite(run: () => Promise<unknown>): void {
 // Update — optimistic. Reflect the change in memory immediately (the catalog
 // row and the open sheet share this object), then persist in the background.
 function save(record: Record<string, any>, values: Record<string, any>): void {
+  const id = resolveId(record)
   Object.assign(record, values)
-  trackWrite(() => executeUpdate(resolveId(record), values))
+  // Serialize per record+field so two quick edits to the same cell apply in
+  // order; edits to different fields run concurrently. Assumes callers save a
+  // single field (or disjoint field sets) — overlapping multi-field saves would
+  // share a column without ordering and need a coarser (per-record) key.
+  const key = `${id}:${Object.keys(values).sort().join(',')}`
+  trackWrite(id, key, () => executeUpdate(id, values))
 }
 
 // Create — blocking. The slow POST runs to completion, then the catalog is
@@ -725,7 +770,26 @@ function save(record: Record<string, any>, values: Record<string, any>): void {
 // The create sheet shows a button spinner meanwhile.
 async function create(values: Record<string, any>): Promise<Record<string, any>> {
   const res = await executeCreate(values)
-  await refreshCatalog()
+  if (pendingWrites.value > 0) {
+    // Other optimistic writes are still syncing; a refetch now would read the
+    // backend before they're visible and clobber those rows. Prepend the new
+    // record optimistically instead — the pending writes' reconcile refreshes
+    // the full list (via the refresh banner) once they settle.
+    if (result.value?.data) {
+      result.value.data.unshift(res.data)
+    }
+    if (result.value?.pagination) {
+      result.value.pagination.total++
+    }
+  } else {
+    // A write batch may have settled during the (slow) POST and kicked off a
+    // reconcile; invalidate it (token bump + busy-flag reset, mirroring
+    // trackWrite) so its possibly-pre-create snapshot can't land behind the
+    // refresh banner after this fresh refetch.
+    reconcileToken++
+    reconciling.value = false
+    await refreshCatalog()
+  }
   if (!hasInitialResults.value && (result.value?.data.length ?? 0) > 0) {
     hasInitialResults.value = true
   }
@@ -747,7 +811,7 @@ function remove(record: Record<string, any>): void {
       }
     }
   }
-  trackWrite(() => executeDelete(id))
+  trackWrite(id, `${id}:__delete__`, () => executeDelete(id))
 }
 
 async function openSheet(record: Record<string, any>): Promise<void> {
@@ -755,16 +819,32 @@ async function openSheet(record: Record<string, any>): Promise<void> {
   // the id cell again), then load the full record (detail-only fields not
   // selected as columns) and render it. A newer open (another row, or the
   // create form) supersedes this one via the token.
+  const id = resolveId(record)
   sheetRecord.value = record
   sheetMode.value = 'view'
   sheetLoading.value = true
   sheetError.value = false
   sheet.on()
   const seq = ++showRequestSeq
+  // Snapshot whether the record had a write in flight when `/show` is issued:
+  // the read can return pre-sync data, so even if the write finishes before
+  // `/show` resolves we must not overwrite the optimistic value.
+  const pendingAtIssue = hasPendingWrite(id)
   try {
-    const res = await executeShow(resolveId(record))
+    const res = await executeShow(id)
     if (seq === showRequestSeq) {
-      Object.assign(record, res.data)
+      if (pendingAtIssue || hasPendingWrite(id)) {
+        // The record had/has an in-flight write, so `/show` may have read the
+        // backend before it synced. Don't overwrite the optimistic values
+        // already on the row; only fill in detail-only fields not yet present.
+        for (const k of Object.keys(res.data)) {
+          if (!(k in record)) {
+            record[k] = res.data[k]
+          }
+        }
+      } else {
+        Object.assign(record, res.data)
+      }
     }
   } catch {
     // Detail load failed: surface an error in the sheet rather than render a

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -275,11 +275,17 @@ const perPage = ref(100)
 
 const lang = useLang()
 
+// The entity name sent on every request. Falls back to the `__no_entity__`
+// sentinel when the prop is omitted, so the search and the CRUD/detail calls
+// target the same entity — otherwise the search would use the fallback while an
+// omitted-entity CRUD payload would serialize `undefined` away and hit no entity.
+const entityName = computed(() => props.entity ?? '__no_entity__')
+
 // Build the search request from the catalog's current state. Shared by the
 // main search and the background reconcile fetch so both query identically.
 function buildSearchInput(): LensQuery {
   return {
-    entity: props.entity ?? '__no_entity__',
+    entity: entityName.value,
     select: withIndexField(_select.value),
     filters: createInputFilters(queryFilter.value, _filters.value),
     sort: _sort.value.length > 0 ? _sort.value : defaultSort.value ?? [],
@@ -678,18 +684,18 @@ function resolveId(record: Record<string, any>): any {
 
 const { execute: executeUpdate } = useMutation((http, id: any, values: Record<string, any>) =>
   http.post(`${endpointBase.value}/update`, {
-    entity: props.entity, id, values, settings: { lang }
+    entity: entityName.value, id, values, settings: { lang }
   })
 )
 
 const { execute: executeCreate } = useMutation((http, values: Record<string, any>) =>
   http.post<LensResult & { data: Record<string, any> }>(`${endpointBase.value}/create`, {
-    entity: props.entity, values, settings: { lang }
+    entity: entityName.value, values, settings: { lang }
   })
 )
 
 const { execute: executeDelete } = useMutation((http, id: any) =>
-  http.post(`${endpointBase.value}/delete`, { entity: props.entity, id })
+  http.post(`${endpointBase.value}/delete`, { entity: entityName.value, id })
 )
 
 // Resolve a single record's full detail (every index/detail field, not just
@@ -697,7 +703,7 @@ const { execute: executeDelete } = useMutation((http, id: any) =>
 // catalog doesn't render as columns (e.g. long-form descriptions).
 const { execute: executeShow } = useMutation((http, id: any) =>
   http.post<LensResult & { data: Record<string, any> }>(`${endpointBase.value}/show`, {
-    entity: props.entity, id, settings: { lang }
+    entity: entityName.value, id, settings: { lang }
   })
 )
 

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -133,6 +133,12 @@ export interface Props {
   // `openCreate()` method / sheet create mode become available. The CRUD
   // endpoints are derived from `endpoint` by replacing the trailing
   // `/search` with `/update`, `/create`, and `/delete`.
+  //
+  // The row identifier (`indexField`, defaulting to `id`) is never
+  // inline- or sheet-editable on an existing row: optimistically changing
+  // a row's id before the slow write settles would re-key the row, so a
+  // follow-up save/delete would address the not-yet-synced new id. It can
+  // still be set on creation (via a `showOnCreate` field).
   editable?: boolean
 
   // Whether new records can be created (enables create mode in the sheet
@@ -648,12 +654,26 @@ function guardBusy(): boolean {
   return false
 }
 
-// Value-level comparison (rows in order + total) — decides whether a reconcile
-// actually surfaced anything newer than the optimistic state on screen.
-function isSameResult(a: LensResult | null, b: LensResult | null): boolean {
-  if (!a || !b) { return a === b }
-  return a.pagination.total === b.pagination.total
-    && JSON.stringify(a.data) === JSON.stringify(b.data)
+// Value-level comparison (rows in order + total) deciding whether a reconcile
+// surfaced anything newer than the optimistic state on screen. `fresh` is the
+// canonical search-shaped result; `shown` is what's displayed, which may carry
+// extra detail-only keys an opened sheet merged in via `/show`. Compare only the
+// keys `fresh` actually has, so that detail-key asymmetry doesn't raise a
+// spurious refresh banner — only genuine changes to the table's own fields count.
+function isSameResult(fresh: LensResult | null, shown: LensResult | null): boolean {
+  if (!fresh || !shown) { return fresh === shown }
+  if (fresh.pagination.total !== shown.pagination.total) { return false }
+  if (fresh.data.length !== shown.data.length) { return false }
+  for (let i = 0; i < fresh.data.length; i++) {
+    const freshRow = fresh.data[i]
+    const shownRow = shown.data[i]
+    for (const key of Object.keys(freshRow)) {
+      if (JSON.stringify(freshRow[key]) !== JSON.stringify(shownRow?.[key])) {
+        return false
+      }
+    }
+  }
+  return true
 }
 
 // After the last in-flight write settles, fetch the canonical state for the
@@ -684,9 +704,30 @@ async function reconcile(): Promise<void> {
 
 function applyLatest(): void {
   if (!latestState.value) { return }
-  result.value = latestState.value
+  const fresh = latestState.value
+  result.value = fresh
   latestState.value = null
   prevFetchInput = null
+  // The table now holds fresh row objects. If a record sheet is open, its
+  // `sheetRecord` still points at the old (replaced) object, so further sheet
+  // edits would mutate an orphan that no longer reflects in the table. Rebind to
+  // the matching fresh row — carrying over any detail-only fields already loaded
+  // via `/show` (the search result omits them) so the sheet keeps showing them —
+  // or close the sheet if the row is no longer present in the fresh results.
+  if (sheet.state.value && sheetMode.value === 'view' && sheetRecord.value) {
+    const id = resolveId(sheetRecord.value)
+    const match = fresh.data.find((r) => resolveId(r) === id)
+    if (match) {
+      for (const key of Object.keys(sheetRecord.value)) {
+        if (!(key in match)) {
+          match[key] = sheetRecord.value[key]
+        }
+      }
+      sheetRecord.value = match
+    } else {
+      sheet.off()
+    }
+  }
 }
 
 // Re-runs the current query against the endpoint, preserving the catalog's
@@ -694,14 +735,15 @@ function applyLatest(): void {
 // reflect server-side changes — e.g. after a bulk action mutates rows —
 // without remounting the component.
 async function refreshCatalog(): Promise<void> {
-  // While a background write is still syncing, a forced refetch would read
-  // stale (pre-write) data from the slow API and clobber the optimistic edits.
-  // Route through the reconcile flow instead, so any newer server state lands
-  // behind the refresh banner once the writes settle rather than overwriting
-  // the screen. This gives the exposed `refresh` the same guarantee the in-app
-  // controls have: a refresh never drops an in-flight optimistic edit.
+  // While a write batch is still settling (or its reconcile is in flight), a
+  // read now could return stale pre-write data, so don't refetch or stash
+  // anything behind the refresh banner: a stale stash could outlive a failed
+  // write (whose post-batch reconcile is skipped) — or a failed reconcile — and
+  // then roll the table back to pre-edit data when the banner is clicked. The
+  // post-batch reconcile already refetches the canonical state for the current
+  // query once the batch settles cleanly, which also reflects any server-side
+  // change a caller wanted surfaced; defer to it rather than reading now.
   if (busy.value) {
-    await reconcile()
     return
   }
   // A refresh is requested precisely when server-side data may have changed

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -2,19 +2,21 @@
 import { useDebounceFn, useElementSize } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 import SDivider from '../../../components/SDivider.vue'
-import { useQuery } from '../../../composables/Api'
+import { useMutation, useQuery } from '../../../composables/Api'
 import { useLang } from '../../../composables/Lang'
 import { usePower } from '../../../composables/Power'
 import { type FieldData } from '../FieldData'
 import { type LensQuery, type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
 import { useCatalogUrlQuerySync } from '../composables/CatalogUrlQuerySync'
+import { provideLensEdit } from '../composables/LensEdit'
 import LensCatalogControl, { type FilterPresets } from './LensCatalogControl.vue'
 import LensCatalogFooter from './LensCatalogFooter.vue'
 import LensCatalogStateFilter from './LensCatalogStateFilter.vue'
 import LensCatalogStateSort from './LensCatalogStateSort.vue'
 import LensFormFilter from './LensFormFilter.vue'
 import LensFormView from './LensFormView.vue'
+import LensSheet from './LensSheet.vue'
 import LensTable from './LensTable.vue'
 
 export interface Props {
@@ -122,6 +124,21 @@ export interface Props {
   // catalog per page may enable this option. The option is read once on
   // setup, so toggling it afterwards has no effect.
   urlSync?: boolean
+
+  // Enable CRUD editing for the catalog. When set, fields the backend
+  // marks `showOnUpdate` become inline-editable, clicking a row's id cell
+  // opens the record sheet (view + per-field edit + delete), and the
+  // `openCreate()` method / sheet create mode become available. The CRUD
+  // endpoints are derived from `endpoint` by replacing the trailing
+  // `/search` with `/update`, `/create`, and `/delete`.
+  editable?: boolean
+
+  // Whether new records can be created (enables create mode in the sheet
+  // and the exposed `openCreate()` method). Requires `editable`.
+  creatable?: boolean
+
+  // Width of the record sheet (any valid CSS width). Defaults to `480px`.
+  sheetWidth?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -468,8 +485,123 @@ async function refreshCatalog(): Promise<void> {
   await doRefresh()
 }
 
+// --- CRUD editing ----------------------------------------------------------
+
+// Derive the CRUD endpoints from the (search) endpoint, e.g.
+// `/api/admin/lens/search` -> `/api/admin/lens/{update,create,delete}`.
+const endpointBase = computed(() => props.endpoint.replace(/\/search$/, ''))
+
+const sheet = usePower()
+const sheetMode = ref<'view' | 'create'>('view')
+const sheetRecord = ref<Record<string, any> | null>(null)
+
+// Resolve a record's identifier, unwrapping the id field's object shape
+// (`{ value, display, path }`) when present.
+function resolveId(record: Record<string, any>): any {
+  const v = record?.[props.indexField ?? 'id']
+  return v !== null && typeof v === 'object' ? v.value : v
+}
+
+const { execute: executeUpdate } = useMutation((http, id: any, values: Record<string, any>) =>
+  http.post<LensResult & { data: Record<string, any> }>(`${endpointBase.value}/update`, {
+    entity: props.entity, id, values
+  })
+)
+
+const { execute: executeCreate } = useMutation((http, values: Record<string, any>) =>
+  http.post<LensResult & { data: Record<string, any> }>(`${endpointBase.value}/create`, {
+    entity: props.entity, values
+  })
+)
+
+const { execute: executeDelete } = useMutation((http, id: any) =>
+  http.post(`${endpointBase.value}/delete`, { entity: props.entity, id })
+)
+
+// Resolve a single record's full detail (every index/detail field, not just
+// the columns in `select`). This lets the sheet show — and edit — fields the
+// catalog doesn't render as columns (e.g. long-form descriptions).
+const { execute: executeShow } = useMutation((http, id: any) =>
+  http.post<LensResult & { data: Record<string, any> }>(`${endpointBase.value}/show`, {
+    entity: props.entity, id
+  })
+)
+
+async function save(record: Record<string, any>, values: Record<string, any>): Promise<void> {
+  const res = await executeUpdate(resolveId(record), values)
+  // Patch the row in place so the table and sheet reflect the server's
+  // re-serialized values without a full refetch.
+  Object.assign(record, res.data)
+}
+
+async function create(values: Record<string, any>): Promise<Record<string, any>> {
+  const res = await executeCreate(values)
+  if (result.value?.data) {
+    result.value.data.unshift(res.data)
+  }
+  if (result.value?.pagination) {
+    result.value.pagination.total++
+  }
+  return res.data
+}
+
+async function remove(record: Record<string, any>): Promise<void> {
+  const id = resolveId(record)
+  await executeDelete(id)
+  if (result.value?.data) {
+    const index = result.value.data.findIndex((r) => resolveId(r) === id)
+    if (index !== -1) {
+      result.value.data.splice(index, 1)
+    }
+  }
+  if (result.value?.pagination) {
+    result.value.pagination.total--
+  }
+}
+
+async function openSheet(record: Record<string, any>): Promise<void> {
+  sheetRecord.value = record
+  sheetMode.value = 'view'
+  sheet.on()
+  // Pull the full record so detail-only fields (not selected as columns)
+  // are populated and editable in the sheet. Patch the row in place so the
+  // values persist on the shared record object. Failures are non-fatal: the
+  // sheet falls back to the fields already present on the row.
+  try {
+    const res = await executeShow(resolveId(record))
+    Object.assign(record, res.data)
+  } catch {
+    // Ignore — keep showing the columns the catalog already fetched.
+  }
+}
+
+function openCreate(): void {
+  sheetRecord.value = null
+  sheetMode.value = 'create'
+  sheet.on()
+}
+
+provideLensEdit({
+  editable: !!props.editable,
+  creatable: !!props.creatable,
+  entity: props.entity ?? '',
+  indexField: props.indexField ?? 'id',
+  resolveId,
+  save,
+  create,
+  remove,
+  openSheet,
+  openCreate
+})
+
 defineExpose({
   refresh: refreshCatalog,
+
+  /**
+   * Open the record sheet in create mode. Exposed so a page's "New …"
+   * button can trigger creation through the unified sheet.
+   */
+  openCreate,
 
   /**
    * Retrieve the current records in the catalog. This method is required when
@@ -602,6 +734,25 @@ defineExpose({
         @apply="onViewUpdated"
       />
     </SModal>
+
+    <LensSheet
+      v-if="editable && result?.fields"
+      :open="sheet.state.value"
+      :mode="sheetMode"
+      :entity="entity ?? ''"
+      :record="sheetRecord"
+      :fields="result.fields"
+      :index-field="indexField ?? 'id'"
+      :width="sheetWidth"
+      @close="sheet.off"
+    >
+      <template v-if="$slots['sheet-before']" #before="s">
+        <slot name="sheet-before" v-bind="s" />
+      </template>
+      <template v-if="$slots['sheet-after']" #after="s">
+        <slot name="sheet-after" v-bind="s" />
+      </template>
+    </LensSheet>
   </div>
 </template>
 

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -458,13 +458,6 @@ const tableSelect = computed(() => {
   return withoutIndexField(result.value?.query.select ?? [])
 })
 
-// The row-identifier the table uses as its selection key. An explicit
-// `indexField`, or `id` for editable catalogs (which always carry it). Without
-// this, an editable catalog that relies on the default would leave the table on
-// positional selection keys, so an optimistic create/delete that shifts rows
-// would leave `selected` pointing at the wrong records. Mirrors `edit.indexField`.
-const tableIndexField = computed(() => props.indexField ?? (props.editable ? 'id' : undefined))
-
 // Whether the currently loaded rows actually carry the effective row identifier.
 // Editing / opening a row needs it (`resolveId`), but rows fetched while
 // `editable` was still false — or before an `indexField` change settled — won't
@@ -475,6 +468,24 @@ const rowsCarryIndexField = computed(() => {
   const rows = result.value?.data
   if (!rows || rows.length === 0) { return true }
   return (props.indexField ?? 'id') in rows[0]
+})
+
+// The row-identifier the table uses as its selection key. An explicit
+// `indexField`, or `id` for editable catalogs (which always carry it). Without
+// this, an editable catalog that relies on the default would leave the table on
+// positional selection keys, so an optimistic create/delete that shifts rows
+// would leave `selected` pointing at the wrong records. Mirrors `edit.indexField`.
+//
+// Gated on `rowsCarryIndexField`: when `editable` flips true (or `indexField`
+// changes) the on-screen rows don't carry the new key until the triggered refetch
+// lands. Switching STable onto it during that window keys every row's selection to
+// `undefined` — wiping the current selection and making any row-select emit
+// `[undefined]` (so parent bulk actions act on no/wrong records). Stay on the
+// previous positional key until the loaded rows carry it, matching the
+// `edit.editable` gate so selection and editing flip together.
+const tableIndexField = computed(() => {
+  const field = props.indexField ?? (props.editable ? 'id' : undefined)
+  return field && rowsCarryIndexField.value ? field : undefined
 })
 
 // The `indexField` is appended to the request `select` so the server
@@ -860,6 +871,12 @@ watch(
   (field, prev) => {
     if (!field || field === prev) { return }
     if (sheet.state.value && sheetMode.value === 'view') { sheet.off() }
+    // Supersede any search still in flight under the previous identifier state: it
+    // was issued before the new id/index field, so its rows won't carry the new
+    // key. If it resolved after this refetch it would assign those id-less rows
+    // back into `result`, flipping `rowsCarryIndexField` (and editing) off again
+    // with no watcher to recover. Bumping the token makes the fetcher drop it.
+    searchToken++
     refetch()
   }
 )

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -139,6 +139,12 @@ export interface Props {
   // a row's id before the slow write settles would re-key the row, so a
   // follow-up save/delete would address the not-yet-synced new id. It can
   // still be set on creation (via a `showOnCreate` field).
+  //
+  // An editable catalog must keep its index field among the rendered columns
+  // (i.e. include it in `select`, or leave `select` empty to use server
+  // defaults): the row's sheet opener — and therefore the only way to view or
+  // delete a record — is the index-field cell, so hiding that column leaves the
+  // rows with no opener.
   editable?: boolean
 
   // Whether new records can be created (enables create mode in the sheet
@@ -1057,7 +1063,11 @@ provideLensEdit({
   get editable() { return !!props.editable },
   get creatable() { return !!props.creatable },
   entity: props.entity ?? '',
-  indexField: props.indexField ?? 'id',
+  // Getter too: `LensTable` / `LensSheetField` read `edit.indexField` to pick the
+  // sheet opener and to block identifier edits, so it must track a prop that
+  // resolves (or changes) after mount — otherwise the new identifier column stays
+  // non-clickable while the old field is still treated as the id.
+  get indexField() { return props.indexField ?? 'id' },
   resolveId,
   save,
   create,

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -216,6 +216,15 @@ const pendingWrites = ref(0)
 let prevFetchInput: LensQuery | null = null
 let prevFetchResult: LensResult | null = null
 
+// Monotonic token bumped whenever an optimistic write starts. The main search
+// reads it so a normal search/refetch already past the network boundary when a
+// write begins won't assign its pre-write rows over the optimistic patch — the
+// busy lock guards the handlers, but not a request already in flight.
+let searchToken = 0
+// Mirror of the currently-shown result (kept in sync just below), so the search
+// fetcher can return it — preserving the optimistic state — when superseded.
+let currentResult: LensResult | undefined
+
 // `_select` carries the caller's intent. The index field is preserved
 // here if it was listed explicitly so the corresponding column gets
 // rendered, and is only added to the request payload separately (see
@@ -275,13 +284,26 @@ const { data: result, execute: refresh, loading } = useQuery(async (http) => {
     return prevFetchResult!
   }
 
+  const token = searchToken
   const res = await http.post<LensResult>(props.endpoint, input)
+
+  // A write started while this search was in flight; its rows are pre-write, so
+  // keep the optimistic state on screen rather than clobbering it. The post-batch
+  // reconcile surfaces the canonical state behind the refresh banner instead.
+  if (token !== searchToken) {
+    return currentResult ?? res
+  }
 
   prevFetchInput = input
   prevFetchResult = res
 
   return res
 })
+
+// Keep `currentResult` pointing at the shown result. The reference changes only
+// on a wholesale replace; optimistic in-place edits keep the same object, so this
+// mirror always reflects them.
+watch(result, (r) => { currentResult = r ?? undefined }, { immediate: true })
 
 const doRefresh = useDebounceFn(() => {
   // A write may have started during the debounce window: the busy lock guards the
@@ -461,6 +483,16 @@ function refetch(): void {
   latestState.value = null
   doRefresh()
 }
+
+// When `editable` resolves from false to true after mount (e.g. async
+// permissions), the initial search may have been issued while it was false — so
+// `withIndexField` didn't append the default `id`, leaving the current rows
+// without the identifier that editing and selection now need (`resolveId` would
+// return `undefined`). Refetch so the rows carry it. A no-op when the index field
+// was already present (the request input is unchanged → cached result reused).
+watch(() => props.editable, (now, prev) => {
+  if (now && !prev) { refetch() }
+})
 
 function onQuery(value: string | null) {
   if (guardBusy()) { return }
@@ -800,6 +832,9 @@ function trackWrite(recordId: any, key: string, run: () => Promise<unknown>): vo
   // reconcile re-derives it.
   latestState.value = null
   reconcileToken++
+  // Invalidate any main search already in flight so it can't assign its pre-write
+  // rows over the optimistic patch we're about to apply when it resolves.
+  searchToken++
   reconciling.value = false
   pendingWrites.value++
   pendingByRecord.set(recordId, (pendingByRecord.get(recordId) ?? 0) + 1)
@@ -955,18 +990,24 @@ async function openSheet(record: Record<string, any>): Promise<void> {
   const pendingAtIssue = hasPendingWrite(id)
   try {
     const res = await executeShow(id)
-    if (seq === showRequestSeq) {
+    // Merge into the *current* sheet record, not the one captured at call time: a
+    // direct refresh may have rebound `sheetRecord` to a fresh row object while
+    // `/show` was in flight, and the detail must land on the row the sheet is
+    // actually showing (else it renders without the detail-only fields). The seq
+    // guard ensures this is still the same logical record (a newer open bumps it).
+    const target = sheetRecord.value
+    if (seq === showRequestSeq && target) {
       if (pendingAtIssue || hasPendingWrite(id)) {
         // The record had/has an in-flight write, so `/show` may have read the
         // backend before it synced. Don't overwrite the optimistic values
         // already on the row; only fill in detail-only fields not yet present.
         for (const k of Object.keys(res.data)) {
-          if (!(k in record)) {
-            record[k] = res.data[k]
+          if (!(k in target)) {
+            target[k] = res.data[k]
           }
         }
       } else {
-        Object.assign(record, res.data)
+        Object.assign(target, res.data)
       }
     }
   } catch {

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -941,6 +941,19 @@ function trackWrite(recordId: any, key: string, run: () => Promise<unknown>): vo
 // row and the open sheet share this object), then persist in the background.
 function save(record: Record<string, any>, values: Record<string, any>): void {
   const id = resolveId(record)
+  // Never let an update re-key the row. The built-in cell / sheet editors already
+  // refuse to edit the index field, but the sheet-slot `save` helper funnels
+  // through here directly and a custom editor could include it. Changing a row's
+  // identifier optimistically (before the slow write settles) would re-key the
+  // row, so a follow-up save / delete would resolve to the new, not-yet-synced id
+  // and miss the in-flight record. Strip it so the invariant holds for every
+  // caller. (The identifier is still settable on create, which uses `create()`.)
+  const indexField = props.indexField ?? 'id'
+  if (indexField in values) {
+    values = { ...values }
+    delete values[indexField]
+  }
+  if (Object.keys(values).length === 0) { return }
   Object.assign(record, values)
   // Serialize per record+field so two quick edits to the same cell apply in
   // order; edits to disjoint fields run concurrently.
@@ -1011,6 +1024,16 @@ async function create(values: Record<string, any>): Promise<Record<string, any>>
       hasInitialResults.value = true
     }
     return res.data
+  } catch (e) {
+    // The create was rejected (e.g. a server `unique` rule). A query/filter/page
+    // change made just before submitting may have scheduled a refresh that the
+    // `creating` bail dropped without issuing a request, leaving the rows on the
+    // previous query. Re-schedule it now: doRefresh fires after `creating` clears,
+    // re-bails if writes are pending, and is a memo no-op when the query is
+    // unchanged (the common case), so it only does work when a query change was
+    // actually stranded.
+    void doRefresh()
+    throw e
   } finally {
     creating.value = false
   }

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -207,6 +207,12 @@ const hasInitialResults = ref(false)
 // (ahead of the query handlers that clear it) so they can reference it.
 const latestState = ref<LensResult | null>(null)
 
+// Count of optimistic background writes currently in flight. Declared here
+// (ahead of the debounced refetch that consults it) so a queued refetch can bail
+// when a write started during its debounce window. See the CRUD section below
+// for the full optimistic-write strategy this is part of.
+const pendingWrites = ref(0)
+
 let prevFetchInput: LensQuery | null = null
 let prevFetchResult: LensResult | null = null
 
@@ -277,7 +283,15 @@ const { data: result, execute: refresh, loading } = useQuery(async (http) => {
   return res
 })
 
-const doRefresh = useDebounceFn(refresh, 50)
+const doRefresh = useDebounceFn(() => {
+  // A write may have started during the debounce window: the busy lock guards the
+  // query handlers at click time, but not this deferred fetch. Bail if so —
+  // reading now would return stale pre-write rows and overwrite the optimistic
+  // edit. The post-batch reconcile refetches the (new) query state once writes
+  // settle, surfacing it behind the refresh banner.
+  if (pendingWrites.value > 0) { return }
+  return refresh()
+}, 50)
 
 if (props.urlSync) {
   // Route URL-driven changes (back/forward, shared links) through `refetch` so
@@ -581,8 +595,8 @@ const sheetError = ref(false)
 // applied to the in-memory result immediately and persisted in the background;
 // the server is never re-read to reconcile until the write settles. While any
 // write is in flight the catalog is "busy": query controls and the refresh
-// affordance are locked and an unload guard is armed.
-const pendingWrites = ref(0)
+// affordance are locked and an unload guard is armed. (`pendingWrites` itself is
+// declared near the top so the debounced refetch can consult it.)
 const reconciling = ref(false)
 const busy = computed(() => pendingWrites.value > 0 || reconciling.value)
 
@@ -711,58 +725,63 @@ async function reconcile(): Promise<void> {
 
 function applyLatest(): void {
   if (!latestState.value) { return }
-  const fresh = latestState.value
-  result.value = fresh
+  result.value = latestState.value
   latestState.value = null
   prevFetchInput = null
-  // The table now holds fresh row objects. If a record sheet is open, its
-  // `sheetRecord` still points at the old (replaced) object, so further sheet
-  // edits would mutate an orphan that no longer reflects in the table. Rebind to
-  // the matching fresh row — carrying over any detail-only fields already loaded
-  // via `/show` (the search result omits them) so the sheet keeps showing them —
-  // or close the sheet if the row is no longer present in the fresh results.
-  if (sheet.state.value && sheetMode.value === 'view' && sheetRecord.value) {
-    const id = resolveId(sheetRecord.value)
-    const match = fresh.data.find((r) => resolveId(r) === id)
-    if (match) {
-      for (const key of Object.keys(sheetRecord.value)) {
-        if (!(key in match)) {
-          match[key] = sheetRecord.value[key]
-        }
-      }
-      sheetRecord.value = match
-    } else {
-      sheet.off()
+  rebindOpenSheet()
+}
+
+// When `result` is replaced wholesale (the refresh banner, or a forced refresh),
+// an open record sheet's `sheetRecord` still points at the old (now-orphaned) row
+// object, so later sheet edits would mutate the orphan and stop reflecting in the
+// table. Rebind to the matching fresh row — carrying over any detail-only fields
+// already loaded via `/show` (the search result omits them) so the sheet keeps
+// showing them — or close the sheet if the row is no longer present.
+function rebindOpenSheet(): void {
+  if (!result.value) { return }
+  if (!sheet.state.value || sheetMode.value !== 'view' || !sheetRecord.value) { return }
+  const id = resolveId(sheetRecord.value)
+  const match = result.value.data.find((r) => resolveId(r) === id)
+  if (!match) {
+    sheet.off()
+    return
+  }
+  for (const key of Object.keys(sheetRecord.value)) {
+    if (!(key in match)) {
+      match[key] = sheetRecord.value[key]
     }
   }
+  sheetRecord.value = match
+}
+
+// Core force-refetch: drop the memoized input + any stash, invalidate an in-flight
+// reconcile (its request may predate the change being surfaced), refetch the
+// current query, then rebind an open sheet to the fresh rows. Bypasses the busy
+// guard — callers (the exposed refresh, the create path) gate it themselves.
+async function forceRefresh(): Promise<void> {
+  reconcileToken++
+  reconciling.value = false
+  prevFetchInput = null
+  latestState.value = null
+  await doRefresh()
+  rebindOpenSheet()
 }
 
 // Re-runs the current query against the endpoint, preserving the catalog's
 // in-memory state (select / filters / sort / page). Exposed so callers can
-// reflect server-side changes — e.g. after a bulk action mutates rows —
-// without remounting the component.
+// reflect server-side changes — e.g. after a bulk action mutates rows — without
+// remounting the component.
 async function refreshCatalog(): Promise<void> {
-  // While writes are still syncing, a read now could return stale pre-write data
-  // that, stashed behind the refresh banner, could outlive a failed write (whose
-  // post-batch reconcile is skipped) and roll the table back when applied. Defer:
-  // the post-batch reconcile refetches the canonical state once the batch settles
-  // cleanly, which also reflects any server-side change a caller wanted surfaced.
-  if (pendingWrites.value > 0) {
+  // Defer while a write — or a (blocking) create — is in flight: a read now could
+  // return stale pre-write / pre-create data and clobber the optimistic or
+  // just-created rows (and a stashed stale result could outlive a failed write
+  // whose post-batch reconcile is skipped). The post-batch reconcile / create
+  // path surfaces the canonical state once things settle. When only a reconcile
+  // is in flight (reads are fresh again), forceRefresh supersedes it.
+  if (pendingWrites.value > 0 || creating.value) {
     return
   }
-  // Writes have settled, so reads are fresh again. If a reconcile is still in
-  // flight, its request may predate the change the caller wants surfaced (e.g. a
-  // bulk action that just ran) — invalidate it (token bump + clear its busy flag)
-  // and force a fresh refetch now rather than dropping the refresh.
-  reconcileToken++
-  reconciling.value = false
-  // A refresh is requested precisely when server-side data may have changed
-  // while the query input did not (e.g. after a bulk action). Clear the
-  // memoized input so the equality shortcut in the fetcher misses and a real
-  // request is issued instead of returning the stale cached result.
-  prevFetchInput = null
-  latestState.value = null
-  await doRefresh()
+  await forceRefresh()
 }
 
 // Track an optimistic background write: count it as pending, surface a snackbar
@@ -869,14 +888,12 @@ async function create(values: Record<string, any>): Promise<Record<string, any>>
       // full list (via the refresh banner) once they settle.
       prependCreated(res.data)
     } else {
-      // A write batch may have settled during the (slow) POST and kicked off a
-      // reconcile; invalidate it (token bump + busy-flag reset, mirroring
-      // trackWrite) so its possibly-pre-create snapshot can't land behind the
-      // refresh banner after this fresh refetch.
-      reconcileToken++
-      reconciling.value = false
+      // Force a fresh refetch directly (not the exposed refreshCatalog, which
+      // would no-op while `creating` is still true). forceRefresh also invalidates
+      // any reconcile that a batch settling mid-POST kicked off, so a pre-create
+      // snapshot can't land behind the refresh banner.
       try {
-        await refreshCatalog()
+        await forceRefresh()
       } catch {
         prependCreated(res.data)
       }

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -140,11 +140,13 @@ export interface Props {
   // follow-up save/delete would address the not-yet-synced new id. It can
   // still be set on creation (via a `showOnCreate` field).
   //
-  // An editable catalog must keep its index field among the rendered columns
-  // (i.e. include it in `select`, or leave `select` empty to use server
-  // defaults): the row's sheet opener — and therefore the only way to view or
-  // delete a record — is the index-field cell, so hiding that column leaves the
-  // rows with no opener.
+  // An editable catalog must keep its index field among the rendered columns,
+  // because the row's sheet opener — and therefore the only way to view or
+  // delete a record — is the index-field cell. The default `id` identifier is
+  // kept when `select` is empty (server defaults), so that case works as-is; a
+  // *custom* `indexField`, however, must be listed in `select` explicitly (an
+  // empty/default `select` drops it from the rendered columns, leaving the rows
+  // with no opener).
   editable?: boolean
 
   // Whether new records can be created (enables create mode in the sheet
@@ -1085,7 +1087,9 @@ provideLensEdit({
   // can't `resolveId()` to `undefined`.
   get editable() { return !!props.editable && rowsCarryIndexField.value },
   get creatable() { return !!props.creatable },
-  entity: props.entity ?? '',
+  // Use the same `__no_entity__` fallback as the search / CRUD requests so slot
+  // side-channel saves (which read this) target the same entity, not an empty one.
+  get entity() { return entityName.value },
   // Getter too: `LensTable` / `LensSheetField` read `edit.indexField` to pick the
   // sheet opener and to block identifier edits, so it must track a prop that
   // resolves (or changes) after mount — otherwise the new identifier column stays
@@ -1268,7 +1272,7 @@ defineExpose({
       v-if="editable && result?.fields"
       :open="sheet.state.value"
       :mode="sheetMode"
-      :entity="entity ?? ''"
+      :entity="entityName"
       :record="sheetRecord"
       :loading="sheetLoading"
       :error="sheetError"

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -139,6 +139,11 @@ export interface Props {
 
   // Width of the record sheet (any valid CSS width). Defaults to `480px`.
   sheetWidth?: string
+
+  // Enable inline editing directly in the table: cells for `showOnUpdate`
+  // fields gain a hover edit affordance that opens an inline editor. Requires
+  // `editable` (it reuses the same CRUD edit context as the sheet).
+  inlineEdit?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -697,6 +702,7 @@ defineExpose({
           :index-field
           :selected
           :clickable-fields
+          :inline-edit
           @filter-updated="onInlineFilterUpdated"
           @sort-updated="onSortUpdated"
           @update:selected="onUpdateSelected"
@@ -766,7 +772,6 @@ defineExpose({
 
 .LensCatalog.show-empty-state {
   border-style: dashed;
-  background-color: var(--c-bg-1);
 }
 
 .LensCatalog.has-border {

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -569,6 +569,15 @@ const sheet = usePower()
 const sheetMode = ref<'view' | 'create'>('view')
 const sheetRecord = ref<Record<string, any> | null>(null)
 
+// Whether the open detail sheet is still loading its full record via `/show`.
+// The sheet opens immediately (so a click gives instant feedback) and shows a
+// spinner until the record is loaded, rather than rendering partial fields.
+const sheetLoading = ref(false)
+
+// Whether the detail load (`/show`) failed. The sheet then shows an error
+// asking the user to reload, rather than rendering a partial record.
+const sheetError = ref(false)
+
 // The slow target API can take a long time to sync a write, and a read during
 // that window returns stale (pre-write) data. So updates and deletes are
 // applied to the in-memory result immediately and persisted in the background;
@@ -583,8 +592,9 @@ const busy = computed(() => pendingWrites.value > 0 || reconciling.value)
 // is skipped (the snackbar already told the user to reload).
 let batchErrored = false
 
-// Monotonic token for the in-flight `/show` request, so a slow detail fetch
-// that predates an edit (or a record switch) can't overwrite newer data.
+// Monotonic token for the in-flight `openSheet` `/show` request, so a newer
+// open (another row, or the create form) supersedes an older one and the stale
+// detail fetch doesn't open over it when it resolves.
 let showRequestSeq = 0
 
 // Monotonic token for the in-flight reconcile fetch, so a newer batch's
@@ -706,11 +716,6 @@ function trackWrite(run: () => Promise<unknown>): void {
 // Update — optimistic. Reflect the change in memory immediately (the catalog
 // row and the open sheet share this object), then persist in the background.
 function save(record: Record<string, any>, values: Record<string, any>): void {
-  // A pending `/show` for this record predates the edit; invalidate it so it
-  // can't overwrite the optimistic value when it lands.
-  if (sheetRecord.value === record) {
-    showRequestSeq++
-  }
   Object.assign(record, values)
   trackWrite(() => executeUpdate(resolveId(record), values))
 }
@@ -746,24 +751,31 @@ function remove(record: Record<string, any>): void {
 }
 
 async function openSheet(record: Record<string, any>): Promise<void> {
+  // Open immediately with a spinner (instant feedback so the user doesn't click
+  // the id cell again), then load the full record (detail-only fields not
+  // selected as columns) and render it. A newer open (another row, or the
+  // create form) supersedes this one via the token.
   sheetRecord.value = record
   sheetMode.value = 'view'
+  sheetLoading.value = true
+  sheetError.value = false
   sheet.on()
   const seq = ++showRequestSeq
-  // Pull the full record so detail-only fields (not selected as columns) are
-  // populated and editable in the sheet. Failures are non-fatal: the sheet
-  // falls back to the columns already on the row.
   try {
     const res = await executeShow(resolveId(record))
-    // Drop the response if it has been superseded — by a record switch, the
-    // create form, or an edit to this record (which bumps the token) — so a
-    // stale detail fetch can't overwrite newer optimistic data.
-    if (seq !== showRequestSeq || sheetRecord.value !== record) {
-      return
+    if (seq === showRequestSeq) {
+      Object.assign(record, res.data)
     }
-    Object.assign(record, res.data)
   } catch {
-    // Ignore — keep showing the columns the catalog already fetched.
+    // Detail load failed: surface an error in the sheet rather than render a
+    // partial record (the user is asked to reload).
+    if (seq === showRequestSeq) {
+      sheetError.value = true
+    }
+  } finally {
+    if (seq === showRequestSeq) {
+      sheetLoading.value = false
+    }
   }
 }
 
@@ -773,8 +785,13 @@ function openCreate(): void {
   if (!props.creatable) {
     return
   }
+  // Supersede any in-flight openSheet `/show` so it can't open over the create
+  // form when it resolves.
+  showRequestSeq++
   sheetRecord.value = null
   sheetMode.value = 'create'
+  sheetLoading.value = false
+  sheetError.value = false
   sheet.on()
 }
 
@@ -965,6 +982,8 @@ defineExpose({
       :mode="sheetMode"
       :entity="entity ?? ''"
       :record="sheetRecord"
+      :loading="sheetLoading"
+      :error="sheetError"
       :fields="result.fields"
       :index-field="indexField ?? 'id'"
       :width="sheetWidth"

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -976,17 +976,20 @@ function prependCreated(data: Record<string, any>): void {
 
 async function create(values: Record<string, any>): Promise<Record<string, any>> {
   creating.value = true
-  // Invalidate any main search already in flight (issued before this create) so
-  // its pre-create rows can't assign over the just-created record when it
-  // resolves — mirrors trackWrite. New searches can't start during the create
-  // (doRefresh bails on `creating`); create's own forceRefresh bypasses that by
-  // calling refresh directly.
-  searchToken++
   try {
     const res = await executeCreate(values)
-    // The POST succeeded — the record exists. From here a refresh failure must
-    // not reject (the caller would treat the create as failed and re-submit a
-    // duplicate); fall back to showing the new record optimistically.
+    // The POST succeeded — the record exists. Invalidate any main search already
+    // in flight (issued before this create) so its pre-create rows can't assign
+    // over the just-created record when it resolves — mirrors trackWrite. Bump
+    // only AFTER success: a rejected create doesn't refetch, so suppressing the
+    // search here too would strand the catalog on the old query — leaving it valid
+    // lets it land its (correct, new-query) rows instead. New searches can't start
+    // during the create (doRefresh bails on `creating`); create's own forceRefresh
+    // bypasses that by calling refresh directly.
+    searchToken++
+    // From here a refresh failure must not reject (the caller would treat the
+    // create as failed and re-submit a duplicate); fall back to showing the new
+    // record optimistically.
     if (pendingWrites.value > 0) {
       // Other optimistic writes are still syncing; a refetch now would read the
       // backend before they're visible and clobber those rows. Prepend the new

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -544,21 +544,6 @@ function onNext() {
   refetch()
 }
 
-// Re-runs the current query against the endpoint, preserving the
-// catalog's in-memory state (select / filters / sort / page). Exposed
-// so callers can reflect server-side changes — e.g. after a bulk action
-// mutates rows — without remounting the component.
-async function refreshCatalog(): Promise<void> {
-  // A refresh is requested precisely when server-side data may have
-  // changed while the query input did not (e.g. after a bulk action).
-  // Clear the memoized input so the equality shortcut in the fetcher
-  // misses and a real request is issued instead of returning the stale
-  // cached result.
-  prevFetchInput = null
-  latestState.value = null
-  await doRefresh()
-}
-
 // --- CRUD editing ----------------------------------------------------------
 
 // Derive the CRUD endpoints from the (search) endpoint, e.g.
@@ -704,6 +689,30 @@ function applyLatest(): void {
   prevFetchInput = null
 }
 
+// Re-runs the current query against the endpoint, preserving the catalog's
+// in-memory state (select / filters / sort / page). Exposed so callers can
+// reflect server-side changes — e.g. after a bulk action mutates rows —
+// without remounting the component.
+async function refreshCatalog(): Promise<void> {
+  // While a background write is still syncing, a forced refetch would read
+  // stale (pre-write) data from the slow API and clobber the optimistic edits.
+  // Route through the reconcile flow instead, so any newer server state lands
+  // behind the refresh banner once the writes settle rather than overwriting
+  // the screen. This gives the exposed `refresh` the same guarantee the in-app
+  // controls have: a refresh never drops an in-flight optimistic edit.
+  if (busy.value) {
+    await reconcile()
+    return
+  }
+  // A refresh is requested precisely when server-side data may have changed
+  // while the query input did not (e.g. after a bulk action). Clear the
+  // memoized input so the equality shortcut in the fetcher misses and a real
+  // request is issued instead of returning the stale cached result.
+  prevFetchInput = null
+  latestState.value = null
+  await doRefresh()
+}
+
 // Track an optimistic background write: count it as pending, surface a snackbar
 // on failure, and once the whole batch settles (with no failures) reconcile.
 function hasPendingWrite(recordId: any): boolean {
@@ -832,7 +841,19 @@ function remove(record: Record<string, any>): void {
       }
     }
   }
-  trackWrite(id, `${id}:__delete__`, () => executeDelete(id))
+  // Serialize the delete behind any in-flight updates for the same record. With
+  // the slow write API, a concurrently-issued delete could otherwise reach the
+  // backend before a pending update — the update would then fail against an
+  // already-deleted row (spurious save-failed snackbar) or resurrect/clobber
+  // it. Gate on the record's current write chains (settled, success or not —
+  // the row is being deleted regardless) before issuing the delete.
+  const pendingForRecord = [...writeChains.entries()]
+    .filter(([key]) => key.startsWith(`${id}:`))
+    .map(([, chain]) => chain)
+  // `Promise.allSettled([])` resolves immediately, so this is a no-op gate when
+  // the record has no in-flight writes.
+  const gate = Promise.allSettled(pendingForRecord)
+  trackWrite(id, `${id}:__delete__`, () => gate.then(() => executeDelete(id)))
 }
 
 async function openSheet(record: Record<string, any>): Promise<void> {

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -518,19 +518,6 @@ function refetch(): void {
   doRefresh()
 }
 
-// When the effective row identifier appears or changes while editing is enabled,
-// the loaded rows won't carry it until a refetch runs — so refetch here. Two
-// cases: `editable` resolving true after mount (async permissions), so
-// `withIndexField` only now appends the default `id`; or a parent resolving /
-// changing `indexField` from async config. Without this the rows lack the new
-// identifier, `rowsCarryIndexField` keeps editing gated off, and selection keys
-// go `undefined` until an unrelated query change. A no-op when the identifier was
-// already present (same request input → cached result reused).
-watch(
-  () => (props.editable ? (props.indexField ?? 'id') : null),
-  (field, prev) => { if (field && field !== prev) { refetch() } }
-)
-
 function onQuery(value: string | null) {
   if (guardBusy()) { return }
   query.value = value
@@ -854,6 +841,28 @@ async function refreshCatalog(): Promise<void> {
   }
   await forceRefresh()
 }
+
+// When the effective row identifier appears or changes while editing is enabled,
+// the loaded rows won't carry it until a refetch runs — so refetch here. Two
+// cases: `editable` resolving true after mount (async permissions), so
+// `withIndexField` only now appends the default `id`; or a parent resolving /
+// changing `indexField` from async config. Without this the rows lack the new
+// identifier, `rowsCarryIndexField` keeps editing gated off, and selection keys
+// go `undefined` until an unrelated query change. A no-op when the identifier was
+// already present (same request input → cached result reused).
+//
+// Close an open record sheet first: it was identified under the old field and
+// can't be reliably re-matched to the new one (its row lacks the new key, so
+// `resolveId` would be `undefined`), which would let a delete/save act on the
+// wrong — or no — id during and after the refetch.
+watch(
+  () => (props.editable ? (props.indexField ?? 'id') : null),
+  (field, prev) => {
+    if (!field || field === prev) { return }
+    if (sheet.state.value && sheetMode.value === 'view') { sheet.off() }
+    refetch()
+  }
+)
 
 // Track an optimistic background write: count it as pending, surface a snackbar
 // on failure, and once the whole batch settles (with no failures) reconcile.

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -277,6 +277,11 @@ if (props.urlSync) {
   // Route URL-driven changes (back/forward, shared links) through `refetch` so
   // they clear any stashed reconcile result, just like the in-app controls — a
   // refresh button must never apply data fetched for a previous query.
+  //
+  // Known limitation: unlike the in-app controls, this path is not gated by the
+  // busy lock, so a URL change landing mid-write could refetch stale data and
+  // drop an optimistic edit. Unreachable today (no page enables `urlSync` with
+  // `editable`); revisit if one ever does.
   useCatalogUrlQuerySync(
     { query, filters: _filters, sort: _sort, page },
     refetch
@@ -654,9 +659,10 @@ async function reconcile(): Promise<void> {
     if (token !== reconcileToken) {
       return
     }
-    if (result.value && !isSameResult(fresh, result.value)) {
-      latestState.value = fresh
-    }
+    // Authoritative: stash the canonical result when it differs from what's
+    // shown, otherwise clear any (possibly stale) stash — an earlier overlapping
+    // reconcile may have left a pre-edit result behind.
+    latestState.value = result.value && !isSameResult(fresh, result.value) ? fresh : null
   } catch {
     // Ignore — keep the optimistic state, offer no refresh.
   } finally {
@@ -676,6 +682,9 @@ function applyLatest(): void {
 // Track an optimistic background write: count it as pending, surface a snackbar
 // on failure, and once the whole batch settles (with no failures) reconcile.
 function trackWrite(run: () => Promise<unknown>): void {
+  // A new write changes the displayed state, so any stashed reconcile result is
+  // now potentially stale; clear it (the post-batch reconcile re-derives it).
+  latestState.value = null
   pendingWrites.value++
   run()
     .catch(() => {

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -518,15 +518,18 @@ function refetch(): void {
   doRefresh()
 }
 
-// When `editable` resolves from false to true after mount (e.g. async
-// permissions), the initial search may have been issued while it was false — so
-// `withIndexField` didn't append the default `id`, leaving the current rows
-// without the identifier that editing and selection now need (`resolveId` would
-// return `undefined`). Refetch so the rows carry it. A no-op when the index field
-// was already present (the request input is unchanged → cached result reused).
-watch(() => props.editable, (now, prev) => {
-  if (now && !prev) { refetch() }
-})
+// When the effective row identifier appears or changes while editing is enabled,
+// the loaded rows won't carry it until a refetch runs — so refetch here. Two
+// cases: `editable` resolving true after mount (async permissions), so
+// `withIndexField` only now appends the default `id`; or a parent resolving /
+// changing `indexField` from async config. Without this the rows lack the new
+// identifier, `rowsCarryIndexField` keeps editing gated off, and selection keys
+// go `undefined` until an unrelated query change. A no-op when the identifier was
+// already present (same request input → cached result reused).
+watch(
+  () => (props.editable ? (props.indexField ?? 'id') : null),
+  (field, prev) => { if (field && field !== prev) { refetch() } }
+)
 
 function onQuery(value: string | null) {
   if (guardBusy()) { return }
@@ -824,6 +827,11 @@ function rebindOpenSheet(): void {
 async function forceRefresh(): Promise<void> {
   reconcileToken++
   reconciling.value = false
+  // Supersede any normal search already in flight (e.g. issued by a query change
+  // before an external bulk mutation) so its older rows can't assign over this
+  // fresh result when it resolves — same token mechanism as the write/create
+  // races. This refetch captures the bumped token, so it isn't self-suppressed.
+  searchToken++
   prevFetchInput = null
   latestState.value = null
   await refresh()

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -310,7 +310,9 @@ const conditionBlocksSize = useElementSize(conditionBlocksEl)
 
 const headerHeight = 'var(--lens-catalog-global-height-offset)'
 const controlHeight = '56px - 1px'
-const conditionBlocksHeight = computed(() => conditionBlocksSize.height.value > 0 ? `${conditionBlocksSize.height.value}px - 1px` : '0px')
+const conditionBlocksHeight = computed(() =>
+  conditionBlocksSize.height.value > 0 ? `${conditionBlocksSize.height.value}px - 1px` : '0px'
+)
 const columnsHeight = '40px - 1px'
 const footerHeight = '56px - 1px'
 
@@ -336,9 +338,13 @@ const tableMaxHeight = computed(() => {
     return undefined
   }
   if (props.height === 'fill') {
-    return `--table-max-height: calc(100vh - ${headerHeight} - ${controlHeight} - ${conditionBlocksHeight.value} - ${columnsHeight} - ${footerHeight} - ${props.heightOffset ?? '0px'})`
+    return '--table-max-height: '
+      + `calc(100vh - ${headerHeight} - ${controlHeight} - ${conditionBlocksHeight.value}`
+      + ` - ${columnsHeight} - ${footerHeight} - ${props.heightOffset ?? '0px'})`
   }
-  return `--table-max-height: calc(${props.height} - ${controlHeight} - ${conditionBlocksHeight.value} - ${columnsHeight} - ${footerHeight})`
+  return '--table-max-height: '
+    + `calc(${props.height} - ${controlHeight} - ${conditionBlocksHeight.value}`
+    + ` - ${columnsHeight} - ${footerHeight})`
 })
 
 // Initial setup when the result is loaded for the first time. When the
@@ -495,7 +501,11 @@ function onResetSorts() {
   emit('sort-updated', _sort.value)
 }
 
-function onViewUpdated(newSelect: string[], newSelectable: string[], overrides: Record<string, Partial<FieldData>>) {
+function onViewUpdated(
+  newSelect: string[],
+  newSelectable: string[],
+  overrides: Record<string, Partial<FieldData>>
+) {
   if (guardBusy()) { return }
   // Treat updates from the view form as deliberate user intent: if the
   // user picked the index field on purpose, surface its column.
@@ -863,7 +873,12 @@ defineExpose({
         </template>
       </LensCatalogControl>
       <div v-else class="control-skeleton" />
-      <div v-if="!hideConditions && result && (_filters.length > 0 || _sort.length > 0)" ref="conditionBlocksEl" class="condition-blocks" :class="{ 'is-busy': busy }">
+      <div
+        v-if="!hideConditions && result && (_filters.length > 0 || _sort.length > 0)"
+        ref="conditionBlocksEl"
+        class="condition-blocks"
+        :class="{ 'is-busy': busy }"
+      >
         <template v-if="_filters.length > 0">
           <SDivider />
           <LensCatalogStateFilter

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -463,6 +463,18 @@ const tableSelect = computed(() => {
 // would leave `selected` pointing at the wrong records. Mirrors `edit.indexField`.
 const tableIndexField = computed(() => props.indexField ?? (props.editable ? 'id' : undefined))
 
+// Whether the currently loaded rows actually carry the effective row identifier.
+// Editing / opening a row needs it (`resolveId`), but rows fetched while
+// `editable` was still false — or before an `indexField` change settled — won't
+// have it until the triggered refetch lands. Editing is gated on this (see the
+// `editable` getter) so a quick save in that window can't post `id: undefined`.
+// An empty result has nothing to edit, so it doesn't block.
+const rowsCarryIndexField = computed(() => {
+  const rows = result.value?.data
+  if (!rows || rows.length === 0) { return true }
+  return (props.indexField ?? 'id') in rows[0]
+})
+
 // The `indexField` is appended to the request `select` so the server
 // returns its value on every row, but it is kept out of the internal
 // `_select` / `_selectable` state so the caller-facing concept of
@@ -1066,7 +1078,12 @@ provideLensEdit({
   // Getters so the injected context tracks prop changes after mount (e.g.
   // permissions resolving async, or a flag toggling `editable` off): LensTable
   // gates inline editing and the id-cell sheet on `edit.editable`.
-  get editable() { return !!props.editable },
+  //
+  // Also gated on `rowsCarryIndexField`: when `editable` flips true after mount we
+  // trigger a refetch to pull in the identifier, but it lands asynchronously —
+  // keep editing off until the rows actually carry it, so a save in that window
+  // can't `resolveId()` to `undefined`.
+  get editable() { return !!props.editable && rowsCarryIndexField.value },
   get creatable() { return !!props.creatable },
   entity: props.entity ?? '',
   // Getter too: `LensTable` / `LensSheetField` read `edit.indexField` to pick the

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -400,6 +400,13 @@ const tableSelect = computed(() => {
   return withoutIndexField(result.value?.query.select ?? [])
 })
 
+// The row-identifier the table uses as its selection key. An explicit
+// `indexField`, or `id` for editable catalogs (which always carry it). Without
+// this, an editable catalog that relies on the default would leave the table on
+// positional selection keys, so an optimistic create/delete that shifts rows
+// would leave `selected` pointing at the wrong records. Mirrors `edit.indexField`.
+const tableIndexField = computed(() => props.indexField ?? (props.editable ? 'id' : undefined))
+
 // The `indexField` is appended to the request `select` so the server
 // returns its value on every row, but it is kept out of the internal
 // `_select` / `_selectable` state so the caller-facing concept of
@@ -735,17 +742,20 @@ function applyLatest(): void {
 // reflect server-side changes — e.g. after a bulk action mutates rows —
 // without remounting the component.
 async function refreshCatalog(): Promise<void> {
-  // While a write batch is still settling (or its reconcile is in flight), a
-  // read now could return stale pre-write data, so don't refetch or stash
-  // anything behind the refresh banner: a stale stash could outlive a failed
-  // write (whose post-batch reconcile is skipped) — or a failed reconcile — and
-  // then roll the table back to pre-edit data when the banner is clicked. The
-  // post-batch reconcile already refetches the canonical state for the current
-  // query once the batch settles cleanly, which also reflects any server-side
-  // change a caller wanted surfaced; defer to it rather than reading now.
-  if (busy.value) {
+  // While writes are still syncing, a read now could return stale pre-write data
+  // that, stashed behind the refresh banner, could outlive a failed write (whose
+  // post-batch reconcile is skipped) and roll the table back when applied. Defer:
+  // the post-batch reconcile refetches the canonical state once the batch settles
+  // cleanly, which also reflects any server-side change a caller wanted surfaced.
+  if (pendingWrites.value > 0) {
     return
   }
+  // Writes have settled, so reads are fresh again. If a reconcile is still in
+  // flight, its request may predate the change the caller wants surfaced (e.g. a
+  // bulk action that just ran) — invalidate it (token bump + clear its busy flag)
+  // and force a fresh refetch now rather than dropping the refresh.
+  reconcileToken++
+  reconciling.value = false
   // A refresh is requested precisely when server-side data may have changed
   // while the query input did not (e.g. after a bulk action). Clear the
   // memoized input so the equality shortcut in the fetcher misses and a real
@@ -814,11 +824,23 @@ function save(record: Record<string, any>, values: Record<string, any>): void {
   const id = resolveId(record)
   Object.assign(record, values)
   // Serialize per record+field so two quick edits to the same cell apply in
-  // order; edits to different fields run concurrently. Assumes callers save a
-  // single field (or disjoint field sets) — overlapping multi-field saves would
-  // share a column without ordering and need a coarser (per-record) key.
-  const key = `${id}:${Object.keys(values).sort().join(',')}`
-  trackWrite(id, key, () => executeUpdate(id, values))
+  // order; edits to disjoint fields run concurrently.
+  const fields = Object.keys(values)
+  const key = `${id}:${[...fields].sort().join(',')}`
+  // Same-cell repeats chain on this key inside trackWrite. But a multi-field save
+  // (e.g. a slot persisting {name,status}) and a later single-field save ({name})
+  // have different keys yet share a column, so without help they'd race — with
+  // the slow API the older one could land last and clobber the newer value. Gate
+  // behind any in-flight write for this record whose fields overlap; disjoint
+  // writes still run concurrently.
+  const prefix = `${id}:`
+  const fieldSet = new Set(fields)
+  const overlapping = [...writeChains.entries()]
+    .filter(([k]) => k !== key && k.startsWith(prefix)
+      && k.slice(prefix.length).split(',').some((f) => fieldSet.has(f)))
+    .map(([, chain]) => chain)
+  const gate = Promise.allSettled(overlapping)
+  trackWrite(id, key, () => gate.then(() => executeUpdate(id, values)))
 }
 
 // Create — blocking. The slow POST runs to completion, then the catalog is
@@ -1097,7 +1119,7 @@ defineExpose({
           :loading
           :overrides="_overrides"
           :select="tableSelect"
-          :index-field
+          :index-field="tableIndexField"
           :selected
           :clickable-fields
           :inline-edit

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -215,11 +215,6 @@ const slotProps = computed(() => ({
   flex-direction: column;
   height: 100%;
   background-color: var(--c-bg-1);
-
-  /* Match the collaborator drawer: nested elevated controls sit on the
-     panel surface rather than a darker elevation. */
-  --c-bg-elv-2: var(--c-bg-1);
-  --c-bg-elv-3: var(--c-bg-1);
 }
 
 .header {

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -219,9 +219,15 @@ function requestClose() {
 const resolvedId = computed(() => (props.record && edit ? edit.resolveId(props.record) : null))
 
 function saveRecord(values: Record<string, any>): Promise<void> {
-  if (props.record && edit) {
-    edit.save(props.record, values)
+  // Refuse to save until the full record has loaded. The slots render before the
+  // `loading` / `error` branch (so a `#before` header can show during the load),
+  // but saving against the partial row mid-`/show` (or after it failed) could
+  // overwrite a not-yet-loaded detail field with an empty value — the built-in
+  // fields avoid this by not rendering until the record is ready.
+  if (props.loading || props.error || !props.record || !edit) {
+    return Promise.resolve()
   }
+  edit.save(props.record, values)
   return Promise.resolve()
 }
 
@@ -229,6 +235,10 @@ const slotProps = computed(() => ({
   record: props.record ?? null,
   id: resolvedId.value,
   entity: props.entity,
+  // Surfaced so custom editors can disable their save controls until the full
+  // record has loaded; `save` also hard-refuses while loading/error as a guard.
+  loading: props.loading ?? false,
+  error: props.error ?? false,
   save: saveRecord
 }))
 </script>

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -118,7 +118,9 @@ const serverErrors = ref<Record<string, string[]>>({})
 
 const { validation, validate, reset } = useValidation(
   () => createModel,
-  () => Object.fromEntries(createInputViews.value.map((e) => [e.key, e.field.generateValidationRules()])),
+  () => Object.fromEntries(
+    createInputViews.value.map((e) => [e.key, e.field.generateValidationRules()])
+  ),
   { $externalResults: serverErrors }
 )
 

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -1,0 +1,289 @@
+<script setup lang="ts">
+import IconTrash from '~icons/ph/trash'
+import IconX from '~icons/ph/x'
+import { computed, reactive, ref, watch } from 'vue'
+import SButton from '../../../components/SButton.vue'
+import SSheet from '../../../components/SSheet.vue'
+import { provideDataListState } from '../../../composables/DataList'
+import { useTrans } from '../../../composables/Lang'
+import { useValidation } from '../../../composables/Validation'
+import { type FieldData } from '../FieldData'
+import { useFieldFactory } from '../composables/FieldFactory'
+import { useLensEdit } from '../composables/LensEdit'
+import LensSheetField from './LensSheetField.vue'
+
+const props = withDefaults(defineProps<{
+  open: boolean
+  mode?: 'view' | 'create'
+  entity: string
+  record?: Record<string, any> | null
+  fields: Record<string, FieldData>
+  indexField?: string
+  width?: string
+}>(), {
+  mode: 'view',
+  indexField: 'id'
+})
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const { t } = useTrans({
+  en: { create: 'Create', cancel: 'Cancel', delete: 'Delete', new_record: 'New record', deleting: 'Deleting…' },
+  ja: { create: '作成', cancel: 'キャンセル', delete: '削除', new_record: '新規作成', deleting: '削除中…' }
+})
+
+const edit = useLensEdit()
+const factory = useFieldFactory()
+
+// Provide the data-list label width directly (instead of wrapping rows in
+// SDataList) so each LensSheetField wrapper doesn't make its SDataListItem a
+// `:first-child`, which would otherwise double SDataList's dashed dividers.
+provideDataListState({ labelWidth: computed(() => '160px') })
+
+const entries = computed(() =>
+  Object.entries(props.fields).map(([key, fieldData]) => ({
+    key,
+    fieldData,
+    field: factory.make(fieldData)
+  }))
+)
+
+const detailFields = computed(() => entries.value.filter((e) => e.fieldData.showOnDetail !== false))
+const createFields = computed(() => entries.value.filter((e) => e.fieldData.showOnCreate === true))
+
+// Materialize the create-form input components once per field set. Calling
+// `formInputComponent()` inline in the template would mint a brand-new
+// component definition on every render, which breaks Vue's component patching
+// (`instance.update is not a function`).
+const createFieldViews = computed(() =>
+  createFields.value.map((e) => ({
+    key: e.key,
+    component: e.field.formInputComponent()
+  }))
+)
+
+const title = computed(() => {
+  if (props.mode === 'create') {
+    return t.new_record
+  }
+  const id = props.record?.[props.indexField]
+  return (id && typeof id === 'object' ? id.display : id) ?? ''
+})
+
+// --- Create mode form state ---
+
+const createModel = reactive<Record<string, any>>({})
+const saving = ref(false)
+
+const { validation, validate, reset } = useValidation(
+  () => createModel,
+  () => Object.fromEntries(createFields.value.map((e) => [e.key, e.field.generateValidationRules()]))
+)
+
+watch(
+  () => [props.open, props.mode] as const,
+  ([open, mode]) => {
+    if (open && mode === 'create') {
+      for (const { key, field } of createFields.value) {
+        createModel[key] = field.inputEmptyValue()
+      }
+      reset()
+    }
+  },
+  { immediate: true }
+)
+
+async function onCreate() {
+  if (!(await validate())) {
+    return
+  }
+
+  saving.value = true
+
+  try {
+    const values: Record<string, any> = {}
+    for (const { key, field } of createFields.value) {
+      values[key] = field.inputToPayload(createModel[key])
+    }
+    await edit!.create(values)
+    emit('close')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function onDelete() {
+  if (!props.record) {
+    return
+  }
+  saving.value = true
+  try {
+    await edit!.remove(props.record)
+    emit('close')
+  } finally {
+    saving.value = false
+  }
+}
+
+// --- Slot context -----------------------------------------------------------
+//
+// Content passed to the `#before` / `#after` slots is declared in the page
+// that hosts the catalog, so it cannot `inject` the edit context (which is
+// provided inside `LensCatalog`, a child of that page). Expose the pieces a
+// slot needs as slot props instead: the resolved record id, a record-bound
+// partial `save`, and the entity key. This keeps the generic sheet free of
+// one-off concerns (avatar upload, social links, linked records) while still
+// letting a page implement them.
+
+const resolvedId = computed(() =>
+  props.record && edit ? edit.resolveId(props.record) : null
+)
+
+function saveRecord(values: Record<string, any>): Promise<void> {
+  if (!props.record || !edit) {
+    return Promise.resolve()
+  }
+  return edit.save(props.record, values)
+}
+
+const slotProps = computed(() => ({
+  record: props.record ?? null,
+  id: resolvedId.value,
+  entity: props.entity,
+  save: saveRecord
+}))
+</script>
+
+<template>
+  <SSheet :open :width="width ?? '480px'" @close="emit('close')">
+    <div class="LensSheet">
+      <div class="header">
+        <div class="title">{{ title }}</div>
+        <button class="close" type="button" aria-label="Close" @click="emit('close')">
+          <IconX class="close-icon" />
+        </button>
+      </div>
+
+      <div class="body">
+        <slot name="before" v-bind="slotProps" />
+
+        <template v-if="mode === 'view' && record">
+          <div class="sheet-rows">
+            <LensSheetField
+              v-for="entry in detailFields"
+              :key="entry.key"
+              :field="entry.field"
+              :field-key="entry.key"
+              :record
+            />
+          </div>
+        </template>
+
+        <template v-else-if="mode === 'create'">
+          <div class="create-form">
+            <component
+              :is="view.component"
+              v-for="view in createFieldViews"
+              :key="view.key"
+              v-model="createModel[view.key]"
+              :validation="validation[view.key]"
+            />
+          </div>
+        </template>
+
+        <slot name="after" v-bind="slotProps" />
+      </div>
+
+      <div class="footer">
+        <template v-if="mode === 'create'">
+          <SButton size="medium" :label="t.cancel" :disabled="saving" @click="emit('close')" />
+          <SButton size="medium" mode="info" :label="t.create" :loading="saving" @click="onCreate" />
+        </template>
+        <template v-else-if="record">
+          <SButton size="medium" mode="danger" type="outline" :icon="IconTrash" :label="t.delete" :loading="saving" @click="onDelete" />
+        </template>
+      </div>
+    </div>
+  </SSheet>
+</template>
+
+<style scoped lang="postcss">
+.LensSheet {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: var(--c-bg-1);
+
+  /* Match the collaborator drawer: nested elevated controls sit on the
+     panel surface rather than a darker elevation. */
+  --c-bg-elv-2: var(--c-bg-1);
+  --c-bg-elv-3: var(--c-bg-1);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--c-divider);
+}
+
+.title {
+  font-size: 16px;
+  font-weight: 500;
+  font-feature-settings: "tnum";
+  color: var(--c-text-1);
+}
+
+.close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  color: var(--c-text-2);
+  transition: background-color 0.1s, color 0.1s;
+}
+
+.close:hover {
+  background-color: var(--c-bg-mute-1);
+  color: var(--c-text-1);
+}
+
+.close-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  flex-grow: 1;
+  padding: 16px 24px;
+  overflow-y: auto;
+}
+
+.sheet-rows {
+  border-top: 1px dashed var(--c-divider);
+}
+
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--c-divider);
+}
+</style>

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -193,6 +193,19 @@ function onDelete() {
   emit('close')
 }
 
+// Block closing while a create is in flight. The create POST is blocking and
+// slow; closing mid-save would dismiss the sheet while `creating` keeps the
+// catalog controls interactive (create isn't part of the busy lock), letting
+// the user submit a duplicate record or start an edit the create's follow-up
+// refresh could overwrite. The backdrop/Escape paths are gated via SSheet's
+// `closable` prop; this guards the explicit close button (and any stray emit).
+function requestClose() {
+  if (saving.value) {
+    return
+  }
+  emit('close')
+}
+
 // --- Slot context -----------------------------------------------------------
 //
 // Content passed to the `#before` / `#after` slots is declared in the page
@@ -221,11 +234,17 @@ const slotProps = computed(() => ({
 </script>
 
 <template>
-  <SSheet :open :width="width ?? '480px'" @close="emit('close')">
+  <SSheet :open :closable="!saving" :width="width ?? '480px'" @close="requestClose">
     <div class="LensSheet">
       <div class="header">
         <div class="title">{{ title }}</div>
-        <button class="close" type="button" aria-label="Close" @click="emit('close')">
+        <button
+          class="close"
+          type="button"
+          aria-label="Close"
+          :disabled="saving"
+          @click="requestClose"
+        >
           <IconX class="close-icon" />
         </button>
       </div>
@@ -268,7 +287,7 @@ const slotProps = computed(() => ({
 
       <div class="footer">
         <template v-if="mode === 'create'">
-          <SButton size="medium" :label="t.cancel" :disabled="saving" @click="emit('close')" />
+          <SButton size="medium" :label="t.cancel" :disabled="saving" @click="requestClose" />
           <SButton
             size="medium"
             mode="info"
@@ -333,9 +352,14 @@ const slotProps = computed(() => ({
   transition: background-color 0.1s, color 0.1s;
 }
 
-.close:hover {
+.close:hover:not(:disabled) {
   background-color: var(--c-bg-mute-1);
   color: var(--c-text-1);
+}
+
+.close:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .close-icon {

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -155,15 +155,19 @@ watch(
 )
 
 async function onCreate() {
-  serverErrors.value = {}
-
-  if (!(await validate())) {
+  // Guard re-entry: set `saving` before the first await so a fast double-click on
+  // Create can't start a second submission (and create a duplicate record) while
+  // the first call's validation is still pending.
+  if (saving.value) {
     return
   }
-
   saving.value = true
+  serverErrors.value = {}
 
   try {
+    if (!(await validate())) {
+      return
+    }
     const values: Record<string, any> = {}
     for (const { key, field } of createInputViews.value) {
       values[key] = field.inputToPayload(createModel[key])

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -6,10 +6,12 @@ import SButton from '../../../components/SButton.vue'
 import SSheet from '../../../components/SSheet.vue'
 import { provideDataListState } from '../../../composables/DataList'
 import { useTrans } from '../../../composables/Lang'
+import { usePower } from '../../../composables/Power'
 import { useValidation } from '../../../composables/Validation'
 import { type FieldData } from '../FieldData'
 import { useFieldFactory } from '../composables/FieldFactory'
 import { useLensEdit } from '../composables/LensEdit'
+import { extractServerErrors } from '../validation/ServerErrors'
 import LensSheetField from './LensSheetField.vue'
 
 const props = withDefaults(defineProps<{
@@ -30,8 +32,20 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useTrans({
-  en: { create: 'Create', cancel: 'Cancel', delete: 'Delete', new_record: 'New record', deleting: 'Deleting…' },
-  ja: { create: '作成', cancel: 'キャンセル', delete: '削除', new_record: '新規作成', deleting: '削除中…' }
+  en: {
+    create: 'Create',
+    cancel: 'Cancel',
+    delete: 'Delete',
+    confirm_delete: 'Delete this record?',
+    new_record: 'New record'
+  },
+  ja: {
+    create: '作成',
+    cancel: 'キャンセル',
+    delete: '削除',
+    confirm_delete: 'このレコードを削除しますか？',
+    new_record: '新規作成'
+  }
 })
 
 const edit = useLensEdit()
@@ -57,12 +71,31 @@ const createFields = computed(() => entries.value.filter((e) => e.fieldData.show
 // `formInputComponent()` inline in the template would mint a brand-new
 // component definition on every render, which breaks Vue's component patching
 // (`instance.update is not a function`).
+//
+// Some field types don't implement a form input (they `throw new
+// Error('Not implemented.')`); resolve defensively and drop those from the
+// form rather than letting one unsupported field crash the create sheet.
 const createFieldViews = computed(() =>
-  createFields.value.map((e) => ({
-    key: e.key,
-    component: e.field.formInputComponent()
-  }))
+  createFields.value
+    .map((e) => ({ key: e.key, field: e.field, component: resolveInput(e.field) }))
+    .filter((v) => v.component != null)
 )
+
+// The subset of create views that actually contribute a value. Display-only
+// fields (e.g. a `content` field showing instructions) still render, but
+// `formInputComponent()` returns static markup with no value, so they must not
+// be seeded, validated, or submitted.
+const createInputViews = computed(() =>
+  createFieldViews.value.filter((v) => v.field.isSubmittable())
+)
+
+function resolveInput(field: { formInputComponent: () => any }): any {
+  try {
+    return field.formInputComponent()
+  } catch {
+    return null
+  }
+}
 
 const title = computed(() => {
   if (props.mode === 'create') {
@@ -77,18 +110,31 @@ const title = computed(() => {
 const createModel = reactive<Record<string, any>>({})
 const saving = ref(false)
 
+// Backend-only validation errors (e.g. `unique`) returned by a rejected
+// create, fed to Vuelidate via `$externalResults` so they surface on the
+// offending field. The create form's keys are the bare field keys, matching
+// the 422 error keys 1:1.
+const serverErrors = ref<Record<string, string[]>>({})
+
 const { validation, validate, reset } = useValidation(
   () => createModel,
-  () => Object.fromEntries(createFields.value.map((e) => [e.key, e.field.generateValidationRules()]))
+  () => Object.fromEntries(createInputViews.value.map((e) => [e.key, e.field.generateValidationRules()])),
+  { $externalResults: serverErrors }
 )
 
+const confirmingDelete = usePower()
+
 watch(
-  () => [props.open, props.mode] as const,
+  () => [props.open, props.mode, props.record] as const,
   ([open, mode]) => {
+    // Reset the delete confirmation whenever the sheet opens, switches mode, or
+    // is reused for a different record.
+    confirmingDelete.off()
     if (open && mode === 'create') {
-      for (const { key, field } of createFields.value) {
+      for (const { key, field } of createInputViews.value) {
         createModel[key] = field.inputEmptyValue()
       }
+      serverErrors.value = {}
       reset()
     }
   },
@@ -96,6 +142,8 @@ watch(
 )
 
 async function onCreate() {
+  serverErrors.value = {}
+
   if (!(await validate())) {
     return
   }
@@ -104,27 +152,32 @@ async function onCreate() {
 
   try {
     const values: Record<string, any> = {}
-    for (const { key, field } of createFields.value) {
+    for (const { key, field } of createInputViews.value) {
       values[key] = field.inputToPayload(createModel[key])
     }
     await edit!.create(values)
     emit('close')
+  } catch (e) {
+    // Surface backend validation errors (e.g. a duplicate `unique` value) on
+    // the offending fields; rethrow anything that isn't a 422.
+    const errors = extractServerErrors(e)
+    if (!errors) {
+      throw e
+    }
+    serverErrors.value = errors
   } finally {
     saving.value = false
   }
 }
 
-async function onDelete() {
+function onDelete() {
   if (!props.record) {
     return
   }
-  saving.value = true
-  try {
-    await edit!.remove(props.record)
-    emit('close')
-  } finally {
-    saving.value = false
-  }
+  // Optimistic: the row is removed immediately and the delete is persisted in
+  // the background, so close right away.
+  edit!.remove(props.record)
+  emit('close')
 }
 
 // --- Slot context -----------------------------------------------------------
@@ -137,15 +190,13 @@ async function onDelete() {
 // one-off concerns (avatar upload, social links, linked records) while still
 // letting a page implement them.
 
-const resolvedId = computed(() =>
-  props.record && edit ? edit.resolveId(props.record) : null
-)
+const resolvedId = computed(() => (props.record && edit ? edit.resolveId(props.record) : null))
 
 function saveRecord(values: Record<string, any>): Promise<void> {
-  if (!props.record || !edit) {
-    return Promise.resolve()
+  if (props.record && edit) {
+    edit.save(props.record, values)
   }
-  return edit.save(props.record, values)
+  return Promise.resolve()
 }
 
 const slotProps = computed(() => ({
@@ -199,10 +250,29 @@ const slotProps = computed(() => ({
       <div class="footer">
         <template v-if="mode === 'create'">
           <SButton size="medium" :label="t.cancel" :disabled="saving" @click="emit('close')" />
-          <SButton size="medium" mode="info" :label="t.create" :loading="saving" @click="onCreate" />
+          <SButton
+            size="medium"
+            mode="info"
+            :label="t.create"
+            :loading="saving"
+            @click="onCreate"
+          />
         </template>
         <template v-else-if="record">
-          <SButton size="medium" mode="danger" type="outline" :icon="IconTrash" :label="t.delete" :loading="saving" @click="onDelete" />
+          <template v-if="confirmingDelete.state.value">
+            <span class="confirm-text">{{ t.confirm_delete }}</span>
+            <SButton size="medium" :label="t.cancel" @click="confirmingDelete.off" />
+            <SButton size="medium" mode="danger" :label="t.delete" @click="onDelete" />
+          </template>
+          <SButton
+            v-else
+            size="medium"
+            mode="danger"
+            type="outline"
+            :icon="IconTrash"
+            :label="t.delete"
+            @click="confirmingDelete.on"
+          />
         </template>
       </div>
     </div>
@@ -280,5 +350,11 @@ const slotProps = computed(() => ({
   gap: 8px;
   padding: 16px 24px;
   border-top: 1px solid var(--c-divider);
+}
+
+.confirm-text {
+  margin-right: auto;
+  font-size: 13px;
+  color: var(--c-text-2);
 }
 </style>

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -137,12 +137,20 @@ const { validation, validate, reset } = useValidation(
 
 const confirmingDelete = usePower()
 
+// Latch for the confirmed delete (see onDelete). Reset only when the sheet
+// (re)opens — not on close — so a double-click during the close transition stays
+// blocked.
+const deleting = ref(false)
+
 watch(
   () => [props.open, props.mode, props.record] as const,
   ([open, mode]) => {
     // Reset the delete confirmation whenever the sheet opens, switches mode, or
     // is reused for a different record.
     confirmingDelete.off()
+    if (open) {
+      deleting.value = false
+    }
     if (open && mode === 'create') {
       for (const { key, field } of createInputViews.value) {
         createModel[key] = field.inputEmptyValue()
@@ -188,9 +196,14 @@ async function onCreate() {
 }
 
 function onDelete() {
-  if (!props.record) {
+  // Latch so a fast double-click — before the sheet's leave transition unmounts
+  // the panel — can't run twice and queue a second DELETE for the same record (a
+  // non-idempotent backend would then show a failure snackbar after the first
+  // delete already succeeded). Reset when the sheet next opens.
+  if (!props.record || deleting.value) {
     return
   }
+  deleting.value = true
   // Optimistic: the row is removed immediately and the delete is persisted in
   // the background, so close right away.
   edit!.remove(props.record)

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -121,6 +121,11 @@ const title = computed(() => {
 const createModel = reactive<Record<string, any>>({})
 const saving = ref(false)
 
+// Whether creation is currently permitted. Reactive (a getter on the injected
+// edit context) so the Create button disables if `creatable` flips off after the
+// sheet opened; `onCreate` re-checks it too.
+const creatable = computed(() => !!edit?.creatable)
+
 // Backend-only validation errors (e.g. `unique`) returned by a rejected
 // create, fed to Vuelidate via `$externalResults` so they surface on the
 // offending field. The create form's keys are the bare field keys, matching
@@ -167,6 +172,15 @@ async function onCreate() {
   // Create can't start a second submission (and create a duplicate record) while
   // the first call's validation is still pending.
   if (saving.value) {
+    return
+  }
+  // Re-check creation is still permitted: `openCreate()`'s guard runs once, so if
+  // `creatable` flipped off after the sheet opened (async permission change, a
+  // parent disabling creation), the context no longer allows it. Close instead of
+  // POSTing a create the server would reject anyway. The Create button is also
+  // disabled in this state; this guards a flip between render and click.
+  if (!edit?.creatable) {
+    emit('close')
     return
   }
   saving.value = true
@@ -320,6 +334,7 @@ const slotProps = computed(() => ({
             mode="info"
             :label="t.create"
             :loading="saving"
+            :disabled="!creatable"
             @click="onCreate"
           />
         </template>

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -4,6 +4,7 @@ import IconX from '~icons/ph/x'
 import { computed, reactive, ref, watch } from 'vue'
 import SButton from '../../../components/SButton.vue'
 import SSheet from '../../../components/SSheet.vue'
+import SSpinner from '../../../components/SSpinner.vue'
 import { provideDataListState } from '../../../composables/DataList'
 import { useTrans } from '../../../composables/Lang'
 import { usePower } from '../../../composables/Power'
@@ -19,6 +20,12 @@ const props = withDefaults(defineProps<{
   mode?: 'view' | 'create'
   entity: string
   record?: Record<string, any> | null
+  // Whether the record's full detail is still loading via `/show`. While true,
+  // the view body shows a spinner instead of partial fields.
+  loading?: boolean
+  // Whether the detail load failed. When true, the view body shows an error
+  // (asking the user to reload) instead of a partial record.
+  error?: boolean
   fields: Record<string, FieldData>
   indexField?: string
   width?: string
@@ -37,14 +44,18 @@ const { t } = useTrans({
     cancel: 'Cancel',
     delete: 'Delete',
     confirm_delete: 'Delete this record?',
-    new_record: 'New record'
+    new_record: 'New record',
+    load_error:
+      'Couldn’t load this record. Please reload the page, and contact support if the problem persists.'
   },
   ja: {
     create: '作成',
     cancel: 'キャンセル',
     delete: '削除',
     confirm_delete: 'このレコードを削除しますか？',
-    new_record: '新規作成'
+    new_record: '新規作成',
+    load_error:
+      'このレコードを読み込めませんでした。ページを再読み込みし、問題が解決しない場合はサポートにお問い合わせください。'
   }
 })
 
@@ -223,7 +234,13 @@ const slotProps = computed(() => ({
         <slot name="before" v-bind="slotProps" />
 
         <template v-if="mode === 'view' && record">
-          <div class="sheet-rows">
+          <div v-if="loading" class="sheet-loading">
+            <SSpinner class="sheet-loading-spinner" />
+          </div>
+          <div v-else-if="error" class="sheet-error">
+            {{ t.load_error }}
+          </div>
+          <div v-else class="sheet-rows">
             <LensSheetField
               v-for="entry in detailFields"
               :key="entry.key"
@@ -260,7 +277,7 @@ const slotProps = computed(() => ({
             @click="onCreate"
           />
         </template>
-        <template v-else-if="record">
+        <template v-else-if="record && !loading && !error">
           <template v-if="confirmingDelete.state.value">
             <span class="confirm-text">{{ t.confirm_delete }}</span>
             <SButton size="medium" :label="t.cancel" @click="confirmingDelete.off" />
@@ -337,6 +354,26 @@ const slotProps = computed(() => ({
 
 .sheet-rows {
   border-top: 1px dashed var(--c-divider);
+}
+
+.sheet-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 0;
+}
+
+.sheet-loading-spinner {
+  width: 28px;
+  height: 28px;
+  color: var(--c-text-2);
+}
+
+.sheet-error {
+  padding: 24px 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--c-text-2);
 }
 
 .create-form {

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -133,14 +133,13 @@ async function apply() {
 
 .edit {
   position: absolute;
-  top: 50%;
+  top: 10px;
   right: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 28px;
   height: 28px;
-  transform: translateY(-50%);
   border-radius: 6px;
   color: var(--c-text-2);
   opacity: 0;

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -59,7 +59,9 @@ const displayValue = computed(() => {
 
 // Display-only fields (e.g. `content`) resolve an input component but render
 // static markup with no value, so they must not gain an edit affordance.
-const canEdit = computed(() => editable.value && !!inputComponent.value && props.field.isSubmittable())
+const canEdit = computed(() =>
+  editable.value && !!inputComponent.value && props.field.isSubmittable()
+)
 
 const editing = ref(false)
 const model = ref<any>(null)

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -60,7 +60,13 @@ const displayValue = computed(() => {
 // Display-only fields (e.g. `content`) resolve an input component but render
 // static markup with no value, so they must not gain an edit affordance.
 const canEdit = computed(() =>
-  editable.value && !!inputComponent.value && props.field.isSubmittable()
+  editable.value
+  && !!inputComponent.value
+  && props.field.isSubmittable()
+  // Not until the field's value is actually loaded into the record. A
+  // detail-only field (not a table column) opens before `/show` populates it;
+  // editing the empty placeholder would post null/[] over the real value.
+  && (props.fieldKey in props.record)
 )
 
 const editing = ref(false)

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import IconPencilSimple from '~icons/ph/pencil-simple'
-import { computed, ref, shallowRef } from 'vue'
+import { computed, ref } from 'vue'
 import SButton from '../../../components/SButton.vue'
 import SDataListItem from '../../../components/SDataListItem.vue'
+import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
@@ -14,6 +15,11 @@ const props = defineProps<{
   record: Record<string, any>
 }>()
 
+const { t } = useTrans({
+  en: { cancel: 'Cancel', apply: 'Apply', edit: 'Edit' },
+  ja: { cancel: 'キャンセル', apply: '適用', edit: '編集' }
+})
+
 const edit = useLensEdit()
 
 const editable = computed(() => !!edit && (props.field as any).data?.showOnUpdate === true)
@@ -22,8 +28,11 @@ const editable = computed(() => !!edit && (props.field as any).data?.showOnUpdat
 // (they `throw new Error('Not implemented.')`). Resolve them defensively so a
 // single unimplemented field never breaks the whole sheet — fall back to a
 // plain label/value row for display, and simply omit the edit affordance.
-const displayComponent = shallowRef(resolve(() => props.field.dataListItemComponent()))
-const inputComponent = shallowRef(resolve(() => props.field.formInputComponent()))
+//
+// Computed off `props.field` so they recompute when the field instance changes
+// (e.g. a refresh swaps in new field metadata for an already-rendered key).
+const displayComponent = computed(() => resolve(() => props.field.dataListItemComponent()))
+const inputComponent = computed(() => resolve(() => props.field.formInputComponent()))
 
 function resolve(fn: () => any): any {
   try {
@@ -48,10 +57,11 @@ const displayValue = computed(() => {
   return String(v)
 })
 
-const canEdit = computed(() => editable.value && !!inputComponent.value)
+// Display-only fields (e.g. `content`) resolve an input component but render
+// static markup with no value, so they must not gain an edit affordance.
+const canEdit = computed(() => editable.value && !!inputComponent.value && props.field.isSubmittable())
 
 const editing = ref(false)
-const saving = ref(false)
 const model = ref<any>(null)
 
 const { validation, validate, reset } = useValidation(
@@ -71,20 +81,18 @@ function cancel() {
 }
 
 async function apply() {
+  // Client-side validation only (required, length, …). Server-only rules such
+  // as `unique` are enforced by the background write, which surfaces a snackbar
+  // on rejection.
   if (!(await validate())) {
     return
   }
 
-  saving.value = true
-
-  try {
-    await edit!.save(props.record, {
-      [props.fieldKey]: props.field.inputToPayload(model.value)
-    })
-    editing.value = false
-  } finally {
-    saving.value = false
-  }
+  // Optimistic: patch + persist in the background, then close immediately.
+  edit!.save(props.record, {
+    [props.fieldKey]: props.field.inputToPayload(model.value)
+  })
+  editing.value = false
 }
 </script>
 
@@ -100,7 +108,7 @@ async function apply() {
         v-if="canEdit"
         class="edit"
         type="button"
-        :aria-label="`Edit ${field.label()}`"
+        :aria-label="`${t.edit} ${field.label()}`"
         @click="start"
       >
         <IconPencilSimple class="edit-icon" />
@@ -110,8 +118,8 @@ async function apply() {
     <div v-else class="form">
       <component :is="inputComponent" v-model="model" :validation="validation.input" />
       <div class="actions">
-        <SButton size="mini" label="Cancel" :disabled="saving" @click="cancel" />
-        <SButton size="mini" mode="info" label="Apply" :loading="saving" @click="apply" />
+        <SButton size="mini" :label="t.cancel" @click="cancel" />
+        <SButton size="mini" mode="info" :label="t.apply" @click="apply" />
       </div>
     </div>
   </div>

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -60,7 +60,10 @@ const displayValue = computed(() => {
 // Display-only fields (e.g. `content`) resolve an input component but render
 // static markup with no value, so they must not gain an edit affordance.
 const canEdit = computed(() =>
-  editable.value && !!inputComponent.value && props.field.isSubmittable()
+  editable.value
+  && !!inputComponent.value
+  && props.field.isSubmittable()
+  && props.field.supportsOptimisticUpdate()
 )
 
 const editing = ref(false)

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -1,0 +1,170 @@
+<script setup lang="ts">
+import IconPencilSimple from '~icons/ph/pencil-simple'
+import { computed, ref, shallowRef } from 'vue'
+import SButton from '../../../components/SButton.vue'
+import SDataListItem from '../../../components/SDataListItem.vue'
+import { useValidation } from '../../../composables/Validation'
+import { type FieldData } from '../FieldData'
+import { useLensEdit } from '../composables/LensEdit'
+import { type Field } from '../fields/Field'
+
+const props = defineProps<{
+  field: Field<FieldData>
+  fieldKey: string
+  record: Record<string, any>
+}>()
+
+const edit = useLensEdit()
+
+const editable = computed(() => !!edit && (props.field as any).data?.showOnUpdate === true)
+
+// Some field types do not implement a detail renderer or an editable input
+// (they `throw new Error('Not implemented.')`). Resolve them defensively so a
+// single unimplemented field never breaks the whole sheet — fall back to a
+// plain label/value row for display, and simply omit the edit affordance.
+const displayComponent = shallowRef(resolve(() => props.field.dataListItemComponent()))
+const inputComponent = shallowRef(resolve(() => props.field.formInputComponent()))
+
+function resolve(fn: () => any): any {
+  try {
+    return fn()
+  } catch {
+    return null
+  }
+}
+
+// Fallback display value for fields without a `dataListItemComponent`.
+const displayValue = computed(() => {
+  const v = props.record[props.fieldKey]
+  if (v == null) {
+    return null
+  }
+  if (Array.isArray(v)) {
+    return v.join(', ')
+  }
+  if (typeof v === 'object') {
+    return v.display ?? v.value ?? JSON.stringify(v)
+  }
+  return String(v)
+})
+
+const canEdit = computed(() => editable.value && !!inputComponent.value)
+
+const editing = ref(false)
+const saving = ref(false)
+const model = ref<any>(null)
+
+const { validation, validate, reset } = useValidation(
+  () => ({ input: model.value }),
+  () => ({ input: props.field.generateValidationRules() })
+)
+
+function start() {
+  const raw = props.record[props.fieldKey]
+  model.value = props.field.payloadToInput(raw ?? props.field.inputEmptyValue())
+  reset()
+  editing.value = true
+}
+
+function cancel() {
+  editing.value = false
+}
+
+async function apply() {
+  if (!(await validate())) {
+    return
+  }
+
+  saving.value = true
+
+  try {
+    await edit!.save(props.record, {
+      [props.fieldKey]: props.field.inputToPayload(model.value)
+    })
+    editing.value = false
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="LensSheetField" :class="{ editing }">
+    <div v-if="!editing" class="display">
+      <component :is="displayComponent" v-if="displayComponent" :value="record[fieldKey]" />
+      <SDataListItem v-else>
+        <template #label>{{ field.label() }}</template>
+        <template v-if="displayValue !== null" #value>{{ displayValue }}</template>
+      </SDataListItem>
+      <button
+        v-if="canEdit"
+        class="edit"
+        type="button"
+        :aria-label="`Edit ${field.label()}`"
+        @click="start"
+      >
+        <IconPencilSimple class="edit-icon" />
+      </button>
+    </div>
+
+    <div v-else class="form">
+      <component :is="inputComponent" v-model="model" :validation="validation.input" />
+      <div class="actions">
+        <SButton size="mini" label="Cancel" :disabled="saving" @click="cancel" />
+        <SButton size="mini" mode="info" label="Apply" :loading="saving" @click="apply" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.LensSheetField {
+  position: relative;
+  border-bottom: 1px dashed var(--c-divider);
+}
+
+.form {
+  padding: 8px 0;
+}
+
+.display {
+  position: relative;
+}
+
+.edit {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  transform: translateY(-50%);
+  border-radius: 6px;
+  color: var(--c-text-2);
+  opacity: 0;
+  transition: opacity 0.1s, background-color 0.1s, color 0.1s;
+}
+
+.LensSheetField:hover .edit {
+  opacity: 1;
+}
+
+.edit:hover {
+  background-color: var(--c-bg-mute-1);
+  color: var(--c-text-1);
+}
+
+.edit-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+</style>

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import IconPencilSimple from '~icons/ph/pencil-simple'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import SButton from '../../../components/SButton.vue'
 import SDataListItem from '../../../components/SDataListItem.vue'
 import { useTrans } from '../../../composables/Lang'
@@ -73,6 +73,18 @@ const canEdit = computed(() =>
 const editing = ref(false)
 const model = ref<any>(null)
 
+// If the backing record is replaced/rebound while this editor is open (the
+// refresh banner, a parent `refresh()`, or a `/show` merge filling detail keys),
+// the `model` captured in `start()` is stale; applying it would overwrite the
+// freshly bound value. Close the editor so the user re-opens against the current
+// value. Our own optimistic save also mutates this value, but `apply()` sets
+// `editing = false` synchronously right after, so this async watcher sees it
+// already closed; user typing only touches the local `model`, never the record.
+watch(
+  () => props.record[props.fieldKey],
+  () => { if (editing.value) { editing.value = false } }
+)
+
 const { validation, validate, reset } = useValidation(
   () => ({ input: model.value }),
   () => ({ input: props.field.generateValidationRules() })
@@ -90,10 +102,22 @@ function cancel() {
 }
 
 async function apply() {
+  // Snapshot the value we're editing so we can detect the backing record being
+  // rebound out from under us during validation (checked below).
+  const editedValue = props.record[props.fieldKey]
+
   // Client-side validation only (required, length, …). Server-only rules such
   // as `unique` are enforced by the background write, which surfaces a snackbar
   // on rejection.
   if (!(await validate())) {
+    return
+  }
+
+  // A refresh / rebind can swap the backing record during the validate microtask;
+  // the watcher above closes the editor but flushes asynchronously and can't abort
+  // this already-running apply, so re-check against the snapshot. If the value
+  // changed, `model` is stale — bail rather than overwrite the fresh value.
+  if (props.record[props.fieldKey] !== editedValue) {
     return
   }
 

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -60,13 +60,7 @@ const displayValue = computed(() => {
 // Display-only fields (e.g. `content`) resolve an input component but render
 // static markup with no value, so they must not gain an edit affordance.
 const canEdit = computed(() =>
-  editable.value
-  && !!inputComponent.value
-  && props.field.isSubmittable()
-  // Not until the field's value is actually loaded into the record. A
-  // detail-only field (not a table column) opens before `/show` populates it;
-  // editing the empty placeholder would post null/[] over the real value.
-  && (props.fieldKey in props.record)
+  editable.value && !!inputComponent.value && props.field.isSubmittable()
 )
 
 const editing = ref(false)

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -58,10 +58,14 @@ const displayValue = computed(() => {
 })
 
 // Display-only fields (e.g. `content`) resolve an input component but render
-// static markup with no value, so they must not gain an edit affordance.
+// static markup with no value, so they must not gain an edit affordance. The
+// row-identifier (`indexField`) is also never editable: optimistically changing
+// the id before the write settles would re-key the row, so a follow-up save /
+// delete would address the not-yet-synced new id instead of the in-flight one.
 const canEdit = computed(() =>
   editable.value
   && !!inputComponent.value
+  && props.fieldKey !== edit?.indexField
   && props.field.isSubmittable()
   && props.field.supportsOptimisticUpdate()
 )

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -186,7 +186,11 @@ const table = useTable({
   records,
   orders,
   columns,
-  indexField: props.indexField,
+  // A getter (not a snapshot) so the selection key stays reactive: `indexField`
+  // can change after mount — e.g. an editable catalog resolves permissions async
+  // and flips from positional keys to `id`. STable reads this inside a computed,
+  // so the getter establishes the dependency and selection re-keys correctly.
+  get indexField() { return props.indexField },
   borderless: true
 })
 

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -120,13 +120,13 @@ const columns = computedAsync(async () => {
 
     const column = field.tableColumn()
 
-    // When editing is enabled, clicking the row-identifier id cell opens the
-    // record sheet (view + per-field edit + delete) instead of following a
-    // link. Restrict this to the configured index field so other id-type
-    // columns (e.g. a `company_id` reference link) keep their own navigation.
+    // When editing is enabled, clicking the row-identifier cell opens the record
+    // sheet (view + per-field edit + delete) instead of following a link. Keyed
+    // off the configured index field for any field type — a slug/code identifier
+    // opens the sheet just like an `id` — so other id-type columns (e.g. a
+    // `company_id` reference link) keep their own navigation.
     if (
       edit?.editable
-      && overriddenFieldData.type === 'id'
       && key === edit.indexField
     ) {
       const original = column.cell

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -124,7 +124,11 @@ const columns = computedAsync(async () => {
     // record sheet (view + per-field edit + delete) instead of following a
     // link. Restrict this to the configured index field so other id-type
     // columns (e.g. a `company_id` reference link) keep their own navigation.
-    if (edit?.editable && overriddenFieldData.type === 'id' && key === edit.indexField) {
+    if (
+      edit?.editable
+      && overriddenFieldData.type === 'id'
+      && key === edit.indexField
+    ) {
       const original = column.cell
       column.cell = (v: any, r: any): TableCell<any, any> => {
         const cell = typeof original === 'function' ? original(v, r) : original
@@ -135,7 +139,13 @@ const columns = computedAsync(async () => {
           onClick: () => edit.openSheet(r)
         } as TableCell<any, any>
       }
-    } else if (props.inlineEdit && edit?.editable && overriddenFieldData.showOnUpdate === true && field.isSubmittable() && hasFormInput(field)) {
+    } else if (
+      props.inlineEdit
+      && edit?.editable
+      && overriddenFieldData.showOnUpdate === true
+      && field.isSubmittable()
+      && hasFormInput(field)
+    ) {
       // Editable fields render a custom cell with a hover edit affordance
       // that opens an inline editor (reusing the field's form input + the
       // edit context's save). Sort/filter menus on the column are kept.
@@ -205,7 +215,10 @@ function hasFormInput(field: Field<FieldData>): boolean {
 </script>
 
 <template>
-  <div class="LensTable" :class="{ 'is-loading': loading, 'is-empty': (result?.data.length ?? 0) === 0 }">
+  <div
+    class="LensTable"
+    :class="{ 'is-loading': loading, 'is-empty': (result?.data.length ?? 0) === 0 }"
+  >
     <STable
       v-if="Object.keys(columns).length > 0"
       class="table"

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computedAsync } from '@vueuse/core'
 import { cloneDeep } from 'lodash-es'
-import { computed } from 'vue'
+import { computed, markRaw } from 'vue'
 import STable from '../../../components/STable.vue'
 import { type DropdownSection } from '../../../composables/Dropdown'
 import { type TableCell, type TableColumns, useTable } from '../../../composables/Table'
@@ -10,6 +10,8 @@ import { type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
 import { useFieldFactory } from '../composables/FieldFactory'
 import { useLensEdit } from '../composables/LensEdit'
+import { provideLensInlineEdit } from '../composables/LensInlineEdit'
+import LensTableEditableCell from './LensTableEditableCell.vue'
 
 const props = defineProps<{
   result?: LensResult
@@ -22,6 +24,9 @@ const props = defineProps<{
   select?: string[]
   selected?: any[]
   indexField?: string
+  // When set (and editing is enabled), cells for `showOnUpdate` fields
+  // render a hover edit affordance that opens an inline editor.
+  inlineEdit?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -33,6 +38,11 @@ const emit = defineEmits<{
 
 const fieldFactory = useFieldFactory()
 const edit = useLensEdit()
+
+// Track which cell's inline editor is open so opening one closes any other.
+provideLensInlineEdit()
+
+const editableCellComponent = markRaw(LensTableEditableCell)
 
 const records = computed(() => props.result?.data ?? [])
 
@@ -121,6 +131,15 @@ const columns = computedAsync(async () => {
           color: 'info',
           onClick: () => edit.openSheet(r)
         } as TableCell<any, any>
+      }
+    } else if (props.inlineEdit && edit?.editable && overriddenFieldData.showOnUpdate === true) {
+      // Editable fields render a custom cell with a hover edit affordance
+      // that opens an inline editor (reusing the field's form input + the
+      // edit context's save). Sort/filter menus on the column are kept.
+      column.cell = {
+        type: 'component',
+        component: editableCellComponent,
+        props: { field, fieldKey: key }
       }
     }
 

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -4,11 +4,12 @@ import { cloneDeep } from 'lodash-es'
 import { computed } from 'vue'
 import STable from '../../../components/STable.vue'
 import { type DropdownSection } from '../../../composables/Dropdown'
-import { type TableColumns, useTable } from '../../../composables/Table'
+import { type TableCell, type TableColumns, useTable } from '../../../composables/Table'
 import { type FieldData } from '../FieldData'
 import { type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
 import { useFieldFactory } from '../composables/FieldFactory'
+import { useLensEdit } from '../composables/LensEdit'
 
 const props = defineProps<{
   result?: LensResult
@@ -31,6 +32,7 @@ const emit = defineEmits<{
 }>()
 
 const fieldFactory = useFieldFactory()
+const edit = useLensEdit()
 
 const records = computed(() => props.result?.data ?? [])
 
@@ -105,7 +107,24 @@ const columns = computedAsync(async () => {
 
     const field = fieldFactory.make(overriddenFieldData)
 
-    columns[key] = field.tableColumn()
+    const column = field.tableColumn()
+
+    // When editing is enabled, clicking a row's id cell opens the record
+    // sheet (view + per-field edit + delete) instead of following a link.
+    if (edit?.editable && overriddenFieldData.type === 'id') {
+      const original = column.cell
+      column.cell = (v: any, r: any): TableCell<any, any> => {
+        const cell = typeof original === 'function' ? original(v, r) : original
+        return {
+          ...(cell as TableCell<any, any>),
+          link: null,
+          color: 'info',
+          onClick: () => edit.openSheet(r)
+        } as TableCell<any, any>
+      }
+    }
+
+    columns[key] = column
 
     const dropdown: DropdownSection[] = []
 

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -144,6 +144,7 @@ const columns = computedAsync(async () => {
       && edit?.editable
       && overriddenFieldData.showOnUpdate === true
       && field.isSubmittable()
+      && field.supportsOptimisticUpdate()
       && hasFormInput(field)
     ) {
       // Editable fields render a custom cell with a hover edit affordance

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -142,6 +142,7 @@ const columns = computedAsync(async () => {
     } else if (
       props.inlineEdit
       && edit?.editable
+      && key !== edit.indexField
       && overriddenFieldData.showOnUpdate === true
       && field.isSubmittable()
       && field.supportsOptimisticUpdate()

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -11,6 +11,7 @@ import { type LensResult } from '../LensResult'
 import { useFieldFactory } from '../composables/FieldFactory'
 import { useLensEdit } from '../composables/LensEdit'
 import { provideLensInlineEdit } from '../composables/LensInlineEdit'
+import { type Field } from '../fields/Field'
 import LensTableEditableCell from './LensTableEditableCell.vue'
 
 const props = defineProps<{
@@ -119,9 +120,11 @@ const columns = computedAsync(async () => {
 
     const column = field.tableColumn()
 
-    // When editing is enabled, clicking a row's id cell opens the record
-    // sheet (view + per-field edit + delete) instead of following a link.
-    if (edit?.editable && overriddenFieldData.type === 'id') {
+    // When editing is enabled, clicking the row-identifier id cell opens the
+    // record sheet (view + per-field edit + delete) instead of following a
+    // link. Restrict this to the configured index field so other id-type
+    // columns (e.g. a `company_id` reference link) keep their own navigation.
+    if (edit?.editable && overriddenFieldData.type === 'id' && key === edit.indexField) {
       const original = column.cell
       column.cell = (v: any, r: any): TableCell<any, any> => {
         const cell = typeof original === 'function' ? original(v, r) : original
@@ -132,10 +135,11 @@ const columns = computedAsync(async () => {
           onClick: () => edit.openSheet(r)
         } as TableCell<any, any>
       }
-    } else if (props.inlineEdit && edit?.editable && overriddenFieldData.showOnUpdate === true) {
+    } else if (props.inlineEdit && edit?.editable && overriddenFieldData.showOnUpdate === true && field.isSubmittable() && hasFormInput(field)) {
       // Editable fields render a custom cell with a hover edit affordance
       // that opens an inline editor (reusing the field's form input + the
       // edit context's save). Sort/filter menus on the column are kept.
+      // Fields without a real input (or display-only ones) stay read-only.
       column.cell = {
         type: 'component',
         component: editableCellComponent,
@@ -184,6 +188,19 @@ function onFilterUpdated(filter: any[]) {
 
 function onSortUpdated(sort: LensQuerySort) {
   emit('sort-updated', sort)
+}
+
+// Some field types do not implement a form input (they `throw new
+// Error('Not implemented.')`). Only upgrade a cell to the inline editor when
+// the field actually has an input component, otherwise leave it read-only so a
+// backend that marks such a field `showOnUpdate` renders a plain cell instead
+// of a pencil that crashes on click.
+function hasFormInput(field: Field<FieldData>): boolean {
+  try {
+    return !!field.formInputComponent()
+  } catch {
+    return false
+  }
 }
 </script>
 

--- a/lib/blocks/lens/components/LensTableEditableCell.vue
+++ b/lib/blocks/lens/components/LensTableEditableCell.vue
@@ -168,7 +168,12 @@ function isTextLikeInput(target: EventTarget | null): boolean {
     </button>
 
     <Teleport v-if="editing && inputComponent" to="#sefirot-modals">
-      <div ref="editorEl" class="LensTableEditableCellEditor" :style="editorStyle" @keydown="onEditorKeydown">
+      <div
+        ref="editorEl"
+        class="LensTableEditableCellEditor"
+        :style="editorStyle"
+        @keydown="onEditorKeydown"
+      >
         <component :is="inputComponent" v-model="model" :validation="validation.input" />
         <div class="actions">
           <SButton size="mini" :label="t.cancel" @click="cancel" />

--- a/lib/blocks/lens/components/LensTableEditableCell.vue
+++ b/lib/blocks/lens/components/LensTableEditableCell.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import IconPencilSimple from '~icons/ph/pencil-simple'
 import { useElementBounding } from '@vueuse/core'
-import { computed, nextTick, onUnmounted, ref, shallowRef } from 'vue'
+import { computed, nextTick, onUnmounted, ref, shallowRef, watch } from 'vue'
 import SButton from '../../../components/SButton.vue'
 import { useManualDropdownPosition } from '../../../composables/Dropdown'
 import { useTrans } from '../../../composables/Lang'
@@ -28,6 +28,19 @@ const inline = useLensInlineEdit()
 
 const myKey = computed(() => `${edit?.resolveId(props.record)}:${props.fieldKey}`)
 const editing = computed(() => inline?.activeKey.value === myKey.value)
+
+// If the backing value is replaced while this editor is open — a refresh banner
+// apply, a parent `refresh()`, or a requery that keeps this row visible — the
+// `model` captured back in `start()` is now stale, and saving it would overwrite
+// the freshly fetched cell. Close the editor so the user re-opens against the
+// current value. Our own optimistic save also mutates `props.value`, but `apply()`
+// calls `inline.stop()` synchronously right after, so `editing` is already false
+// by the time this (async) watcher flushes — it won't fight a normal save. User
+// typing only touches the local `model`, never `props.value`, so it won't trip.
+watch(
+  () => props.value,
+  () => { if (editing.value) { inline?.stop() } }
+)
 
 // STable virtualization can unmount this row (and its teleported editor) while
 // scrolling. If this cell holds the active editor, clear the shared active key
@@ -110,9 +123,23 @@ function cancel() {
 }
 
 async function apply() {
+  // Snapshot the value we're editing so we can detect the backing cell being
+  // replaced out from under us during validation (checked below).
+  const editedValue = props.value
+
   // Client-side validation only; server-only rules (e.g. `unique`) are enforced
   // by the background write, which surfaces a snackbar on rejection.
   if (!(await validate())) {
+    return
+  }
+
+  // A wholesale refresh (refresh banner, a parent `refresh()`, a route change)
+  // can swap the backing row during the validate microtask. If this cell's value
+  // changed, `model` now predates the fresh value and persisting it would clobber
+  // the just-fetched cell — bail. The value watcher above also closes the editor,
+  // but it flushes asynchronously and can't abort this already-running save, so
+  // re-check here against the snapshot rather than relying on its ordering.
+  if (props.value !== editedValue) {
     return
   }
 

--- a/lib/blocks/lens/components/LensTableEditableCell.vue
+++ b/lib/blocks/lens/components/LensTableEditableCell.vue
@@ -1,0 +1,224 @@
+<script setup lang="ts">
+import IconPencilSimple from '~icons/ph/pencil-simple'
+import { useElementBounding } from '@vueuse/core'
+import { computed, nextTick, ref, shallowRef } from 'vue'
+import SButton from '../../../components/SButton.vue'
+import { useManualDropdownPosition } from '../../../composables/Dropdown'
+import { useTrans } from '../../../composables/Lang'
+import { useValidation } from '../../../composables/Validation'
+import { type FieldData } from '../FieldData'
+import { useLensEdit } from '../composables/LensEdit'
+import { useLensInlineEdit } from '../composables/LensInlineEdit'
+import { type Field } from '../fields/Field'
+
+const props = defineProps<{
+  field: Field<FieldData>
+  fieldKey: string
+  value: any
+  record: Record<string, any>
+}>()
+
+const { t } = useTrans({
+  en: { cancel: 'Cancel', save: 'Save', edit: 'Edit' },
+  ja: { cancel: 'キャンセル', save: '保存', edit: '編集' }
+})
+
+const edit = useLensEdit()
+const inline = useLensInlineEdit()
+
+const myKey = computed(() => `${edit?.resolveId(props.record)}:${props.fieldKey}`)
+const editing = computed(() => inline?.activeKey.value === myKey.value)
+
+// Reuse the field's own table-cell rendering for the display value so the
+// label mapping (e.g. select option labels) matches the read-only columns.
+// Falls back to a plain representation for non-text displays.
+const displayValue = computed(() => {
+  try {
+    const cell = props.field.tableColumn().cell
+    const resolved: any = typeof cell === 'function' ? cell(props.value, props.record) : cell
+    if (resolved && (resolved.type === 'text' || resolved.type === 'number')) {
+      return resolved.value ?? ''
+    }
+  } catch {
+    // Field types without a text cell fall through to the generic display.
+  }
+
+  const v = props.value
+  if (v == null) {
+    return ''
+  }
+  if (Array.isArray(v)) {
+    return v.join(', ')
+  }
+  if (typeof v === 'object') {
+    return v.display ?? v.value ?? ''
+  }
+  return String(v)
+})
+
+// --- Editor (a floating box anchored to the cell, escaping table overflow) ---
+
+const anchor = ref<HTMLElement | null>(null)
+const editorEl = ref<HTMLElement | null>(null)
+const bounds = useElementBounding(anchor)
+const { inset, update } = useManualDropdownPosition(anchor)
+
+const inputComponent = shallowRef<any>(null)
+const model = ref<any>(null)
+const saving = ref(false)
+
+const { validation, validate, reset } = useValidation(
+  () => ({ input: model.value }),
+  () => ({ input: props.field.generateValidationRules() })
+)
+
+const editorStyle = computed(() => ({
+  ...inset.value,
+  width: `${Math.max(bounds.width.value, 240)}px`
+}))
+
+function start() {
+  inputComponent.value = props.field.formInputComponent()
+  model.value = props.field.payloadToInput(props.value ?? props.field.inputEmptyValue())
+  reset()
+  inline?.start(myKey.value)
+  nextTick(() => {
+    update()
+    const el = editorEl.value?.querySelector(
+      'input, textarea, [contenteditable], [tabindex]'
+    ) as HTMLElement | null
+    el?.focus()
+  })
+}
+
+function cancel() {
+  inline?.stop()
+}
+
+async function apply() {
+  if (!(await validate())) {
+    return
+  }
+
+  saving.value = true
+
+  try {
+    await edit!.save(props.record, {
+      [props.fieldKey]: props.field.inputToPayload(model.value)
+    })
+    inline?.stop()
+  } finally {
+    saving.value = false
+  }
+}
+
+function onEditorKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    cancel()
+    return
+  }
+  // Enter saves, except in a textarea where it inserts a newline.
+  if (event.key === 'Enter' && (event.target as HTMLElement)?.tagName !== 'TEXTAREA') {
+    event.preventDefault()
+    apply()
+  }
+}
+</script>
+
+<template>
+  <div ref="anchor" class="LensTableEditableCell" :class="{ editing }">
+    <span class="value">{{ displayValue }}</span>
+    <button
+      class="edit"
+      type="button"
+      :aria-label="`${t.edit} ${field.label()}`"
+      @click="start"
+    >
+      <IconPencilSimple class="edit-icon" />
+    </button>
+
+    <Teleport v-if="editing" to="#sefirot-modals">
+      <div ref="editorEl" class="LensTableEditableCellEditor" :style="editorStyle" @keydown="onEditorKeydown">
+        <component :is="inputComponent" v-model="model" :validation="validation.input" />
+        <div class="actions">
+          <SButton size="mini" :label="t.cancel" :disabled="saving" @click="cancel" />
+          <SButton size="mini" mode="info" :label="t.save" :loading="saving" @click="apply" />
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+/* Mirror STableCellText's box so the cell fills the row height instead of
+   collapsing, leaving room on the right for the hover edit affordance. */
+.LensTableEditableCell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  min-height: 40px;
+  padding: 8px 36px 8px 16px;
+}
+
+.value {
+  line-height: 24px;
+  font-size: var(--table-cell-font-size);
+  font-weight: var(--table-cell-font-weight);
+  color: var(--c-text-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.edit {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  transform: translateY(-50%);
+  border-radius: 6px;
+  color: var(--c-text-2);
+  opacity: 0;
+  transition: opacity 0.1s, background-color 0.1s, color 0.1s;
+}
+
+.LensTableEditableCell:hover .edit,
+.LensTableEditableCell.editing .edit {
+  opacity: 1;
+}
+
+.edit:hover {
+  background-color: var(--c-bg-mute-1);
+  color: var(--c-text-1);
+}
+
+.edit-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.LensTableEditableCellEditor {
+  position: fixed;
+  z-index: var(--z-index-sheet, 2000);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  background-color: var(--c-bg-1);
+  box-shadow: var(--shadow-depth-3);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+</style>

--- a/lib/blocks/lens/components/LensTableEditableCell.vue
+++ b/lib/blocks/lens/components/LensTableEditableCell.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import IconPencilSimple from '~icons/ph/pencil-simple'
 import { useElementBounding } from '@vueuse/core'
-import { computed, nextTick, ref, shallowRef } from 'vue'
+import { computed, nextTick, onUnmounted, ref, shallowRef } from 'vue'
 import SButton from '../../../components/SButton.vue'
 import { useManualDropdownPosition } from '../../../composables/Dropdown'
 import { useTrans } from '../../../composables/Lang'
@@ -29,6 +29,16 @@ const inline = useLensInlineEdit()
 const myKey = computed(() => `${edit?.resolveId(props.record)}:${props.fieldKey}`)
 const editing = computed(() => inline?.activeKey.value === myKey.value)
 
+// STable virtualization can unmount this row (and its teleported editor) while
+// scrolling. If this cell holds the active editor, clear the shared active key
+// on unmount so a later remount doesn't reopen a blank editor (the local
+// `inputComponent`/`model` are only set by `start()`).
+onUnmounted(() => {
+  if (inline?.activeKey.value === myKey.value) {
+    inline.stop()
+  }
+})
+
 // Reuse the field's own table-cell rendering for the display value so the
 // label mapping (e.g. select option labels) matches the read-only columns.
 // Falls back to a plain representation for non-text displays.
@@ -38,6 +48,11 @@ const displayValue = computed(() => {
     const resolved: any = typeof cell === 'function' ? cell(props.value, props.record) : cell
     if (resolved && (resolved.type === 'text' || resolved.type === 'number')) {
       return resolved.value ?? ''
+    }
+    // `state` cells (e.g. a select with displayAs: 'state') carry the localized
+    // label, not the raw payload — show that rather than falling through.
+    if (resolved && resolved.type === 'state') {
+      return resolved.label ?? ''
     }
   } catch {
     // Field types without a text cell fall through to the generic display.
@@ -65,7 +80,6 @@ const { inset, update } = useManualDropdownPosition(anchor)
 
 const inputComponent = shallowRef<any>(null)
 const model = ref<any>(null)
-const saving = ref(false)
 
 const { validation, validate, reset } = useValidation(
   () => ({ input: model.value }),
@@ -96,19 +110,22 @@ function cancel() {
 }
 
 async function apply() {
+  // Client-side validation only; server-only rules (e.g. `unique`) are enforced
+  // by the background write, which surfaces a snackbar on rejection.
   if (!(await validate())) {
     return
   }
 
-  saving.value = true
+  // Optimistic: patch + persist in the background, then close immediately.
+  edit!.save(props.record, {
+    [props.fieldKey]: props.field.inputToPayload(model.value)
+  })
 
-  try {
-    await edit!.save(props.record, {
-      [props.fieldKey]: props.field.inputToPayload(model.value)
-    })
-    inline?.stop()
-  } finally {
-    saving.value = false
+  // Only close if this cell is still the active one: the user may have started
+  // editing another cell while validating, and an unconditional stop would
+  // clear that new editor's shared key.
+  if (inline?.activeKey.value === myKey.value) {
+    inline.stop()
   }
 }
 
@@ -118,11 +135,23 @@ function onEditorKeydown(event: KeyboardEvent) {
     cancel()
     return
   }
-  // Enter saves, except in a textarea where it inserts a newline.
-  if (event.key === 'Enter' && (event.target as HTMLElement)?.tagName !== 'TEXTAREA') {
+  // Enter saves only from a plain text-like input. A textarea inserts a
+  // newline, and controls that handle Enter themselves (e.g. a dropdown that
+  // opens its menu on Enter) must keep it — otherwise a keyboard user submits
+  // the old value instead of choosing an option.
+  if (event.key === 'Enter' && isTextLikeInput(event.target)) {
     event.preventDefault()
     apply()
   }
+}
+
+function isTextLikeInput(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null
+  if (!el || el.tagName !== 'INPUT') {
+    return false
+  }
+  const type = (el as HTMLInputElement).type
+  return ['text', 'search', 'url', 'email', 'tel', 'password', 'number'].includes(type)
 }
 </script>
 
@@ -138,12 +167,12 @@ function onEditorKeydown(event: KeyboardEvent) {
       <IconPencilSimple class="edit-icon" />
     </button>
 
-    <Teleport v-if="editing" to="#sefirot-modals">
+    <Teleport v-if="editing && inputComponent" to="#sefirot-modals">
       <div ref="editorEl" class="LensTableEditableCellEditor" :style="editorStyle" @keydown="onEditorKeydown">
         <component :is="inputComponent" v-model="model" :validation="validation.input" />
         <div class="actions">
-          <SButton size="mini" :label="t.cancel" :disabled="saving" @click="cancel" />
-          <SButton size="mini" mode="info" :label="t.save" :loading="saving" @click="apply" />
+          <SButton size="mini" :label="t.cancel" @click="cancel" />
+          <SButton size="mini" mode="info" :label="t.save" @click="apply" />
         </div>
       </div>
     </Teleport>

--- a/lib/blocks/lens/composables/LensEdit.ts
+++ b/lib/blocks/lens/composables/LensEdit.ts
@@ -1,0 +1,52 @@
+import { type InjectionKey, inject, provide } from 'vue'
+
+/**
+ * The edit context shared from `LensCatalog` down to the inline editable
+ * cells and the record sheet via provide/inject. It carries the entity
+ * identity plus the CRUD operations (which talk to the backend and patch
+ * the catalog's in-memory records optimistically) and the sheet controls.
+ */
+export interface LensEditContext {
+  /** Whether the catalog has editing enabled at all. */
+  editable: boolean
+
+  /** Whether new records may be created. */
+  creatable: boolean
+
+  /** The entity key being edited (e.g. `topic`, `user`). */
+  entity: string
+
+  /** The record-identity field key (e.g. `id`). */
+  indexField: string
+
+  /** Resolve a record's identifier, unwrapping the id field's object shape. */
+  resolveId: (record: Record<string, any>) => any
+
+  /**
+   * Persist a partial update for an existing record and patch it in place.
+   * Resolves once the row reflects the server's re-serialized values.
+   */
+  save: (record: Record<string, any>, values: Record<string, any>) => Promise<void>
+
+  /** Create a new record and prepend it to the catalog. */
+  create: (values: Record<string, any>) => Promise<Record<string, any>>
+
+  /** Delete a record and remove it from the catalog. */
+  remove: (record: Record<string, any>) => Promise<void>
+
+  /** Open the record sheet for an existing record (view + per-field edit). */
+  openSheet: (record: Record<string, any>) => void
+
+  /** Open the record sheet in create mode. */
+  openCreate: () => void
+}
+
+const LensEditKey: InjectionKey<LensEditContext> = Symbol('LensEdit')
+
+export function provideLensEdit(ctx: LensEditContext): void {
+  provide(LensEditKey, ctx)
+}
+
+export function useLensEdit(): LensEditContext | null {
+  return inject(LensEditKey, null)
+}

--- a/lib/blocks/lens/composables/LensEdit.ts
+++ b/lib/blocks/lens/composables/LensEdit.ts
@@ -23,16 +23,23 @@ export interface LensEditContext {
   resolveId: (record: Record<string, any>) => any
 
   /**
-   * Persist a partial update for an existing record and patch it in place.
-   * Resolves once the row reflects the server's re-serialized values.
+   * Apply a partial update to an existing record. Optimistic: patches the
+   * record in memory immediately and persists in the background, so it returns
+   * synchronously without waiting for the (potentially slow) write.
    */
-  save: (record: Record<string, any>, values: Record<string, any>) => Promise<void>
+  save: (record: Record<string, any>, values: Record<string, any>) => void
 
-  /** Create a new record and prepend it to the catalog. */
+  /**
+   * Create a new record. Blocking: resolves once the record is persisted and
+   * the catalog has been refreshed with the canonical state.
+   */
   create: (values: Record<string, any>) => Promise<Record<string, any>>
 
-  /** Delete a record and remove it from the catalog. */
-  remove: (record: Record<string, any>) => Promise<void>
+  /**
+   * Delete a record. Optimistic: removes it from the catalog immediately and
+   * persists in the background, so it returns synchronously.
+   */
+  remove: (record: Record<string, any>) => void
 
   /** Open the record sheet for an existing record (view + per-field edit). */
   openSheet: (record: Record<string, any>) => void

--- a/lib/blocks/lens/composables/LensInlineEdit.ts
+++ b/lib/blocks/lens/composables/LensInlineEdit.ts
@@ -1,0 +1,36 @@
+import { type InjectionKey, type Ref, inject, provide, ref } from 'vue'
+
+/**
+ * Tracks which table cell currently has its inline editor open, so that
+ * opening one editor closes any other. The key is `${recordId}:${fieldKey}`.
+ */
+export interface LensInlineEditContext {
+  /** The key of the cell currently being edited, or null. */
+  activeKey: Ref<string | null>
+
+  /** Open the editor for the given cell key (closing any other). */
+  start: (key: string) => void
+
+  /** Close the active editor. */
+  stop: () => void
+}
+
+const LensInlineEditKey: InjectionKey<LensInlineEditContext> = Symbol('LensInlineEdit')
+
+export function provideLensInlineEdit(): LensInlineEditContext {
+  const activeKey = ref<string | null>(null)
+
+  const ctx: LensInlineEditContext = {
+    activeKey,
+    start: (key) => { activeKey.value = key },
+    stop: () => { activeKey.value = null }
+  }
+
+  provide(LensInlineEditKey, ctx)
+
+  return ctx
+}
+
+export function useLensInlineEdit(): LensInlineEditContext | null {
+  return inject(LensInlineEditKey, null)
+}

--- a/lib/blocks/lens/composables/ResourceFetcher.ts
+++ b/lib/blocks/lens/composables/ResourceFetcher.ts
@@ -6,7 +6,10 @@ export function useResourceFetcher(): ResourceFetcher {
   const data = ref<Record<string, any>>({})
   const pendingList: Record<string, Promise<any> | undefined> = {}
 
-  const { execute: resourceFetcher } = useGet<any, [method: ResourceFetchMethod, url: string, body?: Record<string, any> | null]>(async (http, method, url, body) => {
+  const { execute: resourceFetcher } = useGet<
+    any,
+    [method: ResourceFetchMethod, url: string, body?: Record<string, any> | null]
+  >(async (http, method, url, body) => {
     const key = `${method}:${url}:${body ? JSON.stringify(body) : ''}`
 
     if (data.value[key]) {
@@ -17,13 +20,21 @@ export function useResourceFetcher(): ResourceFetcher {
       return pendingList[key]
     }
 
-    // `post` carries a request body (e.g. a lens search payload); `get`
-    // ignores it.
-    pendingList[key] = (method === 'post' ? http.post(url, body ?? {}) : http.get(url)).then((response) => {
-      data.value[key] = response
-      delete pendingList[key]
-      return response
-    })
+    // `post` carries a request body (e.g. a lens search payload); `get` ignores
+    // it. Send no body at all when none is configured — `http.post(url, {})`
+    // would serialize and POST an empty JSON object, which endpoints that
+    // branch on an absent payload could reject.
+    pendingList[key] = (
+      method === 'post'
+        ? (body != null ? http.post(url, body) : http.post(url))
+        : http.get(url)
+    ).then(
+      (response) => {
+        data.value[key] = response
+        delete pendingList[key]
+        return response
+      }
+    )
 
     return pendingList[key]
   })

--- a/lib/blocks/lens/composables/ResourceFetcher.ts
+++ b/lib/blocks/lens/composables/ResourceFetcher.ts
@@ -6,8 +6,8 @@ export function useResourceFetcher(): ResourceFetcher {
   const data = ref<Record<string, any>>({})
   const pendingList: Record<string, Promise<any> | undefined> = {}
 
-  const { execute: resourceFetcher } = useGet<any, [method: ResourceFetchMethod, url: string]>(async (http, method, url) => {
-    const key = `${method}:${url}`
+  const { execute: resourceFetcher } = useGet<any, [method: ResourceFetchMethod, url: string, body?: Record<string, any> | null]>(async (http, method, url, body) => {
+    const key = `${method}:${url}:${body ? JSON.stringify(body) : ''}`
 
     if (data.value[key]) {
       return data.value[key]
@@ -17,7 +17,9 @@ export function useResourceFetcher(): ResourceFetcher {
       return pendingList[key]
     }
 
-    pendingList[key] = http[method](url).then((response) => {
+    // `post` carries a request body (e.g. a lens search payload); `get`
+    // ignores it.
+    pendingList[key] = (method === 'post' ? http.post(url, body ?? {}) : http.get(url)).then((response) => {
       data.value[key] = response
       delete pendingList[key]
       return response

--- a/lib/blocks/lens/fields/ContentField.ts
+++ b/lib/blocks/lens/fields/ContentField.ts
@@ -1,4 +1,4 @@
-import { h } from 'vue'
+import { defineComponent, h } from 'vue'
 import SContent from '../../../components/SContent.vue'
 import SMarkdown from '../../../components/SMarkdown.vue'
 import { type TableCell } from '../../../composables/Table'
@@ -8,6 +8,13 @@ import { type FilterInput } from '../filter-inputs/FilterInput'
 import { Field } from './Field'
 
 export class ContentField extends Field<ContentFieldData> {
+  // `content` is a display-only field: `formInputComponent()` renders static
+  // Markdown (instructions) rather than an editable input, so it must never be
+  // seeded / validated / submitted as a value, nor made inline-editable.
+  override isSubmittable(): boolean {
+    return false
+  }
+
   override tableCell(_v: any, _r: any): TableCell {
     return { type: 'empty' }
   }
@@ -17,18 +24,22 @@ export class ContentField extends Field<ContentFieldData> {
   }
 
   override dataListItemComponent(): any {
-    return null
+    // `content` is display-only: render its Markdown body (the same static
+    // block as the create form) so a detail-visible content field shows its
+    // configured instructions instead of an empty value row.
+    return defineComponent(() => () => this.renderBody(), { props: ['value'] })
   }
 
   override formInputComponent(): any {
-    return this.defineFormInputComponent((_props, _ctx) => {
-      return () => h(SMarkdown, {
-        content: this.ctx.lang === 'ja' ? this.data.bodyJa : this.data.bodyEn
-      }, {
-        default: (slot: any) => {
-          return h(SContent, { innerHTML: slot.rendered })
-        }
-      })
+    return this.defineFormInputComponent((_props, _ctx) => () => this.renderBody())
+  }
+
+  /** Render the field's localized Markdown body. */
+  private renderBody(): any {
+    return h(SMarkdown, {
+      content: this.ctx.lang === 'ja' ? this.data.bodyJa : this.data.bodyEn
+    }, {
+      default: (slot: any) => h(SContent, { innerHTML: slot.rendered })
     })
   }
 }

--- a/lib/blocks/lens/fields/Field.ts
+++ b/lib/blocks/lens/fields/Field.ts
@@ -226,6 +226,18 @@ export abstract class Field<T extends FieldData> {
   }
 
   /**
+   * Whether this field can be edited in place (inline cell / record sheet) with
+   * an optimistic display. False for fields whose input value isn't the
+   * displayed value and needs a server round-trip first (e.g. a file upload,
+   * which holds raw `File` objects before upload) — patching the row with that
+   * raw value would render incorrectly or crash. Such fields remain editable in
+   * the create form, which is blocking.
+   */
+  supportsOptimisticUpdate(): boolean {
+    return true
+  }
+
+  /**
    * Returns the value should be used when the input is empty.
    */
   inputEmptyValue(): any {

--- a/lib/blocks/lens/fields/Field.ts
+++ b/lib/blocks/lens/fields/Field.ts
@@ -213,6 +213,16 @@ export abstract class Field<T extends FieldData> {
   }
 
   /**
+   * Whether this field contributes a value to create / update payloads. Most
+   * fields do. Display-only fields (e.g. `content`, which renders static
+   * instructions in the form) return false so the sheet renders them but
+   * never seeds, validates, submits, or makes them inline-editable.
+   */
+  isSubmittable(): boolean {
+    return true
+  }
+
+  /**
    * Returns the value should be used when the input is empty.
    */
   inputEmptyValue(): any {

--- a/lib/blocks/lens/fields/Field.ts
+++ b/lib/blocks/lens/fields/Field.ts
@@ -110,7 +110,10 @@ export abstract class Field<T extends FieldData> {
    * Renders the table filter menu for the field. The filter maybe null when
    * the field has no available filters.
    */
-  async tableFilterMenu(_filters: any[], _onFilterUpdated: (filters: any[]) => void): Promise<DropdownSection | null> {
+  async tableFilterMenu(
+    _filters: any[],
+    _onFilterUpdated: (filters: any[]) => void
+  ): Promise<DropdownSection | null> {
     return null
   }
 

--- a/lib/blocks/lens/fields/FileUploadField.ts
+++ b/lib/blocks/lens/fields/FileUploadField.ts
@@ -16,6 +16,14 @@ export class FileUploadField extends Field<FileUploadFieldData> {
     this.downloader = downloader
   }
 
+  // The form input holds raw `File` objects until they're uploaded, which only
+  // happens server-side; an optimistic patch would store those `File`s on the
+  // row and crash the persisted-path renderer. So file uploads aren't editable
+  // inline / in the sheet (only on create, which is blocking).
+  override supportsOptimisticUpdate(): boolean {
+    return false
+  }
+
   override tableCell(v: any, _r: any): TableCell {
     return {
       type: 'text',

--- a/lib/blocks/lens/fields/RelatedManyField.ts
+++ b/lib/blocks/lens/fields/RelatedManyField.ts
@@ -1,4 +1,7 @@
 import { xor } from 'lodash-es'
+import { h } from 'vue'
+import SDescAvatar from '../../../components/SDescAvatar.vue'
+import SDescPill from '../../../components/SDescPill.vue'
 import { type DropdownSection } from '../../../composables/Dropdown'
 import { type TableCell } from '../../../composables/Table'
 import { type RelatedManyFieldData } from '../FieldData'
@@ -113,7 +116,32 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
   }
 
   override dataListItemComponent(): any {
-    throw new Error('Not implemented.')
+    return this.defineDataListItemComponent((value) => {
+      // related_many serializes as an array of relation objects (or null).
+      // Read the display name / image from the same keys `tableCell()` uses,
+      // instead of letting the generic fallback render `[object Object]`.
+      const items = (value ?? []) as any[]
+
+      if (items.length === 0) {
+        return null
+      }
+
+      if (this.data.displayAs === 'avatars') {
+        return h(SDescAvatar, {
+          avatar: items.map((item) => ({
+            avatar: this.data.image ? (item[this.data.image] ?? null) : null,
+            name: item[this.data.title] ?? null
+          }))
+        })
+      }
+
+      // 'pills' (and the null default): render one pill per related item.
+      return h(SDescPill, {
+        pill: items.map((item) => ({
+          label: item[this.data.title] ?? ''
+        }))
+      })
+    })
   }
 
   override formInputComponent() {

--- a/lib/blocks/lens/fields/RelatedManyField.ts
+++ b/lib/blocks/lens/fields/RelatedManyField.ts
@@ -27,7 +27,7 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
 
     const selected = this.inFilterValueFor(this.data.key, filters)
 
-    const res = await this.fetcher(method, url)
+    const res = await this.fetcher(method, url, this.data.resourceEndpointBody)
     const data = key ? res[key] : res
 
     const isAvatar = this.data.displayAs === 'avatars'
@@ -37,11 +37,11 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
           type: 'avatar' as const,
           label: item[this.data.resourceTitle],
           image: this.data.resourceImage ? item[this.data.resourceImage] : null,
-          value: item[this.data.filterKey]
+          value: this.resolveValue(item[this.data.filterKey])
         }
       : {
           label: item[this.data.resourceTitle],
-          value: item[this.data.filterKey]
+          value: this.resolveValue(item[this.data.filterKey])
         })
 
     return {
@@ -88,10 +88,10 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
     }
 
     const optionsResolver = async () => {
-      const res = await this.fetcher(method, url)
+      const res = await this.fetcher(method, url, this.data.resourceEndpointBody)
       const data = key ? res[key] : res
       return data.map((item: any) => ({
-        value: item[this.data.filterKey],
+        value: this.resolveValue(item[this.data.filterKey]),
         label: item[this.data.resourceTitle]
       }))
     }
@@ -104,6 +104,12 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
       '!=': selectOne,
       'in': selectMany
     }
+  }
+
+  // Lens id fields serialize as `{ value, display, path? }`; filters need the
+  // raw scalar. Unwrap that shape, passing plain scalars through untouched.
+  private resolveValue(raw: any): any {
+    return raw !== null && typeof raw === 'object' && 'value' in raw ? raw.value : raw
   }
 
   override dataListItemComponent(): any {

--- a/lib/blocks/lens/fields/RelatedManyField.ts
+++ b/lib/blocks/lens/fields/RelatedManyField.ts
@@ -19,7 +19,10 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
     this.fetcher = fetcher
   }
 
-  override async tableFilterMenu(filters: any[], onFilterUpdated: (filters: any[]) => void): Promise<DropdownSection | null> {
+  override async tableFilterMenu(
+    filters: any[],
+    onFilterUpdated: (filters: any[]) => void
+  ): Promise<DropdownSection | null> {
     const method = this.data.resourceEndpointMethod
     const url = this.data.resourceEndpointPath
     const key = this.data.resourceEndpointDataKey

--- a/lib/blocks/lens/fields/RelatedOneField.ts
+++ b/lib/blocks/lens/fields/RelatedOneField.ts
@@ -1,4 +1,6 @@
 import { xor } from 'lodash-es'
+import { h } from 'vue'
+import SDescAvatar from '../../../components/SDescAvatar.vue'
 import { type DropdownSection } from '../../../composables/Dropdown'
 import { type TableCell } from '../../../composables/Table'
 import { type RelatedOneFieldData } from '../FieldData'
@@ -27,7 +29,7 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
 
     const selected = this.inFilterValueFor(this.data.key, filters)
 
-    const res = await this.fetcher(method, url)
+    const res = await this.fetcher(method, url, this.data.resourceEndpointBody)
     const data = key ? res[key] : res
 
     const isAvatar = this.data.displayAs === 'avatar'
@@ -37,11 +39,11 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
           type: 'avatar' as const,
           label: item[this.data.resourceTitle],
           image: this.data.resourceImage ? item[this.data.resourceImage] : null,
-          value: item[this.data.filterKey]
+          value: this.resolveValue(item[this.data.filterKey])
         }
       : {
           label: item[this.data.resourceTitle],
-          value: item[this.data.filterKey]
+          value: this.resolveValue(item[this.data.filterKey])
         })
 
     return {
@@ -91,10 +93,10 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
     }
 
     const optionsResolver = async () => {
-      const res = await this.fetcher(method, url)
+      const res = await this.fetcher(method, url, this.data.resourceEndpointBody)
       const data = key ? res[key] : res
       return data.map((item: any) => ({
-        value: item[this.data.filterKey],
+        value: this.resolveValue(item[this.data.filterKey]),
         label: item[this.data.resourceTitle]
       }))
     }
@@ -109,8 +111,38 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
     }
   }
 
+  // Lens id fields serialize as `{ value, display, path? }`; filters need the
+  // raw scalar. Unwrap that shape, passing plain scalars through untouched.
+  // (Mirrors `RelatedManyField` — relevant when a related-one resource reuses
+  // a Lens search endpoint whose `filterKey` is an id field.)
+  private resolveValue(raw: any): any {
+    return raw !== null && typeof raw === 'object' && 'value' in raw ? raw.value : raw
+  }
+
   override dataListItemComponent(): any {
-    throw new Error('Not implemented.')
+    return this.defineDataListItemComponent((value) => {
+      // related_one serializes as a single relation object (or null). Read the
+      // display name / image from the same keys `tableCell()` uses, instead of
+      // letting the generic fallback render the raw object as JSON.
+      if (value === null || value === undefined) {
+        return null
+      }
+
+      const name = value[this.data.title] ?? null
+
+      if (this.data.displayAs === 'avatar') {
+        return h(SDescAvatar, {
+          avatar: {
+            avatar: this.data.image ? (value[this.data.image] ?? null) : null,
+            name
+          }
+        })
+      }
+
+      // 'text' (and the null default): render the title as plain text, falling
+      // back to the empty placeholder when the title key is missing.
+      return name
+    })
   }
 
   override formInputComponent() {

--- a/lib/blocks/lens/fields/RelatedOneField.ts
+++ b/lib/blocks/lens/fields/RelatedOneField.ts
@@ -18,7 +18,10 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
     this.fetcher = fetcher
   }
 
-  override async tableFilterMenu(filters: any[], onFilterUpdated: (filters: any[]) => void): Promise<DropdownSection | null> {
+  override async tableFilterMenu(
+    filters: any[],
+    onFilterUpdated: (filters: any[]) => void
+  ): Promise<DropdownSection | null> {
     const method = this.data.resourceEndpointMethod
     const url = this.data.resourceEndpointPath
     const key = this.data.resourceEndpointDataKey

--- a/lib/blocks/lens/validation/RuleMapper.ts
+++ b/lib/blocks/lens/validation/RuleMapper.ts
@@ -17,17 +17,25 @@ import { type Rule } from '../Rule'
  */
 export function map(rules: Rule[]): ValidationArgs {
   return rules.reduce((carry: ValidationArgs<any>, rule: Rule) => {
-    carry[rule.type] = mapRule(rule)
+    const mapped = mapRule(rule)
+    if (mapped) {
+      carry[rule.type] = mapped
+    }
     return carry
   }, {})
 }
 
-function mapRule(rule: Rule): ValidationRuleWithParams {
+function mapRule(rule: Rule): ValidationRuleWithParams | null {
   switch (rule.type) {
     case 'max_length':
       return maxLength(rule.length)
     case 'required':
       return required()
+    case 'unique':
+      // Uniqueness can only be verified server-side (it queries the
+      // database). The backend enforces it and returns a 422 with field
+      // errors, so there is no client-side equivalent to apply here.
+      return null
     case 'slack_channel_link':
       return slackChannelLink()
     case 'slack_channel_name':

--- a/lib/blocks/lens/validation/ServerErrors.ts
+++ b/lib/blocks/lens/validation/ServerErrors.ts
@@ -1,0 +1,25 @@
+import { isFetchError } from '../../../http/Http'
+
+/**
+ * Extract Laravel-style validation errors from a failed request. The backend
+ * enforces rules that can't run client-side (e.g. `unique`) and rejects with a
+ * 422 whose body is `{ message, errors: { <fieldKey>: string[] } }`, keyed by
+ * the bare field key.
+ *
+ * Returns the `errors` map so a form can feed it into Vuelidate's
+ * `$externalResults` and surface a fixable per-field message, or `null` when
+ * the error isn't a usable 422 (so the caller can rethrow it).
+ */
+export function extractServerErrors(error: unknown): Record<string, string[]> | null {
+  if (!isFetchError(error) || error.status !== 422) {
+    return null
+  }
+
+  const errors = (error.data as any)?.errors
+
+  if (!errors || typeof errors !== 'object') {
+    return null
+  }
+
+  return errors
+}

--- a/lib/components/SSheet.vue
+++ b/lib/components/SSheet.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { onKeyStroke } from '@vueuse/core'
+import { ref } from 'vue'
+
+export interface Props {
+  open: boolean
+  closable?: boolean
+  position?: 'right' | 'left'
+  width?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  closable: true,
+  position: 'right',
+  width: '480px'
+})
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const el = ref<any>(null)
+
+function onClick(e: MouseEvent) {
+  if (!props.closable) {
+    return
+  }
+
+  if (e.button === 0 && e.target === el.value) {
+    emit('close')
+  }
+}
+
+onKeyStroke('Escape', () => {
+  if (props.open && props.closable) {
+    emit('close')
+  }
+})
+</script>
+
+<template>
+  <Teleport to="#sefirot-modals">
+    <Transition name="s-sheet">
+      <div
+        v-if="open"
+        ref="el"
+        class="SSheet"
+        :class="[`pos-${position}`]"
+        @mousedown="onClick"
+      >
+        <div class="panel" :style="{ width }">
+          <slot />
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.SSheet {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: var(--z-index-sheet);
+  display: flex;
+  padding: 8px;
+  transition: opacity 0.25s;
+}
+
+.SSheet.pos-right { justify-content: flex-end; }
+.SSheet.pos-left { justify-content: flex-start; }
+
+.SSheet.s-sheet-enter-from,
+.SSheet.s-sheet-leave-to {
+  opacity: 0;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  max-width: calc(100% - 16px);
+  height: 100%;
+  border: 1px solid var(--c-divider);
+  border-radius: 12px;
+  background-color: var(--c-bg-1);
+  box-shadow: var(--shadow-depth-3);
+  transition: transform 0.25s, opacity 0.25s;
+  overflow: hidden;
+}
+
+.SSheet.pos-right.s-sheet-enter-from .panel,
+.SSheet.pos-right.s-sheet-leave-to .panel {
+  opacity: 0;
+  transform: translateX(16px);
+}
+
+.SSheet.pos-left.s-sheet-enter-from .panel,
+.SSheet.pos-left.s-sheet-leave-to .panel {
+  opacity: 0;
+  transform: translateX(-16px);
+}
+</style>

--- a/lib/composables/Api.ts
+++ b/lib/composables/Api.ts
@@ -59,11 +59,15 @@ export function useQuery<Data = any>(
   async function execute({ assign = true, silent = false } = {}): Promise<Data> {
     if (!silent) { loading.value = true }
 
-    const res: Data = await req(new Http(httpConfig))
-    if (assign) { data.value = res }
-
-    loading.value = false
-    return res
+    try {
+      const res: Data = await req(new Http(httpConfig))
+      if (assign) { data.value = res }
+      return res
+    } finally {
+      // Always clear loading, even when the request rejects — otherwise a failed
+      // fetch leaves the consumer stuck in its loading/skeleton state.
+      loading.value = false
+    }
   }
 
   return { loading, data, execute }
@@ -79,11 +83,15 @@ export function useMutation<Data = any, Args extends any[] = any[]>(
   async function execute(...args: Args): Promise<Data> {
     loading.value = true
 
-    const res: Data = await req(new Http(httpConfig), ...args)
-    data.value = res
-
-    loading.value = false
-    return res
+    try {
+      const res: Data = await req(new Http(httpConfig), ...args)
+      data.value = res
+      return res
+    } finally {
+      // Always clear loading, even when the request rejects, so a failed
+      // mutation doesn't leave the caller wedged in its loading state.
+      loading.value = false
+    }
   }
 
   return { loading, data, execute }

--- a/lib/styles/variables.css
+++ b/lib/styles/variables.css
@@ -376,6 +376,7 @@
   --z-index-tooltip: 10;
   --z-index-dropdown: 1000;
   --z-index-backdrop: 2000;
+  --z-index-sheet: 2000;
 }
 
 /**

--- a/tests/blocks/lens/fields/ContentField.spec.ts
+++ b/tests/blocks/lens/fields/ContentField.spec.ts
@@ -1,0 +1,69 @@
+import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
+import { type ContentFieldData, type TextFieldData } from 'sefirot/blocks/lens/FieldData'
+import { ContentField } from 'sefirot/blocks/lens/fields/ContentField'
+import { TextField } from 'sefirot/blocks/lens/fields/TextField'
+
+function ctx(lang: 'en' | 'ja' = 'en'): FieldContext {
+  return { lang }
+}
+
+function make(overrides: Partial<ContentFieldData> = {}): ContentField {
+  const data: ContentFieldData = {
+    type: 'content',
+    key: 'instructions',
+    labelEn: 'Instructions',
+    labelJa: '説明',
+    filterKey: 'instructions',
+    sortable: false,
+    freeze: false,
+    width: 0,
+    required: false,
+    rules: [],
+    bodyEn: 'Hello',
+    bodyJa: 'こんにちは',
+    ...overrides
+  }
+  return new ContentField(ctx(), data)
+}
+
+describe('blocks/lens/fields/ContentField', () => {
+  it('is display-only — not submittable', () => {
+    expect(make().isSubmittable()).toBe(false)
+  })
+
+  it('still resolves a (display-only) form input component without throwing', () => {
+    expect(make().formInputComponent()).toBeTruthy()
+  })
+
+  it('renders an empty table cell', () => {
+    expect(make().tableCell(null, {})).toEqual({ type: 'empty' })
+  })
+
+  it('provides a detail component (renders its body, not an empty row)', () => {
+    // Regression: it previously returned null, so a detail-visible content
+    // field rendered as an empty value row instead of its Markdown body.
+    expect(make().dataListItemComponent()).toBeTruthy()
+  })
+
+  it('contrasts with a regular field, which is submittable by default', () => {
+    const data: TextFieldData = {
+      type: 'text',
+      key: 'name',
+      labelEn: 'Name',
+      labelJa: '名前',
+      filterKey: 'name',
+      sortable: false,
+      freeze: false,
+      width: 0,
+      required: false,
+      rules: [],
+      placeholderEn: null,
+      placeholderJa: null,
+      helpEn: null,
+      helpJa: null,
+      unitBefore: null,
+      unitAfter: null
+    }
+    expect(new TextField(ctx(), data).isSubmittable()).toBe(true)
+  })
+})

--- a/tests/blocks/lens/fields/RelatedManyField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedManyField.spec.ts
@@ -1,14 +1,39 @@
+import { mount } from '@vue/test-utils'
 import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
 import { type RelatedManyFieldData } from 'sefirot/blocks/lens/FieldData'
 import { type ResourceFetcher } from 'sefirot/blocks/lens/ResourceFetcher'
 import { RelatedManyField } from 'sefirot/blocks/lens/fields/RelatedManyField'
+import SDescAvatar from 'sefirot/components/SDescAvatar.vue'
+import SDescPill from 'sefirot/components/SDescPill.vue'
+import { DataListStateKey } from 'sefirot/composables/DataList'
+import { computed } from 'vue'
 
 function ctx(lang: 'en' | 'ja' = 'en'): FieldContext {
   return { lang }
 }
 
+function mountDataListItem(field: RelatedManyField, value: any) {
+  return mount(field.dataListItemComponent(), {
+    props: { value },
+    global: {
+      provide: {
+        [DataListStateKey]: { labelWidth: computed(() => '100px') }
+      }
+    }
+  })
+}
+
 function makeFetcher(response: any): ResourceFetcher {
   return (async () => response) as unknown as ResourceFetcher
+}
+
+function captureFetcher(response: any) {
+  const calls: Array<[string, string, any]> = []
+  const fetcher = (async (method: any, url: any, body: any) => {
+    calls.push([method, url, body])
+    return response
+  }) as unknown as ResourceFetcher
+  return { fetcher, calls }
 }
 
 function make(
@@ -150,6 +175,64 @@ describe('blocks/lens/fields/RelatedManyField', () => {
         { type: 'avatar', label: 'Alice', image: 'https://example.com/a.png', value: 1 },
         { type: 'avatar', label: 'Bob', image: 'https://example.com/b.png', value: 2 }
       ])
+    })
+  })
+
+  describe('resourceEndpointBody forwarding', () => {
+    const body = { entity: 'topic', select: ['id', 'name'], perPage: 1000 }
+
+    it('forwards the configured body to the fetcher in tableFilterMenu', async () => {
+      const { fetcher, calls } = captureFetcher([])
+      await make(
+        { resourceEndpointMethod: 'post', resourceEndpointBody: body },
+        fetcher
+      ).tableFilterMenu([], () => {})
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual(['post', '/api/members', body])
+    })
+
+    it('forwards the configured body to the fetcher in availableFilters', async () => {
+      const { fetcher, calls } = captureFetcher([])
+      const filters = make(
+        { resourceEndpointMethod: 'post', resourceEndpointBody: body },
+        fetcher
+      ).availableFilters()
+      await (filters['='] as any).optionsResolver()
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual(['post', '/api/members', body])
+    })
+  })
+
+  describe('dataListItemComponent', () => {
+    it('renders one pill per item title by default', () => {
+      const wrapper = mountDataListItem(make(), [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' }
+      ])
+      const desc = wrapper.findComponent(SDescPill)
+      expect(desc.exists()).toBe(true)
+      expect(desc.props('pill')).toEqual([{ label: 'Alice' }, { label: 'Bob' }])
+      wrapper.unmount()
+    })
+
+    it('renders avatars when displayAs is "avatars"', () => {
+      const wrapper = mountDataListItem(
+        make({ displayAs: 'avatars', image: 'avatarUrl' }),
+        [{ id: 1, name: 'Alice', avatarUrl: 'https://example.com/a.png' }]
+      )
+      const desc = wrapper.findComponent(SDescAvatar)
+      expect(desc.exists()).toBe(true)
+      expect(desc.props('avatar')).toEqual([
+        { avatar: 'https://example.com/a.png', name: 'Alice' }
+      ])
+      wrapper.unmount()
+    })
+
+    it('renders the empty placeholder for an empty list', () => {
+      const wrapper = mountDataListItem(make(), [])
+      expect(wrapper.findComponent(SDescPill).exists()).toBe(false)
+      expect(wrapper.findComponent(SDescAvatar).exists()).toBe(false)
+      wrapper.unmount()
     })
   })
 })

--- a/tests/blocks/lens/fields/RelatedOneField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedOneField.spec.ts
@@ -84,7 +84,7 @@ describe('blocks/lens/fields/RelatedOneField', () => {
       expect((make().tableCell(undefined, {}) as any).value).toBeNull()
     })
 
-    it('renders an empty string (not null) when the title is missing, so the table does not fall back to the raw object', () => {
+    it('renders an empty string (not null) when the title is missing', () => {
       const cell = make().tableCell({ id: 1 }, {}) as any
       expect(cell.value).toBe('')
     })

--- a/tests/blocks/lens/fields/RelatedOneField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedOneField.spec.ts
@@ -1,14 +1,38 @@
+import { mount } from '@vue/test-utils'
 import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
 import { type RelatedOneFieldData } from 'sefirot/blocks/lens/FieldData'
 import { type ResourceFetcher } from 'sefirot/blocks/lens/ResourceFetcher'
 import { RelatedOneField } from 'sefirot/blocks/lens/fields/RelatedOneField'
+import SDescAvatar from 'sefirot/components/SDescAvatar.vue'
+import { DataListStateKey } from 'sefirot/composables/DataList'
+import { computed } from 'vue'
 
 function ctx(lang: 'en' | 'ja' = 'en'): FieldContext {
   return { lang }
 }
 
+function mountDataListItem(field: RelatedOneField, value: any) {
+  return mount(field.dataListItemComponent(), {
+    props: { value },
+    global: {
+      provide: {
+        [DataListStateKey]: { labelWidth: computed(() => '100px') }
+      }
+    }
+  })
+}
+
 function makeFetcher(response: any): ResourceFetcher {
   return (async () => response) as unknown as ResourceFetcher
+}
+
+function captureFetcher(response: any) {
+  const calls: Array<[string, string, any]> = []
+  const fetcher = (async (method: any, url: any, body: any) => {
+    calls.push([method, url, body])
+    return response
+  }) as unknown as ResourceFetcher
+  return { fetcher, calls }
 }
 
 function make(
@@ -182,6 +206,87 @@ describe('blocks/lens/fields/RelatedOneField', () => {
       expect(captured[0]).toEqual(['country', 'in', []])
       menu.onClick(2) // add
       expect(captured[1]).toEqual(['country', 'in', [1, 2]])
+    })
+  })
+
+  describe('resourceEndpointBody forwarding', () => {
+    const body = { entity: 'country', select: ['id', 'name'], perPage: 1000 }
+
+    it('forwards the configured body to the fetcher in tableFilterMenu', async () => {
+      const { fetcher, calls } = captureFetcher([])
+      await make(
+        { resourceEndpointMethod: 'post', resourceEndpointBody: body },
+        fetcher
+      ).tableFilterMenu([], () => {})
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual(['post', '/api/countries', body])
+    })
+
+    it('forwards the configured body to the fetcher in availableFilters', async () => {
+      const { fetcher, calls } = captureFetcher([])
+      const filters = make(
+        { resourceEndpointMethod: 'post', resourceEndpointBody: body },
+        fetcher
+      ).availableFilters()
+      await (filters['='] as any).optionsResolver()
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual(['post', '/api/countries', body])
+    })
+
+    it('passes an undefined body through when none is configured', async () => {
+      const { fetcher, calls } = captureFetcher([])
+      await make({}, fetcher).tableFilterMenu([], () => {})
+      expect(calls[0][2]).toBeUndefined()
+    })
+  })
+
+  describe('Lens id option value unwrapping', () => {
+    it('unwraps a `{ value, display }` id object to its scalar in tableFilterMenu', async () => {
+      const fetcher = makeFetcher([
+        { id: { value: 5, display: 'Japan' }, name: 'Japan' }
+      ])
+      const menu = (await make({ filterKey: 'id' }, fetcher).tableFilterMenu([], () => {})) as any
+      expect(menu.options).toEqual([{ label: 'Japan', value: 5 }])
+    })
+
+    it('unwraps a `{ value, display }` id object to its scalar in availableFilters', async () => {
+      const fetcher = makeFetcher([
+        { id: { value: 5, display: 'Japan' }, name: 'Japan' }
+      ])
+      const filters = make({ filterKey: 'id' }, fetcher).availableFilters()
+      const options = await (filters['='] as any).optionsResolver()
+      expect(options).toEqual([{ value: 5, label: 'Japan' }])
+    })
+
+    it('passes a plain scalar option value through untouched', async () => {
+      const fetcher = makeFetcher([{ id: 7, name: 'USA' }])
+      const menu = (await make({ filterKey: 'id' }, fetcher).tableFilterMenu([], () => {})) as any
+      expect(menu.options).toEqual([{ label: 'USA', value: 7 }])
+    })
+  })
+
+  describe('dataListItemComponent', () => {
+    it('renders the title as text by default', () => {
+      const wrapper = mountDataListItem(make(), { id: 1, name: 'Japan' })
+      expect(wrapper.text()).toContain('Japan')
+      wrapper.unmount()
+    })
+
+    it('renders an avatar with the title name when displayAs is "avatar"', () => {
+      const wrapper = mountDataListItem(
+        make({ displayAs: 'avatar', image: 'avatarUrl' }),
+        { id: 1, name: 'Alice', avatarUrl: 'https://example.com/a.png' }
+      )
+      const desc = wrapper.findComponent(SDescAvatar)
+      expect(desc.exists()).toBe(true)
+      expect(desc.props('avatar')).toEqual({ avatar: 'https://example.com/a.png', name: 'Alice' })
+      wrapper.unmount()
+    })
+
+    it('renders no avatar (empty placeholder) when the value is null', () => {
+      const wrapper = mountDataListItem(make({ displayAs: 'avatar', image: 'avatarUrl' }), null)
+      expect(wrapper.findComponent(SDescAvatar).exists()).toBe(false)
+      wrapper.unmount()
     })
   })
 })


### PR DESCRIPTION
## Summary

Adds editing to the Lens catalog — inline cell editing plus a record sheet for viewing, creating, editing, and deleting records — built around an **optimistic-update** model suited to a slow write API.

Supersedes #740 (closed), which reconciled by refetching. The target write API can take over a minute to sync, and a read during that window returns stale (pre-write) data — so re-reading after a write would revert the user's change. This reworks the flow around that constraint.

## Behavior

- **Update / delete — optimistic.** The in-memory result is patched immediately and the write runs in the background; the editor closes at once (no spinner). The server is never re-read to reconcile until the write settles.
- **Create — blocking.** The POST runs to completion (button spinner), then the catalog refreshes with the now-synced canonical state, preserving the active query. (If other optimistic writes are still syncing, the new row is prepended optimistically instead of refetching, so a stale read can't clobber them; a refresh failure also falls back to an optimistic prepend.) The sheet can't be dismissed while the create is saving.
- **Record sheet loads before it renders.** Opening a row's sheet shows a spinner while the full record is fetched (`/show` returns detail-only fields too, not just the selected columns), then renders the complete record — never partial fields. A failed detail load shows an error asking the user to reload rather than a partial sheet.
- **Reconcile → refresh button.** After a write batch settles cleanly, a background fetch gets the canonical state and, only if it differs from what's shown, stashes it behind a "Refresh" button — never auto-applied. A failed write shows a snackbar telling the user to reload.
- **Busy lock.** While a write is in flight, query controls (search, filters, sort, pagination) and the refresh button are locked, with a `beforeunload` guard (also armed during a create); editing other rows stays available.

## Concurrency

Reads are fast but the slow write means an in-flight read can still carry pre-write data, and writes can overlap — so ordering and read/write interleaving are handled explicitly:

- **In-flight reads never clobber optimistic state.** Query controls are locked during a write; the debounced refetch bails if a write or create begins in its window; and a search already past the network boundary is superseded by a newer write, create, forced refresh, or row-identifier change — it returns the current result instead of assigning its now-older rows. The post-write reconcile then surfaces the canonical state behind the Refresh button.
- **Writes are serialized by overlap.** Two writes to the same record are ordered when their field sets overlap (last edit wins); writes to disjoint fields run concurrently (the backend persists only the changed columns). A delete waits for that row's in-flight updates before its `DELETE` is sent.
- **Create is isolated.** On success the blocking create suppresses any search issued before it (so a stale read can't overwrite the just-created record); a *rejected* create instead lets that prior-query search land — it doesn't refetch, so suppressing it would strand the catalog on the old query — and re-schedules a debounced refresh the `creating` bail dropped, so a query change made just before submitting isn't lost on failure. It can't be double-submitted (a fast double-click is a no-op), re-checks that creation is still permitted at submit (closing if `creatable` was revoked after the sheet opened), and isn't dismissable while saving.
- **The open sheet stays bound to the live row.** `/show` for a record with a pending write preserves its optimistic values, and merges into the *current* row even if a refresh rebinds the sheet mid-load; applying the Refresh banner (or a direct refresh) rebinds the sheet to the fresh row, or closes it if the row is gone (or if the row identifier itself changes, since the open record can't be re-matched across identifier schemes).
- **Selection survives row shifts.** The table is keyed by the row identifier (reactively — even if `editable` or a custom `indexField` resolves or changes asynchronously after mount, a refetch pulls the identifier into the rows; until those rows actually carry it the selection key stays on the previous positional key and editing is held off, so a half-resolved identifier can't key every row to `undefined` and clear/misdirect the selection), so an optimistic create/delete that reorders rows can't move the selection onto the wrong records.

## Also in this PR

- `related_one` / `related_many` render readable detail rows (pills / avatars) instead of `[object Object]`; `content` fields render their Markdown body; resource fetches forward `resourceEndpointBody` (and send no body when none is set).
- Backend-only validation errors (e.g. `unique`) surface on the offending field in the create form via Vuelidate `$externalResults`.
- `useQuery` / `useMutation` now clear `loading` in a `finally`, so a failed request (e.g. a failed post-create refresh) no longer wedges the loading state.
- Guards: inline editing only for fields with a real input; the index-field cell opens the sheet (any field type) rather than being inline-editable; display-only fields excluded from submit; an open inline cell editor or sheet field editor closes — and its pending save re-checks the value after validation — when the backing record is replaced by a refresh, so a stale edit can't overwrite freshly fetched data; i18n for editor labels.

## Checks

- `pnpm check` green — type + lint + 1189 tests (incl. new `RelatedOne` / `RelatedMany` / `ContentField` specs).

> Treat as experimental. Known follow-ups: optimistic patching for avatar / file-upload fields (two-step upload); the create form only collects field types that implement a form input (text / textarea / select / content / link / file) — other types (boolean, number, decimal, datetime, related, avatar) are omitted, so mark only input-supported fields `showOnCreate` (or implement the input) until those land; deleting the last row of the last page leaves an empty page until refresh (by design — no refetch mid-write); and the `urlSync` query-change path isn't gated by the busy lock, so combining `urlSync` with `editable` (no page does today) could drop an optimistic edit on a mid-write back/forward. The row identifier (`indexField`) isn't optimistically editable on an existing row — only set on create — since changing a row's id mid-write would re-key it and misroute follow-up writes; this is enforced centrally (the index field is stripped from update payloads in `save()`), so even a custom sheet-slot save can't re-key a row. Relatedly, an editable catalog must keep its index field among the rendered columns (include it in `select`), since the row's sheet opener is the index-field cell — hiding it leaves the rows with no opener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







