### PR TITLE
fix(lens): only render a table column once its definition is built

### DIFF
--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -68,11 +68,6 @@ const columnKeys = computed(() => {
   return visible.map((k) => (k === '__empty__' ? `__empty__::${emptyIndex++}` : k))
 })
 
-const orders = computed(() => [
-  ...columnKeys.value,
-  '__last_empty__'
-])
-
 const columns = computedAsync(async () => {
   const r = props.result
 
@@ -193,6 +188,18 @@ const columns = computedAsync(async () => {
 
   return columns
 }, {})
+
+// Render a column only once its definition exists. `columns` resolves
+// asynchronously (computedAsync), so when a column is toggled back on its key
+// lands in `columnKeys` a tick before `columns` rebuilds to include it. Emitting
+// that key in `orders` during the gap makes STable render the column with no cell
+// definition — STableCell then falls back to STableCellText with the raw value
+// (e.g. the `id` field's `{ value, display, path }` object), tripping a Vue
+// prop-type warning. Gating on presence in `columns` keeps the two in lockstep.
+const orders = computed(() => [
+  ...columnKeys.value.filter((key) => key in columns.value),
+  '__last_empty__'
+])
 
 const table = useTable({
   records,


### PR DESCRIPTION
## What

Fixes a Vue prop-type warning (`Invalid prop: type check failed for prop "text". Expected String | Null, got Object`) that appeared in a Lens catalog after toggling a column off and back on through the table view editor.

## Why

`LensTable` derived the column render order (`orders`) synchronously from the selected keys, but the column **definitions** (`columns`) are built in a `computedAsync`. Re-selecting a column put its key into `orders` a tick before `columns` rebuilt to include it. Because `STable` renders any `orders` key even when its column definition is missing, the cell fell back to `STableCellText` with the raw field value — for an `id` field that value is an object (`{ value, display, path }`), which fails the `text` prop's `String | Null` check. The column rendered correctly once `columns` caught up a tick later, so it was a transient console warning rather than a visible break.

## Fix

`orders` now only includes keys whose definition already exists in the resolved `columns` map, so a column and its cell definition always appear together — there's no frame where a column is rendered without its definition. As a side benefit, a selected key with no field definition now renders nothing instead of a definitionless column.

## Test plan

- `pnpm type` (vue-tsc) — 0 errors.
- `pnpm lint` — clean.
- `pnpm test` — lens suite (120 tests) passing.
- Confirmed locally: toggling the `id` column off/on in a catalog no longer emits the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
