### PR TITLE
fix(lens): surface server error messages instead of generic or silent failures

### DIFF
--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -208,12 +208,14 @@ const emit = defineEmits<{
 const { t } = useTrans({
   en: {
     write_error: 'We couldn’t save your change. Please reload and try again.',
+    write_error_recover: 'Please reload to see the latest.',
     busy_warning: 'Still saving — please wait a moment before changing the view.',
     refresh_text: 'Newer results are available.',
     refresh_action: 'Refresh'
   },
   ja: {
     write_error: '変更を保存できませんでした。ページを再読み込みして、もう一度お試しください。',
+    write_error_recover: 'ページを再読み込みして最新の状態をご確認ください。',
     busy_warning: '保存中です。表示を変更する前に少しお待ちください。',
     refresh_text: '新しい結果があります。',
     refresh_action: '更新'
@@ -951,9 +953,15 @@ function trackWrite(recordId: any, key: string, run: () => Promise<unknown>): vo
       batchErrored = true
       // Prefer a server-provided reason (a policy / business-rule deny, a
       // validation message) so a rejected write explains itself instead of the
-      // generic "reload" copy — which also wouldn't fix a deliberate 4xx denial.
-      // Fall back to write_error for network / 5xx / opaque failures.
-      snackbars.push({ mode: 'danger', text: extractServerMessage(e) ?? t.write_error })
+      // generic copy. The optimistic edit was already applied and isn't rolled
+      // back here, so keep the reload-to-resync guidance alongside the reason.
+      // Fall back to write_error (which carries its own guidance) for network /
+      // 5xx / opaque / auth failures, where extractServerMessage returns null.
+      const reason = extractServerMessage(e)
+      snackbars.push({
+        mode: 'danger',
+        text: reason ? `${reason} ${t.write_error_recover}` : t.write_error
+      })
     })
     .finally(() => {
       // Only drop the chain entry if a newer write hasn't replaced it.

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -13,6 +13,7 @@ import { type LensQuery, type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
 import { useCatalogUrlQuerySync } from '../composables/CatalogUrlQuerySync'
 import { provideLensEdit } from '../composables/LensEdit'
+import { extractServerMessage } from '../validation/ServerErrors'
 import LensCatalogControl, { type FilterPresets } from './LensCatalogControl.vue'
 import LensCatalogFooter from './LensCatalogFooter.vue'
 import LensCatalogStateFilter from './LensCatalogStateFilter.vue'
@@ -946,9 +947,13 @@ function trackWrite(recordId: any, key: string, run: () => Promise<unknown>): vo
   writeChains.set(key, current)
 
   current
-    .catch(() => {
+    .catch((e) => {
       batchErrored = true
-      snackbars.push({ mode: 'danger', text: t.write_error })
+      // Prefer a server-provided reason (a policy / business-rule deny, a
+      // validation message) so a rejected write explains itself instead of the
+      // generic "reload" copy — which also wouldn't fix a deliberate 4xx denial.
+      // Fall back to write_error for network / 5xx / opaque failures.
+      snackbars.push({ mode: 'danger', text: extractServerMessage(e) ?? t.write_error })
     })
     .finally(() => {
       // Only drop the chain entry if a newer write hasn't replaced it.

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -207,14 +207,14 @@ const emit = defineEmits<{
 
 const { t } = useTrans({
   en: {
-    write_error: 'Your latest changes might not be saved. Please reload the page, and contact support if the problem persists.',
-    busy_warning: 'A save is still in progress — changes you make now may not be saved.',
+    write_error: 'We couldn’t save your change. Please reload and try again.',
+    busy_warning: 'Still saving — please wait a moment before changing the view.',
     refresh_text: 'Newer results are available.',
     refresh_action: 'Refresh'
   },
   ja: {
-    write_error: '最新の変更が保存されていない可能性があります。ページを再読み込みし、問題が解決しない場合はサポートにお問い合わせください。',
-    busy_warning: '保存処理中です。ここでの変更は保存されない可能性があります。',
+    write_error: '変更を保存できませんでした。ページを再読み込みして、もう一度お試しください。',
+    busy_warning: '保存中です。表示を変更する前に少しお待ちください。',
     refresh_text: '新しい結果があります。',
     refresh_action: '更新'
   }

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -9,10 +9,11 @@ import { provideDataListState } from '../../../composables/DataList'
 import { useTrans } from '../../../composables/Lang'
 import { usePower } from '../../../composables/Power'
 import { useValidation } from '../../../composables/Validation'
+import { useSnackbars } from '../../../stores/Snackbars'
 import { type FieldData } from '../FieldData'
 import { useFieldFactory } from '../composables/FieldFactory'
 import { useLensEdit } from '../composables/LensEdit'
-import { extractServerErrors } from '../validation/ServerErrors'
+import { extractServerErrors, extractServerMessage } from '../validation/ServerErrors'
 import LensSheetField from './LensSheetField.vue'
 
 const props = withDefaults(defineProps<{
@@ -61,6 +62,7 @@ const { t } = useTrans({
 
 const edit = useLensEdit()
 const factory = useFieldFactory()
+const snackbars = useSnackbars()
 
 // Provide the data-list label width directly (instead of wrapping rows in
 // SDataList) so each LensSheetField wrapper doesn't make its SDataListItem a
@@ -202,13 +204,23 @@ async function onCreate() {
     await edit!.create(values)
     emit('close')
   } catch (e) {
-    // Surface backend validation errors (e.g. a duplicate `unique` value) on
-    // the offending fields; rethrow anything that isn't a 422.
+    // Surface backend validation errors (e.g. a duplicate `unique` value) on the
+    // offending fields. Failing that, surface a server-provided message (a policy
+    // / business-rule deny, or a form-level 422) as a snackbar and keep the sheet
+    // open with the input intact — rather than rethrowing into the global
+    // full-page error handler. Only genuinely unexpected failures (no usable
+    // message: network, 5xx, opaque) propagate.
     const errors = extractServerErrors(e)
-    if (!errors) {
-      throw e
+    if (errors) {
+      serverErrors.value = errors
+      return
     }
-    serverErrors.value = errors
+    const message = extractServerMessage(e)
+    if (message) {
+      snackbars.push({ mode: 'danger', text: message })
+      return
+    }
+    throw e
   } finally {
     saving.value = false
   }

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -208,8 +208,9 @@ async function onCreate() {
     // offending fields. Failing that, surface a server-provided message (a policy
     // / business-rule deny, or a form-level 422) as a snackbar and keep the sheet
     // open with the input intact — rather than rethrowing into the global
-    // full-page error handler. Only genuinely unexpected failures (no usable
-    // message: network, 5xx, opaque) propagate.
+    // full-page error handler. Failures without a displayable message — network,
+    // 5xx, opaque, and auth / session expiry (which extractServerMessage excludes
+    // so the app can prompt re-auth) — still propagate.
     const errors = extractServerErrors(e)
     if (errors) {
       serverErrors.value = errors

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -47,7 +47,7 @@ const { t } = useTrans({
     confirm_delete: 'Delete this record?',
     new_record: 'New record',
     load_error:
-      'Couldn’t load this record. Please reload the page, and contact support if the problem persists.'
+      'We couldn’t load this record. Please reload the page and try again.'
   },
   ja: {
     create: '作成',
@@ -56,7 +56,7 @@ const { t } = useTrans({
     confirm_delete: 'このレコードを削除しますか？',
     new_record: '新規作成',
     load_error:
-      'このレコードを読み込めませんでした。ページを再読み込みし、問題が解決しない場合はサポートにお問い合わせください。'
+      'このレコードを読み込めませんでした。ページを再読み込みして、もう一度お試しください。'
   }
 })
 

--- a/lib/blocks/lens/composables/FileDownloader.ts
+++ b/lib/blocks/lens/composables/FileDownloader.ts
@@ -7,7 +7,7 @@ export function useFileDownloader(): FileDownloader {
   const snackbars = useSnackbars()
 
   const { t } = useTrans({
-    en: { download_error: 'Couldn’t download this file. Please try again.' },
+    en: { download_error: 'We couldn’t download this file. Please try again.' },
     ja: { download_error: 'ファイルをダウンロードできませんでした。もう一度お試しください。' }
   })
 

--- a/lib/blocks/lens/composables/FileDownloader.ts
+++ b/lib/blocks/lens/composables/FileDownloader.ts
@@ -1,10 +1,30 @@
 import { useGet } from '../../../composables/Api'
+import { useTrans } from '../../../composables/Lang'
+import { useSnackbars } from '../../../stores/Snackbars'
 import { type FileDownloader } from '../FileDownloader'
 
 export function useFileDownloader(): FileDownloader {
+  const snackbars = useSnackbars()
+
+  const { t } = useTrans({
+    en: { download_error: 'Couldn’t download this file. Please try again.' },
+    ja: { download_error: 'ファイルをダウンロードできませんでした。もう一度お試しください。' }
+  })
+
   const { execute: fileDownloader } = useGet<any, [url: string]>(async (http, url) => {
     return http.download(url)
   })
 
-  return fileDownloader
+  // The click binding (e.g. SDescFile's `@click`) doesn't await the returned
+  // promise, so a failed download would otherwise be an unhandled rejection with
+  // no feedback — the click just appears to do nothing. Catch and surface a
+  // snackbar. The response is a blob, so the server's message isn't readily
+  // decodable here; generic copy is the right level.
+  return async (url) => {
+    try {
+      return await fileDownloader(url)
+    } catch {
+      snackbars.push({ mode: 'danger', text: t.download_error })
+    }
+  }
 }

--- a/lib/blocks/lens/composables/FileDownloader.ts
+++ b/lib/blocks/lens/composables/FileDownloader.ts
@@ -2,6 +2,7 @@ import { useGet } from '../../../composables/Api'
 import { useTrans } from '../../../composables/Lang'
 import { useSnackbars } from '../../../stores/Snackbars'
 import { type FileDownloader } from '../FileDownloader'
+import { isAuthError } from '../validation/ServerErrors'
 
 export function useFileDownloader(): FileDownloader {
   const snackbars = useSnackbars()
@@ -23,7 +24,13 @@ export function useFileDownloader(): FileDownloader {
   return async (url) => {
     try {
       return await fileDownloader(url)
-    } catch {
+    } catch (e) {
+      // Let auth / session-expiry failures (401 / 419) propagate to the app's
+      // error flow so it can prompt re-authentication — the click path doesn't
+      // await this, so the rejection reaches the global handler as it did before.
+      if (isAuthError(e)) {
+        throw e
+      }
       snackbars.push({ mode: 'danger', text: t.download_error })
     }
   }

--- a/lib/blocks/lens/composables/ResourceFetcher.ts
+++ b/lib/blocks/lens/composables/ResourceFetcher.ts
@@ -33,6 +33,12 @@ export function useResourceFetcher(): ResourceFetcher {
         data.value[key] = response
         delete pendingList[key]
         return response
+      },
+      (error) => {
+        // Clear the pending entry on failure too — otherwise the rejected promise
+        // stays cached under `key` and every retry returns the same rejection.
+        delete pendingList[key]
+        throw error
       }
     )
 

--- a/lib/blocks/lens/filter-inputs/SelectFilterInput.ts
+++ b/lib/blocks/lens/filter-inputs/SelectFilterInput.ts
@@ -53,10 +53,19 @@ export class SelectFilterInput extends FilterInput {
   }
 
   async valueToText(value: any): Promise<string> {
-    const options = await this.resolveOptions()
+    // Degrade gracefully: if the options can't be fetched, or the applied filter
+    // value isn't among them (the option set changed, or the referenced record was
+    // deleted), fall back to the raw value instead of asserting — a throw here
+    // leaves the filter chip stuck on its loading placeholder forever.
+    let options: Option[] = []
+    try {
+      options = await this.resolveOptions()
+    } catch {
+      options = []
+    }
 
     return this.valueAsArray(value)
-      .map((v) => options.find((o) => o.value === v)!.label)
+      .map((v) => options.find((o) => o.value === v)?.label ?? String(v))
       .join(', ')
   }
 

--- a/lib/blocks/lens/filter-inputs/SelectFilterInput.ts
+++ b/lib/blocks/lens/filter-inputs/SelectFilterInput.ts
@@ -2,6 +2,7 @@ import { type ValidationArgs } from '@vuelidate/core'
 import { defineAsyncComponent } from 'vue'
 import SInputDropdown, { type Option } from '../../../components/SInputDropdown.vue'
 import { required } from '../../../validation/rules'
+import { isAuthError } from '../validation/ServerErrors'
 import { FilterInput } from './FilterInput'
 
 export class SelectFilterInput extends FilterInput {
@@ -60,7 +61,13 @@ export class SelectFilterInput extends FilterInput {
     let options: Option[] = []
     try {
       options = await this.resolveOptions()
-    } catch {
+    } catch (e) {
+      // Let auth / session-expiry failures reach the app's error / re-auth flow
+      // instead of silently degrading to raw values. Other failures — an option
+      // miss or a non-auth fetch error — fall back so the chip stays readable.
+      if (isAuthError(e)) {
+        throw e
+      }
       options = []
     }
 

--- a/lib/blocks/lens/validation/ServerErrors.ts
+++ b/lib/blocks/lens/validation/ServerErrors.ts
@@ -25,15 +25,35 @@ export function extractServerErrors(error: unknown): Record<string, string[]> | 
 }
 
 /**
+ * Auth / session-expiry statuses (Laravel: 401 unauthenticated, 419 session /
+ * CSRF token expired). These need the app-level error flow — e.g. to prompt
+ * re-authentication — so Lens never surfaces them inline or swallows them into a
+ * snackbar; callers let them propagate to the global handler instead.
+ */
+const AUTH_STATUSES = new Set([401, 419])
+
+export function isAuthError(error: unknown): boolean {
+  return isFetchError(error) && error.status != null && AUTH_STATUSES.has(error.status)
+}
+
+/**
  * Extract a human-readable top-level message from a failed request, when the
  * server provides one worth showing the user. Laravel includes a `message` on
  * most error responses — policy denials (`Response::deny('…')`), business-rule
  * rejections, and 422 summaries. Limited to 4xx so internal 5xx detail never
- * leaks to the UI; 5xx / network / opaque failures return `null` so the caller
- * can fall back to its own generic copy.
+ * leaks to the UI, and excludes auth / session statuses (see `isAuthError`) so
+ * those reach the app's re-auth flow rather than being shown inline. 5xx /
+ * network / opaque / auth failures return `null` so the caller can fall back to
+ * its own generic copy or rethrow.
  */
 export function extractServerMessage(error: unknown): string | null {
-  if (!isFetchError(error) || error.status == null || error.status < 400 || error.status >= 500) {
+  if (
+    !isFetchError(error)
+    || error.status == null
+    || error.status < 400
+    || error.status >= 500
+    || AUTH_STATUSES.has(error.status)
+  ) {
     return null
   }
 

--- a/lib/blocks/lens/validation/ServerErrors.ts
+++ b/lib/blocks/lens/validation/ServerErrors.ts
@@ -23,3 +23,21 @@ export function extractServerErrors(error: unknown): Record<string, string[]> | 
 
   return errors
 }
+
+/**
+ * Extract a human-readable top-level message from a failed request, when the
+ * server provides one worth showing the user. Laravel includes a `message` on
+ * most error responses — policy denials (`Response::deny('…')`), business-rule
+ * rejections, and 422 summaries. Limited to 4xx so internal 5xx detail never
+ * leaks to the UI; 5xx / network / opaque failures return `null` so the caller
+ * can fall back to its own generic copy.
+ */
+export function extractServerMessage(error: unknown): string | null {
+  if (!isFetchError(error) || error.status == null || error.status < 400 || error.status >= 500) {
+    return null
+  }
+
+  const message = (error.data as any)?.message
+
+  return typeof message === 'string' && message.trim() !== '' ? message : null
+}


### PR DESCRIPTION
## What

First-cut improvements to error handling across the Lens block, from an audit of its failure paths. Several discarded the server's human-readable message and instead showed a generic "reload the page" string, took over the whole page with a full-page error, or failed silently with no feedback.

## Changes

- **`extractServerMessage()`** — a new helper alongside `extractServerErrors` that pulls the top-level `message` from a failed request, limited to `4xx` so internal `5xx` detail never leaks to the UI. Auth / session statuses (`401` / `419`, via a shared `isAuthError`) are excluded so they reach the app's error / re-auth flow rather than being shown inline.
- **Create failures** no longer rethrow into the global full-page error handler. A server-provided message (a policy / business-rule denial, or a form-level `422`) shows as a snackbar and the create sheet stays open with the input intact. Auth / session failures and anything without a displayable message (network, `5xx`, opaque) still propagate.
- **Optimistic update / delete failures** surface the server's reason (e.g. "Cannot delete a published post.") instead of the blanket "reload" copy. Because the optimistic edit isn't rolled back, a reload-to-resync hint is kept alongside the reason; the generic message stays as the fallback for network / `5xx` / opaque / auth failures.
- **File downloads** now catch and show a snackbar on failure instead of an unhandled rejection, while rethrowing auth / session failures so they still reach the app's error flow.
- **`ResourceFetcher`** clears its pending entry on a failed fetch — previously a rejected promise stayed cached under its key, so every retry returned the same rejection (latent bug).
- **Filter chips** fall back to the raw value when an applied filter value isn't among the resolved options (option set changed, referenced record deleted, or the option fetch failed) instead of asserting and getting stuck on the loading placeholder.
- **Friendlier copy** — rewrote the remaining generic error / warning strings (write, busy-while-saving, record load, download) to a plainer, less formal voice (EN + JA), dropping the wordy "contact support if the problem persists" boilerplate from the transient snackbars.

## Out of scope (follow-ups)

Identified by the audit / review but deliberately deferred — they touch the optimistic-write invariants or need a UX decision:
- Per-field error attribution and rollback for inline / sheet edits (surface a rejected `422` in-place, and revert a rejected optimistic change, rather than relying on a reload).
- Uniform auth propagation on the optimistic-write path (today an auth failure there shows the generic write copy, whose reload guidance routes the user to re-auth, rather than propagating like create / download).
- An in-catalog error state for a failed user-driven re-search (today a failed refetch leaves stale rows with no signal).
- An error / retry affordance for filter / related-field option fetches that fail.

## Test plan

- `pnpm type` (vue-tsc) — 0 errors.
- `pnpm lint` — clean.
- `pnpm test` — lens suite (120 tests) passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
