### PR TITLE
feat(lens): show an error state with retry when a search fails

### DIFF
--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -216,7 +216,9 @@ const { t } = useTrans({
     busy_warning: 'Still saving — please wait a moment before changing the view.',
     refresh_text: 'Newer results are available.',
     refresh_failed_text: 'Some changes couldn’t be saved. Refresh to restore the latest values.',
-    refresh_action: 'Refresh'
+    refresh_action: 'Refresh',
+    search_error: 'We couldn’t load the records.',
+    search_retry: 'Try again'
   },
   ja: {
     save_failed: (label: string) => `「${label}」を保存できませんでした。`,
@@ -228,7 +230,9 @@ const { t } = useTrans({
     busy_warning: '保存中です。表示を変更する前に少しお待ちください。',
     refresh_text: '新しい結果があります。',
     refresh_failed_text: '保存できなかった変更があります。更新して最新の値に戻してください。',
-    refresh_action: '更新'
+    refresh_action: '更新',
+    search_error: 'レコードを読み込めませんでした。',
+    search_retry: '再試行'
   }
 })
 
@@ -358,12 +362,43 @@ const { data: result, execute: refresh, loading } = useQuery(async (http) => {
   prevFetchResult = res
 
   return res
-})
+}, { immediate: false })
 
 // Keep `currentResult` pointing at the shown result. The reference changes only
 // on a wholesale replace; optimistic in-place edits keep the same object, so this
 // mirror always reflects them.
 watch(result, (r) => { currentResult = r ?? undefined }, { immediate: true })
+
+// Whether the most recent table search (initial load or a user-driven re-search)
+// failed. A failed fetch otherwise leaves the previous rows on screen with the
+// controls re-enabled — indistinguishable from the new query legitimately
+// returning them — so the list shows an inline error + retry instead.
+const searchError = ref(false)
+
+// Monotonic token so only the latest search may raise the error flag: with the
+// slow backend two searches can overlap, and an older one failing *after* a newer
+// one succeeded must not flash an error over the good rows now on screen.
+let searchRunSeq = 0
+
+// Run the main table search, tracking whether it failed. Clears the flag up
+// front so a retry / new search drops the error immediately (showing the loading
+// state), and only a genuine fetch failure from the *latest* run re-raises it — a
+// superseded search resolves successfully (the fetcher returns the current
+// result), so racing writes / queries don't trip it. Drives the initial load (the
+// query's `immediate` is off so this owns it) and every `doRefresh`.
+async function runSearch(): Promise<void> {
+  const seq = ++searchRunSeq
+  searchError.value = false
+  try {
+    await refresh()
+  } catch {
+    if (seq === searchRunSeq) {
+      searchError.value = true
+    }
+  }
+}
+
+onMounted(runSearch)
 
 const doRefresh = useDebounceFn(() => {
   // A write or a blocking create may have started during the debounce window: the
@@ -374,7 +409,7 @@ const doRefresh = useDebounceFn(() => {
   // (Deliberate refreshes go through `forceRefresh`, which calls `refresh`
   // directly to bypass this guard.)
   if (pendingWrites.value > 0 || creating.value) { return }
-  return refresh()
+  return runSearch()
 }, 50)
 
 if (props.urlSync) {
@@ -909,6 +944,10 @@ async function forceRefresh(): Promise<void> {
   prevFetchInput = null
   latestState.value = null
   await refresh()
+  // A deliberate reload landed fresh rows — clear any prior search-error state so
+  // the list shows them instead of a stale error. (On failure this rethrows and
+  // the flag is left untouched; the create path handles its own fallback.)
+  searchError.value = false
   rebindOpenSheet()
 }
 
@@ -1121,6 +1160,10 @@ async function create(values: Record<string, any>): Promise<Record<string, any>>
     // during the create (doRefresh bails on `creating`); create's own forceRefresh
     // bypasses that by calling refresh directly.
     searchToken++
+    // The create landed a valid record, so clear any prior search-error state —
+    // both refresh paths below leave the list populated (forceRefresh, or the
+    // optimistic prepend), so the new row must show instead of a stale error.
+    searchError.value = false
     // From here a refresh failure must not reject (the caller would treat the
     // create as failed and re-submit a duplicate); fall back to showing the new
     // record optimistically.
@@ -1425,28 +1468,34 @@ defineExpose({
         <SButton size="mini" mode="info" :label="t.refresh_action" @click="applyLatest" />
       </div>
       <div class="list" :style="tableMaxHeight">
-        <LensTable
-          :result
-          :loading
-          :overrides="_overrides"
-          :select="tableSelect"
-          :index-field="tableIndexField"
-          :selected
-          :clickable-fields
-          :inline-editable
-          @filter-updated="onInlineFilterUpdated"
-          @sort-updated="onSortUpdated"
-          @update:selected="onUpdateSelected"
-          @cell-clicked="(v, r) => emit('cell-clicked', v, r)"
-        />
-        <LensCatalogFooter
-          v-if="result && result?.pagination.total > 0"
-          :class="{ 'is-busy': busy }"
-          :result
-          :loading
-          @prev="onPrev"
-          @next="onNext"
-        />
+        <div v-if="searchError" class="list-error">
+          <p class="list-error-text">{{ t.search_error }}</p>
+          <SButton size="small" mode="info" :label="t.search_retry" @click="runSearch" />
+        </div>
+        <template v-else>
+          <LensTable
+            :result
+            :loading
+            :overrides="_overrides"
+            :select="tableSelect"
+            :index-field="tableIndexField"
+            :selected
+            :clickable-fields
+            :inline-editable
+            @filter-updated="onInlineFilterUpdated"
+            @sort-updated="onSortUpdated"
+            @update:selected="onUpdateSelected"
+            @cell-clicked="(v, r) => emit('cell-clicked', v, r)"
+          />
+          <LensCatalogFooter
+            v-if="result && result?.pagination.total > 0"
+            :class="{ 'is-busy': busy }"
+            :result
+            :loading
+            @prev="onPrev"
+            @next="onNext"
+          />
+        </template>
       </div>
     </div>
 
@@ -1557,6 +1606,23 @@ defineExpose({
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+}
+
+.list-error {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px 16px;
+  text-align: center;
+}
+
+.list-error-text {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--c-text-2);
 }
 
 .control-skeleton {

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -380,26 +380,27 @@ const searchError = ref(false)
 // one succeeded must not flash an error over the good rows now on screen.
 let searchRunSeq = 0
 
-// Run the main table search, tracking whether it failed. Clears the flag up
-// front so a retry / new search drops the error immediately (showing the loading
-// state), and only a genuine fetch failure raises it. Drives the initial load
+// Run the main table search, tracking whether it failed. Drives the initial load
 // (the query's `immediate` is off so this owns it) and every `doRefresh`.
 async function runSearch(): Promise<void> {
   const seq = ++searchRunSeq
   // Snapshot `searchToken` too: a write / create / forced refresh / index-field
   // change bumps it to supersede an in-flight search (so even on success the
-  // fetcher discards that search's rows). If such a superseded search *rejects*
-  // instead, its failure is for a request we already decided to drop — and a
-  // follow-up (the write's reconcile, the forced result) replaces the state — so
-  // don't surface it as an error over the rows now shown.
+  // fetcher discards that search's rows and returns the current result instead).
+  // Such a superseded run must neither raise the error (its rejection is for a
+  // request we already decided to drop) nor clear it (its "success" is the stale
+  // current result, not the requested rows) — the follow-up (the write's
+  // reconcile, the forced result) settles the state instead.
   const token = searchToken
   try {
     await refresh()
-    // Clear only on the latest run's success — an older run resolving late must
-    // not wipe a newer run's error. Not cleared up front: keeping the error state
-    // visible until the retry actually succeeds avoids flashing the previous
+    // Clear only on the latest, non-superseded run's success — an older run
+    // resolving late must not wipe a newer run's error, and a write-invalidated
+    // run resolving with the current result must not dismiss the error over rows
+    // that aren't the requested ones. Not cleared up front either: keeping the
+    // error visible until a retry actually succeeds avoids flashing the previous
     // query's (interactable) rows back on screen mid-retry.
-    if (seq === searchRunSeq) {
+    if (seq === searchRunSeq && token === searchToken) {
       searchError.value = false
     }
   } catch {
@@ -721,33 +722,14 @@ function onResetSelection() {
 
 function onPrev() {
   if (guardBusy()) { return }
-  void changePage(page.value - 1)
+  page.value--
+  refetch()
 }
 
 function onNext() {
   if (guardBusy()) { return }
-  void changePage(page.value + 1)
-}
-
-// Move to `next`, reverting on failure. A failed page load otherwise strands the
-// user on a page that won't load: the error state hides the footer, so there's no
-// Prev to go back, and a retry just repeats the same failing page. Restoring the
-// previous page keeps the catalog state aligned with the rows still shown, so a
-// retry re-runs the page they came from. (`guardBusy` already blocked this while a
-// write is in flight, so the search here can't read pre-write rows.)
-//
-// Runs the search undebounced, so it relies on its caller being disabled while
-// `loading` — the footer's Prev/Next are (`:disabled="loading"` via SPagination),
-// which keeps overlapping page fetches from landing out of order. Preserve that
-// for any new caller.
-async function changePage(next: number): Promise<void> {
-  const restore = page.value
-  page.value = next
-  latestState.value = null
-  await runSearch()
-  if (searchError.value) {
-    page.value = restore
-  }
+  page.value++
+  refetch()
 }
 
 // --- CRUD editing ----------------------------------------------------------
@@ -1504,13 +1486,16 @@ defineExpose({
       <div class="list" :style="tableMaxHeight">
         <div v-if="searchError" class="list-error">
           <p class="list-error-text">{{ t.search_error }}</p>
+          <!-- Retry the same query via the busy-guarded `doRefresh` (not `refetch`,
+               which would clear a `latestState` recovery banner before the retry
+               resolves — a failed retry would then lose that known-good stash). -->
           <SButton
             size="small"
             mode="info"
             :label="t.search_retry"
             :loading
             :disabled="busy"
-            @click="refetch"
+            @click="doRefresh"
           />
         </div>
         <template v-else>

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -402,6 +402,12 @@ async function runSearch(): Promise<void> {
     // query's (interactable) rows back on screen mid-retry.
     if (seq === searchRunSeq && token === searchToken) {
       searchError.value = false
+      // These fresh rows for the current query supersede any pending recovery
+      // banner (a reconcile stash), so its button can't later overwrite them with
+      // an older snapshot. Query-change refetches already drop it; the retry path
+      // (doRefresh, which keeps the banner for a failed retry) doesn't, so a
+      // successful retry must clear it here.
+      latestState.value = null
     }
   } catch (e) {
     // Auth / session-expiry (401 / 419) must reach the app's re-auth flow, not be

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -382,17 +382,22 @@ let searchRunSeq = 0
 
 // Run the main table search, tracking whether it failed. Clears the flag up
 // front so a retry / new search drops the error immediately (showing the loading
-// state), and only a genuine fetch failure from the *latest* run re-raises it — a
-// superseded search resolves successfully (the fetcher returns the current
-// result), so racing writes / queries don't trip it. Drives the initial load (the
-// query's `immediate` is off so this owns it) and every `doRefresh`.
+// state), and only a genuine fetch failure raises it. Drives the initial load
+// (the query's `immediate` is off so this owns it) and every `doRefresh`.
 async function runSearch(): Promise<void> {
   const seq = ++searchRunSeq
+  // Snapshot `searchToken` too: a write / create / forced refresh / index-field
+  // change bumps it to supersede an in-flight search (so even on success the
+  // fetcher discards that search's rows). If such a superseded search *rejects*
+  // instead, its failure is for a request we already decided to drop — and a
+  // follow-up (the write's reconcile, the forced result) replaces the state — so
+  // don't surface it as an error over the rows now shown.
+  const token = searchToken
   searchError.value = false
   try {
     await refresh()
   } catch {
-    if (seq === searchRunSeq) {
+    if (seq === searchRunSeq && token === searchToken) {
       searchError.value = true
     }
   }
@@ -900,6 +905,10 @@ function applyLatest(): void {
   if (!latestState.value) { return }
   result.value = latestState.value.result
   latestState.value = null
+  // These are fresh authoritative rows for the current query, so drop any
+  // search-error state — e.g. a search failed, then a sheet save's reconcile
+  // surfaced this banner; applying it must reveal the rows, not stay on the retry.
+  searchError.value = false
   prevFetchInput = null
   rebindOpenSheet()
 }

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -393,9 +393,15 @@ async function runSearch(): Promise<void> {
   // follow-up (the write's reconcile, the forced result) replaces the state — so
   // don't surface it as an error over the rows now shown.
   const token = searchToken
-  searchError.value = false
   try {
     await refresh()
+    // Clear only on the latest run's success — an older run resolving late must
+    // not wipe a newer run's error. Not cleared up front: keeping the error state
+    // visible until the retry actually succeeds avoids flashing the previous
+    // query's (interactable) rows back on screen mid-retry.
+    if (seq === searchRunSeq) {
+      searchError.value = false
+    }
   } catch {
     if (seq === searchRunSeq && token === searchToken) {
       searchError.value = true
@@ -715,14 +721,33 @@ function onResetSelection() {
 
 function onPrev() {
   if (guardBusy()) { return }
-  page.value--
-  refetch()
+  void changePage(page.value - 1)
 }
 
 function onNext() {
   if (guardBusy()) { return }
-  page.value++
-  refetch()
+  void changePage(page.value + 1)
+}
+
+// Move to `next`, reverting on failure. A failed page load otherwise strands the
+// user on a page that won't load: the error state hides the footer, so there's no
+// Prev to go back, and a retry just repeats the same failing page. Restoring the
+// previous page keeps the catalog state aligned with the rows still shown, so a
+// retry re-runs the page they came from. (`guardBusy` already blocked this while a
+// write is in flight, so the search here can't read pre-write rows.)
+//
+// Runs the search undebounced, so it relies on its caller being disabled while
+// `loading` — the footer's Prev/Next are (`:disabled="loading"` via SPagination),
+// which keeps overlapping page fetches from landing out of order. Preserve that
+// for any new caller.
+async function changePage(next: number): Promise<void> {
+  const restore = page.value
+  page.value = next
+  latestState.value = null
+  await runSearch()
+  if (searchError.value) {
+    page.value = restore
+  }
 }
 
 // --- CRUD editing ----------------------------------------------------------
@@ -1479,7 +1504,14 @@ defineExpose({
       <div class="list" :style="tableMaxHeight">
         <div v-if="searchError" class="list-error">
           <p class="list-error-text">{{ t.search_error }}</p>
-          <SButton size="small" mode="info" :label="t.search_retry" @click="runSearch" />
+          <SButton
+            size="small"
+            mode="info"
+            :label="t.search_retry"
+            :loading
+            :disabled="busy"
+            @click="refetch"
+          />
         </div>
         <template v-else>
           <LensTable

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -13,7 +13,7 @@ import { type LensQuery, type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
 import { useCatalogUrlQuerySync } from '../composables/CatalogUrlQuerySync'
 import { provideLensEdit } from '../composables/LensEdit'
-import { extractServerMessage } from '../validation/ServerErrors'
+import { extractServerMessage, isAuthError } from '../validation/ServerErrors'
 import LensCatalogControl, { type FilterPresets } from './LensCatalogControl.vue'
 import LensCatalogFooter from './LensCatalogFooter.vue'
 import LensCatalogStateFilter from './LensCatalogStateFilter.vue'
@@ -403,7 +403,14 @@ async function runSearch(): Promise<void> {
     if (seq === searchRunSeq && token === searchToken) {
       searchError.value = false
     }
-  } catch {
+  } catch (e) {
+    // Auth / session-expiry (401 / 419) must reach the app's re-auth flow, not be
+    // parked on the inline retry state — matches the download / filter paths and
+    // the ServerErrors contract. Rethrow so the rejection propagates to the global
+    // handler as it did before this wrapper caught it.
+    if (isAuthError(e)) {
+      throw e
+    }
     if (seq === searchRunSeq && token === searchToken) {
       searchError.value = true
     }

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -644,6 +644,12 @@ function createInputFilters(queryFilters: any[], filters: any[]) {
 // reconcile result (the refreshed state supersedes it).
 function refetch(): void {
   latestState.value = null
+  // Supersede any in-flight search now, not only once the debounced run starts:
+  // a retry/search still loading for the previous query state would otherwise
+  // remain "latest" through the debounce window and, on resolving, clear the error
+  // or assign its rows after the query has already moved on. The next run captures
+  // the bumped token, so it isn't self-suppressed.
+  searchToken++
   doRefresh()
 }
 
@@ -940,6 +946,9 @@ function applyLatest(): void {
   // search-error state — e.g. a search failed, then a sheet save's reconcile
   // surfaced this banner; applying it must reveal the rows, not stay on the retry.
   searchError.value = false
+  // Supersede any in-flight retry started from that error state, so it can't
+  // assign over these rows or re-raise the error after they've been applied.
+  searchToken++
   prevFetchInput = null
   rebindOpenSheet()
 }
@@ -981,13 +990,19 @@ async function forceRefresh(): Promise<void> {
   // fresh result when it resolves — same token mechanism as the write/create
   // races. This refetch captures the bumped token, so it isn't self-suppressed.
   searchToken++
+  const token = searchToken
   prevFetchInput = null
   latestState.value = null
   await refresh()
   // A deliberate reload landed fresh rows — clear any prior search-error state so
-  // the list shows them instead of a stale error. (On failure this rethrows and
-  // the flag is left untouched; the create path handles its own fallback.)
-  searchError.value = false
+  // the list shows them instead of a stale error. But only if this reload wasn't
+  // itself invalidated mid-flight (a write bumping `searchToken` makes the fetcher
+  // return the current result, not freshly-assigned rows) — otherwise we'd dismiss
+  // the error over the previous query's rows. (On failure this rethrows and the
+  // flag is left untouched; the create path handles its own fallback.)
+  if (token === searchToken) {
+    searchError.value = false
+  }
   rebindOpenSheet()
 }
 

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -419,6 +419,16 @@ async function runSearch(): Promise<void> {
 
 onMounted(runSearch)
 
+// When a search fails, the error state replaces the table but the control bar —
+// including its selected-actions (bulk) slot — stays mounted. Clear any selection
+// on entering the error so the user can't act on now-hidden rows from the previous
+// result while the UI says the current query failed.
+watch(searchError, (err) => {
+  if (err && selected.value?.length) {
+    selected.value = []
+  }
+})
+
 const doRefresh = useDebounceFn(() => {
   // A write or a blocking create may have started during the debounce window: the
   // busy lock guards the query handlers at click time, but not this deferred
@@ -447,7 +457,14 @@ if (props.urlSync) {
 }
 
 const _showEmptyState = computed(() => {
-  return props.showEmptyState && !hasInitialResults.value && result.value?.data.length === 0
+  // Exclude `searchError`: when a re-search fails the result still holds the
+  // previous (possibly zero-row) data, which would otherwise keep the empty-state
+  // slot showing — and it sits in this branch's `v-else`, so the inline error +
+  // retry would never render. Yield to the error state instead.
+  return props.showEmptyState
+    && !searchError.value
+    && !hasInitialResults.value
+    && result.value?.data.length === 0
 })
 
 const hasConditions = computed(() => {
@@ -1183,10 +1200,11 @@ async function create(values: Record<string, any>): Promise<Record<string, any>>
     // during the create (doRefresh bails on `creating`); create's own forceRefresh
     // bypasses that by calling refresh directly.
     searchToken++
-    // The create landed a valid record, so clear any prior search-error state —
-    // both refresh paths below leave the list populated (forceRefresh, or the
-    // optimistic prepend), so the new row must show instead of a stale error.
-    searchError.value = false
+    // Don't clear `searchError` here: only a successful current-query refresh
+    // should (forceRefresh does so on success). The fallbacks below show the
+    // previous query's rows plus the new record — not the requested query — so
+    // dismissing the error there would present stale rows as if they matched.
+    //
     // From here a refresh failure must not reject (the caller would treat the
     // create as failed and re-submit a duplicate); fall back to showing the new
     // record optimistically.


### PR DESCRIPTION
## What

A failed table search in the Lens catalog was **silent**, so a failure was indistinguishable from a legitimate result:

- `useQuery.execute` clears `loading` in its `finally` but only assigns `data` on success, so on rejection the **previous rows stayed on screen**.
- The re-search path (`refetch → doRefresh → refresh`) was fire-and-forget, so the rejection was unhandled.

Observable bug: change a filter, the request 500s or the network drops, and the table keeps showing the **old query's rows** with the controls re-enabled — looking exactly as if the new filter returned them. A failed **initial load** rendered as an empty table ("no records") rather than an error.

## Change

Track the search outcome in a `searchError` flag and render an inline error state — a message plus a **"Try again"** button — in place of the table when it's set.

- The query's `immediate` is turned off so a single `runSearch()` wrapper owns **both** the initial load (`onMounted`) and every user-driven re-search (`doRefresh`).
- The error is raised/cleared only by the **latest, non-superseded** run, via two snapshots taken at the start of each run:
  - **`searchRunSeq`** (latest-run): an older overlapping search resolving after a newer one can neither raise an error nor clear one over the rows now shown.
  - **`searchToken`** (supersession): a write / create / forced refresh / index-field change bumps it to discard an in-flight search's rows even on success. Such a superseded run neither raises the error (its rejection is for a request already dropped) nor clears it (its "success" is the stale current result, not the requested rows) — the follow-up (the write's reconcile, the forced result) settles the state.
- The error stays visible until a retry **succeeds** (it's not cleared up front), so a retry never flashes the previous query's interactable rows while the request is in flight.
- The retry button routes through the busy-guarded refresh path and is disabled while busy, so a retry during an optimistic write can't read pre-write rows and clobber the edit; it goes through `doRefresh` (not `refetch`) so it doesn't drop a pending `latestState` recovery banner before the retry resolves.
- Auth / session-expiry (401 / 419) is rethrown rather than shown inline, so it reaches the app's re-auth flow (the `ServerErrors` contract) instead of being parked on the retry state.
- Deliberate reloads (`forceRefresh`), successful creates, and applying the reconcile refresh banner (`applyLatest`) all clear the flag.

The error block replaces the (stale) table rather than overlaying it, so there's no ambiguity about whether the shown rows are current.

### Known limitation

A failed **Prev/Next** leaves the page advanced and the error state hides the footer, so there's no one-click way back to the previous page — the user retries (repeats the page) or changes any filter/search/sort (which resets to page 1) to escape. A page-rollback was prototyped but reverted: awaiting the search undebounced to drive the rollback broke the debounce coalescing with the URL-sync echo and the shared error flag couldn't attribute a failure to a specific page request. Left as a follow-up if it proves to matter.

## Verification

- `pnpm type`, `pnpm lint`, `pnpm test` (1201 tests) pass.
- Adversarially reviewed the search lifecycle across review rounds (initial-load equivalence, superseded-vs-failed distinction, the set/clear lifecycle across `runSearch`/`forceRefresh`/`create`/`applyLatest`, overlapping-search and write-invalidation races, retry-during-write clobber, recovery-banner preservation, and template remount on retry).