### PR TITLE
feat(lens): recover from failed optimistic writes and name the failed row

### DIFF
--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -212,6 +212,7 @@ const { t } = useTrans({
     delete_failed: (label: string) => `We couldn’t delete “${label}”.`,
     delete_failed_anon: 'We couldn’t delete this record.',
     write_error_reload: 'Please reload and try again.',
+    write_error_recover: 'Please reload to see the latest.',
     busy_warning: 'Still saving — please wait a moment before changing the view.',
     refresh_text: 'Newer results are available.',
     refresh_failed_text: 'Some changes couldn’t be saved. Refresh to restore the latest values.',
@@ -223,6 +224,7 @@ const { t } = useTrans({
     delete_failed: (label: string) => `「${label}」を削除できませんでした。`,
     delete_failed_anon: 'レコードを削除できませんでした。',
     write_error_reload: 'ページを再読み込みして、もう一度お試しください。',
+    write_error_recover: 'ページを再読み込みして最新の状態をご確認ください。',
     busy_warning: '保存中です。表示を変更する前に少しお待ちください。',
     refresh_text: '新しい結果があります。',
     refresh_failed_text: '保存できなかった変更があります。更新して最新の値に戻してください。',
@@ -963,16 +965,21 @@ function hasPendingWrite(recordId: any): boolean {
 }
 
 // Compose the failure snackbar: name the affected row when we have a label, then
-// append the server's reason (a policy / business-rule / validation message)
-// when present — it explains the failure and reloading wouldn't change it — or a
-// generic reload hint otherwise (network / 5xx / opaque, where reloading is the
-// actionable advice). The refresh banner, when it appears, handles restoring the
-// row's canonical value either way.
+// the server's reason (a policy / business-rule / validation message) when
+// present, and always a recovery hint. The optimistic value isn't rolled back, so
+// the user needs a way back to canonical state — the refresh banner offers a
+// one-click path when it appears, but it can't always (a failed recovery reconcile
+// shows none, and `isSameResult` can't see detail-only sheet fields absent from
+// the search), so the reload hint stays as the guaranteed fallback. With a reason
+// present, "reload to see the latest" (the change didn't take; reload to resync);
+// without one (network / 5xx / opaque), "reload and try again".
 function writeErrorText(op: 'save' | 'delete', label: string | null, reason: string | null): string {
   const subject = op === 'delete'
     ? (label != null ? t.delete_failed(label) : t.delete_failed_anon)
     : (label != null ? t.save_failed(label) : t.save_failed_anon)
-  return `${subject} ${reason ?? t.write_error_reload}`
+  return reason
+    ? `${subject} ${reason} ${t.write_error_recover}`
+    : `${subject} ${t.write_error_reload}`
 }
 
 // Track an optimistic background write for `recordId`, serialized per `key` so

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -496,6 +496,13 @@ const tableSelect = computed(() => {
   return withoutIndexField(result.value?.query.select ?? [])
 })
 
+// The effective row identifier when resolving / editing a row: the configured
+// `indexField`, or `id` by default. Distinct from the raw `props.indexField`,
+// whose `undefined` means "no index field configured" — `withIndexField` /
+// `withoutIndexField` rely on that to leave a non-editable catalog's columns
+// alone, so they deliberately keep using the prop directly rather than this.
+const idField = computed(() => props.indexField ?? 'id')
+
 // Whether the currently loaded rows actually carry the effective row identifier.
 // Editing / opening a row needs it (`resolveId`), but rows fetched while
 // `editable` was still false — or before an `indexField` change settled — won't
@@ -505,7 +512,7 @@ const tableSelect = computed(() => {
 const rowsCarryIndexField = computed(() => {
   const rows = result.value?.data
   if (!rows || rows.length === 0) { return true }
-  return (props.indexField ?? 'id') in rows[0]
+  return idField.value in rows[0]
 })
 
 // The row-identifier the table uses as its selection key. An explicit
@@ -732,7 +739,7 @@ let reconcileToken = 0
 // Resolve a record's identifier, unwrapping the id field's object shape
 // (`{ value, display, path }`) when present.
 function resolveId(record: Record<string, any>): any {
-  const v = record?.[props.indexField ?? 'id']
+  const v = record?.[idField.value]
   return v !== null && typeof v === 'object' ? v.value : v
 }
 
@@ -741,7 +748,7 @@ function resolveId(record: Record<string, any>): any {
 // identifier — to name the affected row in a write-failure snackbar. Null when
 // no usable label exists, so the snackbar can fall back to anonymous copy.
 function resolveLabel(record: Record<string, any>): string | null {
-  const v = record?.[props.indexField ?? 'id']
+  const v = record?.[idField.value]
   const label = v !== null && typeof v === 'object' ? (v.display ?? v.value) : v
   return label != null && label !== '' ? String(label) : null
 }
@@ -934,7 +941,7 @@ async function refreshCatalog(): Promise<void> {
 // `resolveId` would be `undefined`), which would let a delete/save act on the
 // wrong — or no — id during and after the refetch.
 watch(
-  () => (props.editable ? (props.indexField ?? 'id') : null),
+  () => (props.editable ? idField.value : null),
   (field, prev) => {
     if (!field || field === prev) { return }
     if (sheet.state.value && sheetMode.value === 'view') { sheet.off() }
@@ -1047,7 +1054,7 @@ function save(record: Record<string, any>, values: Record<string, any>): void {
   // row, so a follow-up save / delete would resolve to the new, not-yet-synced id
   // and miss the in-flight record. Strip it so the invariant holds for every
   // caller. (The identifier is still settable on create, which uses `create()`.)
-  const indexField = props.indexField ?? 'id'
+  const indexField = idField.value
   if (indexField in values) {
     values = { ...values }
     delete values[indexField]
@@ -1283,7 +1290,7 @@ provideLensEdit({
   // sheet opener and to block identifier edits, so it must track a prop that
   // resolves (or changes) after mount — otherwise the new identifier column stays
   // non-clickable while the old field is still treated as the id.
-  get indexField() { return props.indexField ?? 'id' },
+  get indexField() { return idField.value },
   canEdit,
   canDelete,
   resolveId,
@@ -1468,7 +1475,7 @@ defineExpose({
       :loading="sheetLoading"
       :error="sheetError"
       :fields="result.fields"
-      :index-field="indexField ?? 'id'"
+      :index-field="idField"
       :width="sheetWidth"
       @close="sheet.off"
     >

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -207,17 +207,25 @@ const emit = defineEmits<{
 
 const { t } = useTrans({
   en: {
-    write_error: 'We couldn’t save your change. Please reload and try again.',
-    write_error_recover: 'Please reload to see the latest.',
+    save_failed: (label: string) => `We couldn’t save “${label}”.`,
+    save_failed_anon: 'We couldn’t save your change.',
+    delete_failed: (label: string) => `We couldn’t delete “${label}”.`,
+    delete_failed_anon: 'We couldn’t delete this record.',
+    write_error_reload: 'Please reload and try again.',
     busy_warning: 'Still saving — please wait a moment before changing the view.',
     refresh_text: 'Newer results are available.',
+    refresh_failed_text: 'Some changes couldn’t be saved. Refresh to restore the latest values.',
     refresh_action: 'Refresh'
   },
   ja: {
-    write_error: '変更を保存できませんでした。ページを再読み込みして、もう一度お試しください。',
-    write_error_recover: 'ページを再読み込みして最新の状態をご確認ください。',
+    save_failed: (label: string) => `「${label}」を保存できませんでした。`,
+    save_failed_anon: '変更を保存できませんでした。',
+    delete_failed: (label: string) => `「${label}」を削除できませんでした。`,
+    delete_failed_anon: 'レコードを削除できませんでした。',
+    write_error_reload: 'ページを再読み込みして、もう一度お試しください。',
     busy_warning: '保存中です。表示を変更する前に少しお待ちください。',
     refresh_text: '新しい結果があります。',
+    refresh_failed_text: '保存できなかった変更があります。更新して最新の値に戻してください。',
     refresh_action: '更新'
   }
 })
@@ -238,9 +246,12 @@ const hasInitialResults = ref(false)
 
 // A fresher server result fetched after the optimistic writes settled, awaiting
 // the user's explicit opt-in via the refresh button — never auto-applied (that
-// would momentarily revert the optimistic edits to stale data). Declared here
-// (ahead of the query handlers that clear it) so they can reference it.
-const latestState = ref<LensResult | null>(null)
+// would momentarily revert the optimistic edits to stale data). `fromError` marks
+// a stash produced by a *failed* write (the optimistic value diverged from the
+// canonical one), so the banner can explain it's a recovery rather than just
+// newer data. Declared here (ahead of the query handlers that clear it) so they
+// can reference it.
+const latestState = ref<{ result: LensResult; fromError: boolean } | null>(null)
 
 // Count of optimistic background writes currently in flight. Declared here
 // (ahead of the debounced refetch that consults it) so a queued refetch can bail
@@ -694,8 +705,9 @@ const sheetError = ref(false)
 const reconciling = ref(false)
 const busy = computed(() => pendingWrites.value > 0 || reconciling.value)
 
-// Whether any write in the current in-flight batch failed; when so the reconcile
-// is skipped (the snackbar already told the user to reload).
+// Whether any write in the current in-flight batch failed; passed to the
+// post-batch reconcile so the refresh banner can label itself as a recovery for
+// the failed write's diverged row rather than just "newer data".
 let batchErrored = false
 
 // In-flight write chains keyed by record+field, so repeated writes to the same
@@ -722,6 +734,16 @@ let reconcileToken = 0
 function resolveId(record: Record<string, any>): any {
   const v = record?.[props.indexField ?? 'id']
   return v !== null && typeof v === 'object' ? v.value : v
+}
+
+// Resolve a human-facing label for a record — the index field's display value
+// (the id object's `{ value, display, path }` shape) falling back to the bare
+// identifier — to name the affected row in a write-failure snackbar. Null when
+// no usable label exists, so the snackbar can fall back to anonymous copy.
+function resolveLabel(record: Record<string, any>): string | null {
+  const v = record?.[props.indexField ?? 'id']
+  const label = v !== null && typeof v === 'object' ? (v.display ?? v.value) : v
+  return label != null && label !== '' ? String(label) : null
 }
 
 const { execute: executeUpdate } = useMutation((http, id: any, values: Record<string, any>) =>
@@ -799,8 +821,11 @@ function isSameResult(fresh: LensResult | null, shown: LensResult | null): boole
 
 // After the last in-flight write settles, fetch the canonical state for the
 // current query and, only if it differs from what's shown, stash it behind the
-// refresh button. The server is fresh by now (the write completed).
-async function reconcile(): Promise<void> {
+// refresh button. The server is fresh by now (the write completed). `afterError`
+// is set when a write in the batch *failed*: its optimistic edit wasn't rolled
+// back, so the canonical state diverges and the stash becomes the user's one-click
+// path to restore it — the banner labels it accordingly.
+async function reconcile(afterError = false): Promise<void> {
   const token = ++reconcileToken
   reconciling.value = true
   try {
@@ -813,9 +838,13 @@ async function reconcile(): Promise<void> {
     // Authoritative: stash the canonical result when it differs from what's
     // shown, otherwise clear any (possibly stale) stash — an earlier overlapping
     // reconcile may have left a pre-edit result behind.
-    latestState.value = result.value && !isSameResult(fresh, result.value) ? fresh : null
+    latestState.value = result.value && !isSameResult(fresh, result.value)
+      ? { result: fresh, fromError: afterError }
+      : null
   } catch {
-    // Ignore — keep the optimistic state, offer no refresh.
+    // Ignore — keep the optimistic state, offer no refresh. After a failed write
+    // this means no recovery banner, so the failure snackbar's reload guidance is
+    // the fallback.
   } finally {
     if (token === reconcileToken) {
       reconciling.value = false
@@ -825,7 +854,7 @@ async function reconcile(): Promise<void> {
 
 function applyLatest(): void {
   if (!latestState.value) { return }
-  result.value = latestState.value
+  result.value = latestState.value.result
   latestState.value = null
   prevFetchInput = null
   rebindOpenSheet()
@@ -920,14 +949,35 @@ watch(
 )
 
 // Track an optimistic background write: count it as pending, surface a snackbar
-// on failure, and once the whole batch settles (with no failures) reconcile.
+// on failure, and once the whole batch settles reconcile (so a failed write's
+// diverged row can be restored via the refresh banner).
 function hasPendingWrite(recordId: any): boolean {
   return pendingByRecord.has(recordId)
 }
 
+// Compose the failure snackbar: name the affected row when we have a label, then
+// append the server's reason (a policy / business-rule / validation message)
+// when present — it explains the failure and reloading wouldn't change it — or a
+// generic reload hint otherwise (network / 5xx / opaque, where reloading is the
+// actionable advice). The refresh banner, when it appears, handles restoring the
+// row's canonical value either way.
+function writeErrorText(op: 'save' | 'delete', label: string | null, reason: string | null): string {
+  const subject = op === 'delete'
+    ? (label != null ? t.delete_failed(label) : t.delete_failed_anon)
+    : (label != null ? t.save_failed(label) : t.save_failed_anon)
+  return `${subject} ${reason ?? t.write_error_reload}`
+}
+
 // Track an optimistic background write for `recordId`, serialized per `key` so
-// writes to the same cell reach the server in edit order.
-function trackWrite(recordId: any, key: string, run: () => Promise<unknown>): void {
+// writes to the same cell reach the server in edit order. `op` / `label` name the
+// affected row in the failure snackbar.
+function trackWrite(
+  recordId: any,
+  key: string,
+  op: 'save' | 'delete',
+  label: string | null,
+  run: () => Promise<unknown>
+): void {
   // A new write changes the displayed state. Clear any stashed reconcile result
   // and invalidate an in-flight reconcile (advance the token so its result is
   // dropped; clear its busy flag — `pendingWrites` keeps us busy), so neither
@@ -951,16 +1001,14 @@ function trackWrite(recordId: any, key: string, run: () => Promise<unknown>): vo
   current
     .catch((e) => {
       batchErrored = true
-      // Prefer a server-provided reason (a policy / business-rule deny, a
-      // validation message) so a rejected write explains itself instead of the
-      // generic copy. The optimistic edit was already applied and isn't rolled
-      // back here, so keep the reload-to-resync guidance alongside the reason.
-      // Fall back to write_error (which carries its own guidance) for network /
-      // 5xx / opaque / auth failures, where extractServerMessage returns null.
-      const reason = extractServerMessage(e)
+      // Name the affected row and prefer a server-provided reason (a policy /
+      // business-rule deny, a validation message) so a rejected write explains
+      // itself and the user can tell which edit failed when several are in flight.
+      // The optimistic edit isn't rolled back here; the post-batch reconcile
+      // surfaces the refresh banner to restore it.
       snackbars.push({
         mode: 'danger',
-        text: reason ? `${reason} ${t.write_error_recover}` : t.write_error
+        text: writeErrorText(op, label, extractServerMessage(e))
       })
     })
     .finally(() => {
@@ -978,9 +1026,12 @@ function trackWrite(recordId: any, key: string, run: () => Promise<unknown>): vo
       if (pendingWrites.value === 0) {
         const errored = batchErrored
         batchErrored = false
-        if (!errored) {
-          reconcile()
-        }
+        // Reconcile on error too: a failed write left its optimistic edit on the
+        // row, so the canonical state now diverges and the refresh banner becomes
+        // the user's one-click path to restore it (labelled as a recovery). If the
+        // reconcile itself fails, no banner shows and the snackbar's reload
+        // guidance is the fallback.
+        reconcile(errored)
       }
     })
 }
@@ -1028,7 +1079,7 @@ function save(record: Record<string, any>, values: Record<string, any>): void {
       && k.slice(prefix.length).split(',').some((f) => fieldSet.has(f)))
     .map(([, chain]) => chain)
   const gate = Promise.allSettled(overlapping)
-  trackWrite(id, key, () => gate.then(() => executeUpdate(id, values)))
+  trackWrite(id, key, 'save', resolveLabel(record), () => gate.then(() => executeUpdate(id, values)))
 }
 
 // Create — blocking. The slow POST runs to completion, then the catalog is
@@ -1122,7 +1173,7 @@ function remove(record: Record<string, any>): void {
   // `Promise.allSettled([])` resolves immediately, so this is a no-op gate when
   // the record has no in-flight writes.
   const gate = Promise.allSettled(pendingForRecord)
-  trackWrite(id, `${id}:__delete__`, () => gate.then(() => executeDelete(id)))
+  trackWrite(id, `${id}:__delete__`, 'delete', resolveLabel(record), () => gate.then(() => executeDelete(id)))
 }
 
 async function openSheet(record: Record<string, any>): Promise<void> {
@@ -1356,7 +1407,7 @@ defineExpose({
       </div>
       <SDivider />
       <div v-if="latestState && !busy" class="refresh-banner">
-        <span class="refresh-banner-text">{{ t.refresh_text }}</span>
+        <span class="refresh-banner-text">{{ latestState.fromError ? t.refresh_failed_text : t.refresh_text }}</span>
         <SButton size="mini" mode="info" :label="t.refresh_action" @click="applyLatest" />
       </div>
       <div class="list" :style="tableMaxHeight">


### PR DESCRIPTION
## What

Improves how the Lens catalog handles a **failed optimistic write** (background save/delete), on top of the recent error-surfacing work (#748).

### 1. One-click recovery instead of "reload the page"

Previously, when a background write failed, its optimistic edit stayed on the row (looking saved) and the only way back to the truth was a full page reload. Now a failed batch reconciles against canonical server state just like a successful one. Because the failed row's optimistic value diverges from canonical, the existing **refresh banner** appears — so the user restores the correct data in one click.

The banner is labelled for the situation:
- write failed → **"Some changes couldn't be saved. Refresh to restore the latest values."**
- genuinely newer data → unchanged **"Newer results are available."**

The banner is best-effort, not guaranteed (see the snackbar below for the fallback).

### 2. Name the failed row in the snackbar

With several edits in flight, a bare "we couldn't save your change" doesn't tell the user *which* one failed. The failure snackbar now names the affected row (the index field's display value, falling back to its id) and the operation, and **always keeps a recovery hint**:

> We couldn't save “TPC000001”. _&lt;server reason&gt;_ Please reload to see the latest.

- The server-provided reason (policy/business-rule/validation message) is shown when present.
- A reload hint is **always** appended — `Please reload to see the latest.` with a reason, `Please reload and try again.` without one — because the refresh banner can't always appear (a failed recovery reconcile shows none, and the banner's diff can't see detail-only sheet fields that aren't in the catalog's `select`). Reload is the guaranteed fallback; the banner is the nicer one-click path when available.
- Falls back to anonymous copy when no usable row label exists. Save and delete get distinct wording.

## Implementation notes

- `reconcile()` takes an `afterError` flag and now runs on every settled batch (previously only fully-successful ones). It still only **stashes** behind the banner — never auto-applies — and reuses the existing `reconcileToken`/`searchToken` invalidation, so a follow-up write or refresh supersedes an in-flight recovery reconcile exactly as before.
- `latestState` now carries `{ result, fromError }` so the banner can pick its copy.
- Failure snackbar text composed via a small `writeErrorText(op, label, reason)` helper; `trackWrite` threads `op`/`label` from `save()`/`remove()`.
- Drive-by refactor: the effective row identifier (`indexField` or `id`) was resolved inline as `props.indexField ?? 'id'` at every row-resolution / edit site; extracted into a single `idField` computed. `withIndexField` / `withoutIndexField` / `tableIndexField` deliberately keep using the raw prop, where `undefined` (no index field configured) is distinct from `id`.

## Known limitation / follow-up

A failed save of a **detail-only sheet field** (loaded via `/show`, not part of the search `select`) can't surface the one-click banner — `isSameResult` only diffs search-shaped fields, and `rebindOpenSheet` carries detail keys over. Reload is the recovery path for that case today; making it a one-click restore (refetch `/show` on rebind, or per-field revert) is left as a follow-up.

## i18n

New EN/JA keys for the row-named save/delete failures, the reload/recovery hints, and the recovery banner copy.

## Verification

- `pnpm type`, `pnpm lint`, `pnpm test` (1201 tests) all pass.
- Reviewed the concurrency-sensitive reconcile-on-error path for races (concurrent write / blocking create / mixed-success batch / delete-failure restore) — recovery reuses the established token-invalidation invariants.