### PR TITLE
feat(lens): support more validation rules and array-nested rules

### DIFF
--- a/lib/blocks/lens/Rule.ts
+++ b/lib/blocks/lens/Rule.ts
@@ -1,17 +1,81 @@
 export type Rule =
   | MaxLengthRule
+  | MinLengthRule
+  | MinValueRule
+  | MaxValueRule
   | RequiredRule
   | UniqueRule
+  | EmailRule
+  | UrlRule
+  | DecimalRule
+  | DecimalOrHyphenRule
+  | PositiveIntegerRule
+  | NegativeIntegerRule
+  | ZeroOrPositiveIntegerRule
+  | ZeroOrNegativeIntegerRule
+  | CheckedRule
   | SlackChannelLinkRule
   | SlackChannelNameRule
   | BeforeRule
   | BeforeOrEqualRule
   | AfterRule
   | AfterOrEqualRule
+  | EachRule
 
 export interface MaxLengthRule {
   type: 'max_length'
   length: number
+}
+
+export interface MinLengthRule {
+  type: 'min_length'
+  length: number
+}
+
+export interface MinValueRule {
+  type: 'min_value'
+  value: number
+}
+
+export interface MaxValueRule {
+  type: 'max_value'
+  value: number
+}
+
+export interface EmailRule {
+  type: 'email'
+}
+
+export interface UrlRule {
+  type: 'url'
+}
+
+export interface DecimalRule {
+  type: 'decimal'
+}
+
+export interface DecimalOrHyphenRule {
+  type: 'decimal_or_hyphen'
+}
+
+export interface PositiveIntegerRule {
+  type: 'positive_integer'
+}
+
+export interface NegativeIntegerRule {
+  type: 'negative_integer'
+}
+
+export interface ZeroOrPositiveIntegerRule {
+  type: 'zero_or_positive_integer'
+}
+
+export interface ZeroOrNegativeIntegerRule {
+  type: 'zero_or_negative_integer'
+}
+
+export interface CheckedRule {
+  type: 'checked'
 }
 
 export interface RequiredRule {
@@ -49,4 +113,13 @@ export interface AfterRule {
 export interface AfterOrEqualRule {
   type: 'after_or_equal'
   date: string
+}
+
+/**
+ * Applies the nested `rules` to every element of an array value, mirroring
+ * Laravel's `field.*` wildcard on the backend.
+ */
+export interface EachRule {
+  type: 'each'
+  rules: Rule[]
 }

--- a/lib/blocks/lens/validation/RuleMapper.ts
+++ b/lib/blocks/lens/validation/RuleMapper.ts
@@ -29,12 +29,10 @@ import { type EachRule, type Rule } from '../Rule'
  * Maps field rules to vuelidate validation rules.
  */
 export function map(rules: Rule[]): ValidationArgs {
-  return rules.reduce((carry: ValidationArgs<any>, rule: Rule) => {
-    // `each` validates every element of an array value rather than the value
-    // itself, so it maps to a single validator that runs the nested rules over
-    // each element (see `mapEach`).
+  const carry = rules.reduce((carry: ValidationArgs<any>, rule: Rule) => {
+    // `each` rules are handled separately below so that multiple of them on the
+    // same field compose rather than overwrite.
     if (rule.type === 'each') {
-      carry.each = mapEach(rule)
       return carry
     }
     const mapped = mapRule(rule)
@@ -43,6 +41,18 @@ export function map(rules: Rule[]): ValidationArgs {
     }
     return carry
   }, {})
+
+  // `each` validates every element of an array value rather than the value
+  // itself, so it maps to a single per-element validator (see `mapEach`). If a
+  // field carries more than one `each` rule, merge their child rules so every
+  // wildcard rule runs — the backend accumulates them the same way. A single
+  // `each` is the common case.
+  const eachRules = rules.filter((rule): rule is EachRule => rule.type === 'each')
+  if (eachRules.length) {
+    carry.each = mapEach({ type: 'each', rules: eachRules.flatMap((rule) => rule.rules) })
+  }
+
+  return carry
 }
 
 /**

--- a/lib/blocks/lens/validation/RuleMapper.ts
+++ b/lib/blocks/lens/validation/RuleMapper.ts
@@ -5,18 +5,38 @@ import {
   afterOrEqual,
   before,
   beforeOrEqual,
+  checked,
+  decimal,
+  decimalOrHyphen,
+  email,
   maxLength,
+  maxValue,
+  minLength,
+  minValue,
+  negativeInteger,
+  positiveInteger,
   required,
+  rule,
   slackChannelLink,
-  slackChannelName
+  slackChannelName,
+  url,
+  zeroOrNegativeInteger,
+  zeroOrPositiveInteger
 } from '../../../validation/rules'
-import { type Rule } from '../Rule'
+import { type EachRule, type Rule } from '../Rule'
 
 /**
  * Maps field rules to vuelidate validation rules.
  */
 export function map(rules: Rule[]): ValidationArgs {
   return rules.reduce((carry: ValidationArgs<any>, rule: Rule) => {
+    // `each` validates every element of an array value rather than the value
+    // itself, so it maps to a single validator that runs the nested rules over
+    // each element (see `mapEach`).
+    if (rule.type === 'each') {
+      carry.each = mapEach(rule)
+      return carry
+    }
     const mapped = mapRule(rule)
     if (mapped) {
       carry[rule.type] = mapped
@@ -25,10 +45,40 @@ export function map(rules: Rule[]): ValidationArgs {
   }, {})
 }
 
-function mapRule(rule: Rule): ValidationRuleWithParams | null {
+/**
+ * Builds a validator that applies an `each` rule's nested rules to every
+ * element of an array value. vuelidate's `forEach` only handles arrays of
+ * objects, so for the scalar arrays Lens fields hold (multi-select values,
+ * related ids) we run each element through the mapped child validators
+ * directly. Mirrors the backend, which expands the same rules onto Laravel's
+ * `key.*` wildcard. A non-array value fails; an empty/absent value is left to
+ * `required` (the rule is optional on its own).
+ */
+function mapEach(eachRule: EachRule): ValidationRuleWithParams {
+  // Map each child rule straight to a validator rather than through the
+  // type-keyed `map()` object, so two child rules of the same family are both
+  // kept (the backend's `key.*` expansion is additive and de-dupes nothing).
+  // Server-only children (e.g. `unique`) map to null and are dropped.
+  const childValidators = eachRule.rules
+    .map((r) => (r.type === 'each' ? mapEach(r) : mapRule(r)))
+    .filter((v): v is ValidationRuleWithParams => v !== null)
+
+  return rule((value) =>
+    Array.isArray(value)
+    && value.every((item) => childValidators.every((v) => v.$validator(item, {}, {}) === true))
+  )
+}
+
+function mapRule(rule: Exclude<Rule, EachRule>): ValidationRuleWithParams | null {
   switch (rule.type) {
     case 'max_length':
       return maxLength(rule.length)
+    case 'min_length':
+      return minLength(rule.length)
+    case 'min_value':
+      return minValue(rule.value)
+    case 'max_value':
+      return maxValue(rule.value)
     case 'required':
       return required()
     case 'unique':
@@ -36,6 +86,24 @@ function mapRule(rule: Rule): ValidationRuleWithParams | null {
       // database). The backend enforces it and returns a 422 with field
       // errors, so there is no client-side equivalent to apply here.
       return null
+    case 'email':
+      return email()
+    case 'url':
+      return url()
+    case 'decimal':
+      return decimal()
+    case 'decimal_or_hyphen':
+      return decimalOrHyphen()
+    case 'positive_integer':
+      return positiveInteger()
+    case 'negative_integer':
+      return negativeInteger()
+    case 'zero_or_positive_integer':
+      return zeroOrPositiveInteger()
+    case 'zero_or_negative_integer':
+      return zeroOrNegativeInteger()
+    case 'checked':
+      return checked()
     case 'slack_channel_link':
       return slackChannelLink()
     case 'slack_channel_name':

--- a/tests/blocks/lens/validation/RuleMapper.spec.ts
+++ b/tests/blocks/lens/validation/RuleMapper.spec.ts
@@ -64,6 +64,107 @@ describe('blocks/lens/validation/RuleMapper', () => {
     expect(args.after_or_equal.$validator(day('2026-01-01'), null, null)).toBe(false)
   })
 
+  it('maps min_length rule', () => {
+    const args = map([{ type: 'min_length', length: 3 }]) as any
+
+    expect(args.min_length.$validator('abc', null, null)).toBe(true)
+    expect(args.min_length.$validator('ab', null, null)).toBe(false)
+  })
+
+  it('maps min_value and max_value rules', () => {
+    const args = map([
+      { type: 'min_value', value: 10 },
+      { type: 'max_value', value: 20 }
+    ]) as any
+
+    expect(args.min_value.$validator(10, null, null)).toBe(true)
+    expect(args.min_value.$validator(9, null, null)).toBe(false)
+    expect(args.max_value.$validator(20, null, null)).toBe(true)
+    expect(args.max_value.$validator(21, null, null)).toBe(false)
+  })
+
+  it('maps email rule', () => {
+    const args = map([{ type: 'email' }]) as any
+
+    expect(args.email.$validator('jane@example.com', null, null)).toBe(true)
+    expect(args.email.$validator('not-an-email', null, null)).toBe(false)
+  })
+
+  it('maps url rule', () => {
+    const args = map([{ type: 'url' }]) as any
+
+    expect(args.url.$validator('https://example.com', null, null)).toBe(true)
+    expect(args.url.$validator('not a url', null, null)).toBe(false)
+  })
+
+  it('maps decimal rule', () => {
+    const args = map([{ type: 'decimal' }]) as any
+
+    expect(args.decimal.$validator(3.14, null, null)).toBe(true)
+    expect(args.decimal.$validator('abc', null, null)).toBe(false)
+  })
+
+  it('maps decimal_or_hyphen rule', () => {
+    const args = map([{ type: 'decimal_or_hyphen' }]) as any
+
+    expect(args.decimal_or_hyphen.$validator('-', null, null)).toBe(true)
+    expect(args.decimal_or_hyphen.$validator(3.14, null, null)).toBe(true)
+    expect(args.decimal_or_hyphen.$validator('abc', null, null)).toBe(false)
+  })
+
+  it('maps the integer sign rules', () => {
+    const args = map([
+      { type: 'positive_integer' },
+      { type: 'negative_integer' },
+      { type: 'zero_or_positive_integer' },
+      { type: 'zero_or_negative_integer' }
+    ]) as any
+
+    expect(args.positive_integer.$validator(1, null, null)).toBe(true)
+    expect(args.positive_integer.$validator(0, null, null)).toBe(false)
+    expect(args.negative_integer.$validator(-1, null, null)).toBe(true)
+    expect(args.negative_integer.$validator(0, null, null)).toBe(false)
+    expect(args.zero_or_positive_integer.$validator(0, null, null)).toBe(true)
+    expect(args.zero_or_positive_integer.$validator(-1, null, null)).toBe(false)
+    expect(args.zero_or_negative_integer.$validator(0, null, null)).toBe(true)
+    expect(args.zero_or_negative_integer.$validator(1, null, null)).toBe(false)
+  })
+
+  it('maps checked rule', () => {
+    const args = map([{ type: 'checked' }]) as any
+
+    expect(args.checked.$validator(true, null, null)).toBe(true)
+    expect(args.checked.$validator(false, null, null)).toBe(false)
+  })
+
+  it('maps each rule, validating every array element', () => {
+    const args = map([
+      { type: 'each', rules: [{ type: 'max_length', length: 5 }] }
+    ]) as any
+
+    expect(args.each.$validator(['ok', 'fine'], null, null)).toBe(true)
+    expect(args.each.$validator(['ok', 'toolong'], null, null)).toBe(false)
+    expect(args.each.$validator('not-an-array', null, null)).toBe(false)
+    // An empty array defers to `required`, so the each rule alone passes it.
+    expect(args.each.$validator([], null, null)).toBe(true)
+  })
+
+  it('maps each rule with a required child, rejecting empty elements', () => {
+    const args = map([{ type: 'each', rules: [{ type: 'required' }] }]) as any
+
+    expect(args.each.$validator(['a', 'b'], null, null)).toBe(true)
+    expect(args.each.$validator(['a', ''], null, null)).toBe(false)
+  })
+
+  it('maps each rule, dropping server-only children but keeping the rest', () => {
+    const args = map([
+      { type: 'each', rules: [{ type: 'unique' }, { type: 'max_length', length: 5 }] }
+    ]) as any
+
+    expect(args.each.$validator(['ok'], null, null)).toBe(true)
+    expect(args.each.$validator(['toolong'], null, null)).toBe(false)
+  })
+
   describe('relative date keywords', () => {
     beforeEach(() => {
       vi.useFakeTimers()

--- a/tests/blocks/lens/validation/RuleMapper.spec.ts
+++ b/tests/blocks/lens/validation/RuleMapper.spec.ts
@@ -165,6 +165,17 @@ describe('blocks/lens/validation/RuleMapper', () => {
     expect(args.each.$validator(['toolong'], null, null)).toBe(false)
   })
 
+  it('composes multiple each rules instead of keeping only the last', () => {
+    const args = map([
+      { type: 'each', rules: [{ type: 'min_length', length: 2 }] },
+      { type: 'each', rules: [{ type: 'max_length', length: 4 }] }
+    ]) as any
+
+    expect(args.each.$validator(['abc'], null, null)).toBe(true)
+    expect(args.each.$validator(['a'], null, null)).toBe(false)
+    expect(args.each.$validator(['abcde'], null, null)).toBe(false)
+  })
+
   describe('relative date keywords', () => {
     beforeEach(() => {
       vi.useFakeTimers()


### PR DESCRIPTION
## Summary

Extends the Lens `RuleMapper` so more of the validation rules a field can
declare are mapped to their client-side vuelidate validators, keeping
client-side validation in parity with what the backend enforces. Also adds
an `each` rule for validating the elements of array-valued fields.

## Rule types now mapped

| Rule | vuelidate validator |
| --- | --- |
| `min_length` | `minLength` |
| `min_value` / `max_value` | `minValue` / `maxValue` |
| `email` | `email` |
| `url` | `url` |
| `decimal` | `decimal` |
| `decimal_or_hyphen` | `decimalOrHyphen` |
| `positive_integer` / `negative_integer` | `positiveInteger` / `negativeInteger` |
| `zero_or_positive_integer` / `zero_or_negative_integer` | `zeroOrPositiveInteger` / `zeroOrNegativeInteger` |
| `checked` | `checked` |

These pair with the rule definitions emitted by the backend; the wire format
is `{ type, ...params }` (e.g. `{ type: 'min_length', length: 10 }`).

## Array-nested rules (`each`)

A new `each` rule applies its nested rules to every element of an array-valued
field (multi-select values, related ids, etc.), mirroring the per-element
validation the backend performs.

vuelidate's `forEach` only validates arrays of **objects** (it inspects each
item's properties), so it doesn't fit the **scalar** arrays these fields hold.
`mapEach` instead builds a composite validator that runs the mapped child
validators against each element. It supports nesting (`each` inside `each`),
drops server-only children (e.g. `unique`) that have no client equivalent, and
— when a field declares more than one `each` rule — merges their child rules so
every per-element rule runs (matching how the backend accumulates them).

As elsewhere in Lens, client-side validation is best-effort — the server stays
authoritative and re-validates on submit.

## Test plan

- `tests/blocks/lens/validation/RuleMapper.spec.ts` — a case per new rule plus
  `each` (element validation, required child, non-array rejection, empty-array
  defer-to-required, server-only child dropping, and multiple-`each`
  composition).
- `pnpm test:fail`, `pnpm type`, and `pnpm lint:fail` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
