### PR TITLE
fix(lens): respect a server-provided id link in editable catalogs

### DIFF
--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -125,15 +125,23 @@ const columns = computedAsync(async () => {
     // off the configured index field for any field type — a slug/code identifier
     // opens the sheet just like an `id` — so other id-type columns (e.g. a
     // `company_id` reference link) keep their own navigation.
+    //
+    // Exception: when the server gives the id cell its own link (the id's `path`),
+    // respect it — that row's id navigates to the path and does not open the sheet.
+    // Decided per row, so id's with a path link out while id's without one still
+    // open the sheet.
     if (
       edit?.editable
       && key === edit.indexField
     ) {
       const original = column.cell
       column.cell = (v: any, r: any): TableCell<any, any> => {
-        const cell = typeof original === 'function' ? original(v, r) : original
+        const cell = (typeof original === 'function' ? original(v, r) : original) as TableCell<any, any>
+        if ('link' in cell && cell.link) {
+          return cell
+        }
         return {
-          ...(cell as TableCell<any, any>),
+          ...cell,
           link: null,
           color: 'info',
           onClick: () => edit.openSheet(r)

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -126,22 +126,24 @@ const columns = computedAsync(async () => {
     // opens the sheet just like an `id` — so other id-type columns (e.g. a
     // `company_id` reference link) keep their own navigation.
     //
-    // Exception: when the server gives the id cell its own link (the id's `path`),
-    // respect it — that row's id navigates to the path and does not open the sheet.
-    // Decided per row, so id's with a path link out while id's without one still
-    // open the sheet.
+    // Exception: an `id` field whose server value carries a `path` renders that
+    // path as a link; respect it so those rows navigate to the details page instead
+    // of opening the sheet (decided per row, so id's without a path still open it).
+    // Scoped to `id` fields — a custom index field that itself renders a link (e.g.
+    // a `link` / `slack_message` identifier) is still turned into the sheet opener,
+    // as is a column whose `cell` is undefined (falls straight through to the opener).
     if (
       edit?.editable
       && key === edit.indexField
     ) {
       const original = column.cell
       column.cell = (v: any, r: any): TableCell<any, any> => {
-        const cell = (typeof original === 'function' ? original(v, r) : original) as TableCell<any, any>
-        if ('link' in cell && cell.link) {
+        const cell = typeof original === 'function' ? original(v, r) : original
+        if (overriddenFieldData.type === 'id' && cell && 'link' in cell && cell.link) {
           return cell
         }
         return {
-          ...cell,
+          ...(cell as TableCell<any, any>),
           link: null,
           color: 'info',
           onClick: () => edit.openSheet(r)

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -143,11 +143,13 @@ const columns = computedAsync(async () => {
           return cell
         }
         return {
-          ...(cell as TableCell<any, any>),
+          ...cell,
           link: null,
+          // @ts-expect-error avatar and day cells don't have info as color,
+          // but we don't use those for the index field anyway, so it's safe to force it here
           color: 'info',
           onClick: () => edit.openSheet(r)
-        } as TableCell<any, any>
+        }
       }
     } else if (
       props.inlineEditable


### PR DESCRIPTION
## What

In an editable `LensCatalog`, the row-identifier (id) cell is repurposed as the record-sheet opener — its link is stripped and a click opens the sheet instead of navigating.

This adds an exception: when the server gives the id cell its own link (the id's `path`), that link is respected. The cell renders as a link and navigates on click rather than opening the sheet. The decision is made per row, so id's that carry a `path` link out while id's without one still open the sheet.

## Why

A backend can point a row's id at a details page through the id field's `path`. Previously, enabling `editable` overrode that link unconditionally with the sheet opener, so a server-provided link was lost. Now an explicit server link wins.

## Test plan

- `pnpm type` (vue-tsc) — 0 errors.
- `pnpm lint` — clean.
- `pnpm test` — lens suite (120 tests) passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
