### PR TITLE
feat(lens): make avatar fields editable and creatable

### DIFF
--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -70,9 +70,23 @@ export interface AvatarFieldData extends FieldDataBase {
    * avatar uses the name (resolved against the active language) for the
    * initials fallback / tooltip when the image is unavailable. The field
    * value itself is the image URL.
+   *
+   * When the field is editable, these companion keys also become editable from
+   * the inline cell (the pencil affordance beside the avatar edits both names),
+   * so the avatar and its names can be updated together.
    */
   nameEn?: string | null
   nameJa?: string | null
+  /**
+   * The `accept` attribute for the file picker (e.g. `image/jpeg,image/png`).
+   * Defaults to `image/*`.
+   */
+  accept?: string | null
+  /** Help text shown beneath the picker, per language. */
+  helpEn?: string | null
+  helpJa?: string | null
+  /** Picker preview shape. Defaults to `circle` (avatars are round). */
+  imageType?: 'circle' | 'rectangle' | null
 }
 
 export interface BooleanFieldData extends FieldDataBase {

--- a/lib/blocks/lens/components/LensAvatarInput.vue
+++ b/lib/blocks/lens/components/LensAvatarInput.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import SInputImage, { type ImageType, type Size } from '../../../components/SInputImage.vue'
+import { useTrans } from '../../../composables/Lang'
+import { type Validatable } from '../../../composables/Validation'
+
+withDefaults(defineProps<{
+  label?: string
+  help?: string
+  accept?: string
+  imageType?: ImageType
+  size?: Size
+  disabled?: boolean
+  validation?: Validatable
+}>(), {
+  imageType: 'circle',
+  size: 'small'
+})
+
+// The model is the raw `File` the user just picked, the existing image URL
+// (a string), or `null` when there is no image / it was removed. `SInputImage`
+// renders a preview from any of these via `useImageSrcFromFile`.
+const model = defineModel<File | string | null>()
+
+const { t } = useTrans({
+  en: { select: 'Select image', remove: 'Remove image' },
+  ja: { select: '画像を選択', remove: '画像を削除' }
+})
+</script>
+
+<template>
+  <SInputImage
+    v-model="model"
+    class="LensAvatarInput"
+    :label
+    :help
+    :accept
+    :image-type
+    :size
+    :disabled
+    :select-text="t.select"
+    :remove-text="t.remove"
+    :validation
+  />
+</template>

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -12,6 +12,7 @@ import { type FieldData } from '../FieldData'
 import { type LensQuery, type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
 import { useCatalogUrlQuerySync } from '../composables/CatalogUrlQuerySync'
+import { type LensAvatarUploadHandler, provideLensAvatarUpload } from '../composables/LensAvatarUpload'
 import { provideLensEdit } from '../composables/LensEdit'
 import { extractServerMessage, isAuthError } from '../validation/ServerErrors'
 import LensCatalogControl, { type FilterPresets } from './LensCatalogControl.vue'
@@ -178,6 +179,15 @@ export interface Props {
   // CRUD edit context). Defaults to enabled when the catalog is `editable`; pass
   // `false` to restrict editing to the record sheet.
   inlineEditable?: boolean
+
+  // Persist an avatar image change for an `avatar` field. Avatars are stored
+  // out-of-band (a multipart upload the consuming app owns) rather than through
+  // the Lens create/update write, so the catalog delegates the actual upload to
+  // this handler and reflects the URL it returns on the row. Without it, avatar
+  // fields stay read-only (the inline/sheet image affordance is hidden). The
+  // handler receives the picked file (or `null` on removal) and the record's id
+  // (`null` while creating) and resolves to the new image URL (or `null`).
+  avatarUpload?: LensAvatarUploadHandler
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -1196,6 +1206,20 @@ function save(record: Record<string, any>, values: Record<string, any>): void {
   trackWrite(id, key, 'save', resolveLabel(record), () => gate.then(() => executeUpdate(id, values)))
 }
 
+// Reflect an out-of-band change (e.g. an avatar uploaded via the consumer's
+// handler) on the in-memory record — no Lens write, no reconcile. The catalog
+// row and any open sheet share the object, so the change shows immediately. The
+// row identifier is stripped so a patch can never re-key the row.
+function patch(record: Record<string, any>, values: Record<string, any>): void {
+  const indexField = idField.value
+  if (indexField in values) {
+    values = { ...values }
+    delete values[indexField]
+  }
+  if (Object.keys(values).length === 0) { return }
+  Object.assign(record, values)
+}
+
 // Create — blocking. The slow POST runs to completion, then the catalog is
 // refreshed with the now-synced canonical state (preserving the active query).
 // The create sheet shows a button spinner meanwhile.
@@ -1407,10 +1431,19 @@ provideLensEdit({
   canDelete,
   resolveId,
   save,
+  patch,
   create,
   remove,
   openSheet,
-  openCreate
+  openCreate,
+  refresh: refreshCatalog
+})
+
+// Avatars are persisted out-of-band (the consumer's upload handler), not through
+// the Lens write. Expose the handler to the avatar cell / sheet field / create
+// form via a thin accessor so a prop that resolves after mount is read live.
+provideLensAvatarUpload({
+  get handler() { return props.avatarUpload ?? null }
 })
 
 // Warn the user (native prompt) if they try to leave while a write is still

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -1262,7 +1262,13 @@ async function uploadAvatar(record: Record<string, any>, field: string, file: Fi
 
   try {
     const url = await run
-    const values = { [field]: url }
+    const values: Record<string, any> = { [field]: url }
+    // Advance `updated_at` to ~now like save() does: the upload endpoint bumps the
+    // server timestamp, but the reconcile ignores `updated_at` (so it never
+    // surfaces it), so without this the displayed timestamp would stay stale.
+    if (UPDATED_AT_KEY in record) {
+      values[UPDATED_AT_KEY] = day().toISOString()
+    }
     // Patch the passed record (e.g. the sheet's detail record) and, when it's a
     // different object, the live displayed row resolved by id (e.g. a create that
     // refetched replaced `created` with a fresh row object).
@@ -1381,11 +1387,13 @@ function remove(record: Record<string, any>): void {
   // already-deleted row (spurious save-failed snackbar) or resurrect/clobber
   // it. Gate on the record's current write chains (settled, success or not —
   // the row is being deleted regardless) before issuing the delete.
-  const pendingForRecord = [...writeChains.entries()]
+  const pendingForRecord = [...writeChains.entries(), ...avatarChains.entries()]
     .filter(([key]) => key.startsWith(`${id}:`))
     .map(([, chain]) => chain)
   // `Promise.allSettled([])` resolves immediately, so this is a no-op gate when
-  // the record has no in-flight writes.
+  // the record has no in-flight writes. Avatar uploads are gated too (they live
+  // in their own chain map) so a delete can't race an in-flight upload — the
+  // upload would otherwise fail against a removed row or write after the delete.
   const gate = Promise.allSettled(pendingForRecord)
   trackWrite(id, `${id}:__delete__`, 'delete', resolveLabel(record), () => gate.then(() => executeDelete(id)))
 }

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -818,6 +818,12 @@ let batchErrored = false
 // cells run concurrently; the backend persists only the changed columns.
 const writeChains = new Map<string, Promise<unknown>>()
 
+// In-flight avatar-upload chains keyed by record+field, so two uploads to the
+// same avatar (e.g. from the inline cell then the reopened sheet) are serialized
+// — the later-issued one's request is sent after the earlier resolves and it
+// patches last, so the newest image wins instead of a slower earlier upload.
+const avatarChains = new Map<string, Promise<unknown>>()
+
 // Count of in-flight writes per record id, so `/show` for a record that's
 // mid-write can avoid overwriting its optimistic values with stale data.
 const pendingByRecord = new Map<any, number>()
@@ -1206,10 +1212,10 @@ function save(record: Record<string, any>, values: Record<string, any>): void {
   trackWrite(id, key, 'save', resolveLabel(record), () => gate.then(() => executeUpdate(id, values)))
 }
 
-// Reflect an out-of-band change (e.g. an avatar uploaded via the consumer's
-// handler) on the in-memory record — no Lens write, no reconcile. The catalog
-// row and any open sheet share the object, so the change shows immediately. The
-// row identifier is stripped so a patch can never re-key the row.
+// Reflect an out-of-band change on the in-memory record. Pure in-memory
+// mutation: the caller (`uploadAvatar`) owns the write accounting (invalidation,
+// reconcile). The catalog row and any open sheet share the object, so the change
+// shows immediately. The row identifier is stripped so it can never re-key.
 function patch(record: Record<string, any>, values: Record<string, any>): void {
   const indexField = idField.value
   if (indexField in values) {
@@ -1217,36 +1223,70 @@ function patch(record: Record<string, any>, values: Record<string, any>): void {
     delete values[indexField]
   }
   if (Object.keys(values).length === 0) { return }
-  // An out-of-band change supersedes any stashed / in-flight reconcile or search,
-  // exactly like a normal write (see trackWrite): otherwise clicking a stale
-  // refresh banner — or a search resolving with pre-patch rows — would revert the
-  // value we just patched (e.g. drop a freshly uploaded avatar).
-  latestState.value = null
-  reconcileToken++
-  searchToken++
-  reconciling.value = false
   Object.assign(record, values)
 }
 
 // Persist an avatar image out-of-band (via the consumer's `avatar-upload`
-// handler) and reflect the returned URL on the record. Accounted for like an
-// optimistic write — `pendingWrites` locks the query controls while it's in
-// flight (a refetch then would read pre-upload data) and a reconcile resyncs
-// once it settles — so a concurrent query change can't land stale rows over it.
-// Patches the `record` passed at call time (the sheet may rebind to another row
-// mid-upload). Resolves to the new URL, or null when no handler is wired.
+// handler) and reflect the returned URL on the row, with the same accounting as
+// an optimistic write so it stays consistent with concurrent reads/writes:
+//   - an up-front invalidation preamble (mirroring `trackWrite`) supersedes any
+//     stashed / in-flight reconcile or search, so a request that predates the
+//     upload can't reassign pre-upload rows mid-flight and a stale refresh banner
+//     can't revert the patched URL;
+//   - `pendingWrites` locks the query controls while it's in flight, and
+//     `pendingByRecord` arms `openSheet`'s `/show` stale-read guard;
+//   - uploads to the same record+field are serialized (last issued wins);
+//   - the URL lands on the live displayed row (resolved by id), not only the
+//     passed `record` (which can be an orphan after a create refetched);
+//   - a reconcile resyncs once the batch settles.
+// Resolves to the new URL (rejects if the handler throws), or null when no
+// handler is wired.
 async function uploadAvatar(record: Record<string, any>, field: string, file: File | null): Promise<string | null> {
   if (!props.avatarUpload) { return null }
+  const handler = props.avatarUpload
   const id = resolveId(record)
+
+  latestState.value = null
+  reconcileToken++
+  searchToken++
+  reconciling.value = false
   pendingWrites.value++
+  pendingByRecord.set(id, (pendingByRecord.get(id) ?? 0) + 1)
+
+  // Serialize uploads to the same record+field: chain after any in-flight one so
+  // its request is sent (and patched) only once the earlier resolves.
+  const key = `${id}:${field}`
+  const prev = avatarChains.get(key) ?? Promise.resolve()
+  const run = prev.catch(() => {}).then(() => handler({ id, record, field, file }))
+  avatarChains.set(key, run)
+
   try {
-    const url = await props.avatarUpload({ id, record, field, file })
-    patch(record, { [field]: url })
+    const url = await run
+    const values = { [field]: url }
+    // Patch the passed record (e.g. the sheet's detail record) and, when it's a
+    // different object, the live displayed row resolved by id (e.g. a create that
+    // refetched replaced `created` with a fresh row object).
+    patch(record, values)
+    const row = result.value?.data.find((r) => resolveId(r) === id)
+    if (row && row !== record) {
+      patch(row, values)
+    }
     return url
   } finally {
+    if (avatarChains.get(key) === run) {
+      avatarChains.delete(key)
+    }
+    const remaining = (pendingByRecord.get(id) ?? 1) - 1
+    remaining > 0 ? pendingByRecord.set(id, remaining) : pendingByRecord.delete(id)
     pendingWrites.value--
     if (pendingWrites.value === 0) {
-      reconcile()
+      // Drive the post-batch reconcile like trackWrite does — this upload shares
+      // the `pendingWrites` batch, so when it settles last it must forward (and
+      // reset) `batchErrored` so a concurrent failed write's diverged row still
+      // gets the recovery banner, and the flag doesn't leak into the next batch.
+      const errored = batchErrored
+      batchErrored = false
+      reconcile(errored)
     }
   }
 }

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -1217,7 +1217,38 @@ function patch(record: Record<string, any>, values: Record<string, any>): void {
     delete values[indexField]
   }
   if (Object.keys(values).length === 0) { return }
+  // An out-of-band change supersedes any stashed / in-flight reconcile or search,
+  // exactly like a normal write (see trackWrite): otherwise clicking a stale
+  // refresh banner — or a search resolving with pre-patch rows — would revert the
+  // value we just patched (e.g. drop a freshly uploaded avatar).
+  latestState.value = null
+  reconcileToken++
+  searchToken++
+  reconciling.value = false
   Object.assign(record, values)
+}
+
+// Persist an avatar image out-of-band (via the consumer's `avatar-upload`
+// handler) and reflect the returned URL on the record. Accounted for like an
+// optimistic write — `pendingWrites` locks the query controls while it's in
+// flight (a refetch then would read pre-upload data) and a reconcile resyncs
+// once it settles — so a concurrent query change can't land stale rows over it.
+// Patches the `record` passed at call time (the sheet may rebind to another row
+// mid-upload). Resolves to the new URL, or null when no handler is wired.
+async function uploadAvatar(record: Record<string, any>, field: string, file: File | null): Promise<string | null> {
+  if (!props.avatarUpload) { return null }
+  const id = resolveId(record)
+  pendingWrites.value++
+  try {
+    const url = await props.avatarUpload({ id, record, field, file })
+    patch(record, { [field]: url })
+    return url
+  } finally {
+    pendingWrites.value--
+    if (pendingWrites.value === 0) {
+      reconcile()
+    }
+  }
 }
 
 // Create — blocking. The slow POST runs to completion, then the catalog is
@@ -1431,7 +1462,7 @@ provideLensEdit({
   canDelete,
   resolveId,
   save,
-  patch,
+  uploadAvatar,
   create,
   remove,
   openSheet,

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -12,8 +12,10 @@ import { useValidation } from '../../../composables/Validation'
 import { useSnackbars } from '../../../stores/Snackbars'
 import { type FieldData } from '../FieldData'
 import { useFieldFactory } from '../composables/FieldFactory'
+import { useLensAvatarUpload } from '../composables/LensAvatarUpload'
 import { useLensEdit } from '../composables/LensEdit'
 import { extractServerErrors, extractServerMessage } from '../validation/ServerErrors'
+import LensSheetAvatarField from './LensSheetAvatarField.vue'
 import LensSheetField from './LensSheetField.vue'
 
 const props = withDefaults(defineProps<{
@@ -47,7 +49,8 @@ const { t } = useTrans({
     confirm_delete: 'Delete this record?',
     new_record: 'New record',
     load_error:
-      'We couldn’t load this record. Please reload the page and try again.'
+      'We couldn’t load this record. Please reload the page and try again.',
+    avatar_upload_error: 'The record was created, but we couldn’t upload the image.'
   },
   ja: {
     create: '作成',
@@ -56,12 +59,14 @@ const { t } = useTrans({
     confirm_delete: 'このレコードを削除しますか？',
     new_record: '新規作成',
     load_error:
-      'このレコードを読み込めませんでした。ページを再読み込みして、もう一度お試しください。'
+      'このレコードを読み込めませんでした。ページを再読み込みして、もう一度お試しください。',
+    avatar_upload_error: 'レコードは作成されましたが、画像をアップロードできませんでした。'
   }
 })
 
 const edit = useLensEdit()
 const factory = useFieldFactory()
+const avatarUpload = useLensAvatarUpload()
 const snackbars = useSnackbars()
 
 // Provide the data-list label width directly (instead of wrapping rows in
@@ -100,6 +105,14 @@ const createFieldViews = computed(() =>
 // be seeded, validated, or submitted.
 const createInputViews = computed(() =>
   createFieldViews.value.filter((v) => v.field.isSubmittable())
+)
+
+// Avatar fields render in the create form but aren't submittable — their value
+// is a raw `File`, uploaded out-of-band after the record exists (it needs the
+// new id), not sent in the create payload. Tracked separately so the form seeds
+// their model and the post-create step can upload whatever was picked.
+const createAvatarViews = computed(() =>
+  createFields.value.filter((e) => e.fieldData.type === 'avatar')
 )
 
 function resolveInput(field: { formInputComponent: () => any }): any {
@@ -167,6 +180,11 @@ watch(
       for (const { key, field } of createInputViews.value) {
         createModel[key] = field.inputEmptyValue()
       }
+      // Seed avatar pickers too (not submittable, so excluded above) and clear
+      // any file left from a previous create.
+      for (const { key, field } of createAvatarViews.value) {
+        createModel[key] = field.inputEmptyValue()
+      }
       serverErrors.value = {}
       reset()
     }
@@ -201,7 +219,9 @@ async function onCreate() {
     for (const { key, field } of createInputViews.value) {
       values[key] = field.inputToPayload(createModel[key])
     }
-    await edit!.create(values)
+    const created = await edit!.create(values)
+    // The record now exists, so its avatar(s) can be uploaded to the new id.
+    await uploadCreateAvatars(created)
     emit('close')
   } catch (e) {
     // Surface backend validation errors (e.g. a duplicate `unique` value) on the
@@ -224,6 +244,35 @@ async function onCreate() {
     throw e
   } finally {
     saving.value = false
+  }
+}
+
+// Upload any avatar image picked on the create form to the just-created record.
+// Avatars aren't part of the create payload (they need the new id and persist
+// out-of-band), so they're uploaded here via the consumer's handler and the
+// catalog is refreshed to reflect them. A failed upload doesn't fail the create
+// — the record exists — it just surfaces a snackbar.
+async function uploadCreateAvatars(created: Record<string, any>): Promise<void> {
+  const handler = avatarUpload?.handler
+  if (!handler || !created) {
+    return
+  }
+  const id = edit?.resolveId(created) ?? null
+  let uploaded = false
+  for (const { key } of createAvatarViews.value) {
+    const file = createModel[key]
+    if (!(file instanceof File)) {
+      continue
+    }
+    try {
+      await handler({ id, record: created, field: key, file })
+      uploaded = true
+    } catch {
+      snackbars.push({ mode: 'danger', text: t.avatar_upload_error })
+    }
+  }
+  if (uploaded) {
+    await edit?.refresh()
   }
 }
 
@@ -327,13 +376,20 @@ const slotProps = computed(() => ({
             {{ t.load_error }}
           </div>
           <div v-else class="sheet-rows">
-            <LensSheetField
-              v-for="entry in detailFields"
-              :key="entry.key"
-              :field="entry.field"
-              :field-key="entry.key"
-              :record
-            />
+            <template v-for="entry in detailFields" :key="entry.key">
+              <LensSheetAvatarField
+                v-if="entry.fieldData.type === 'avatar'"
+                :field="entry.field"
+                :field-key="entry.key"
+                :record
+              />
+              <LensSheetField
+                v-else
+                :field="entry.field"
+                :field-key="entry.key"
+                :record
+              />
+            </template>
           </div>
         </template>
 

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -120,6 +120,14 @@ const createAvatarViews = computed(() =>
   createFields.value.filter((e) => e.fieldData.type === 'avatar' && !!avatarUpload?.handler)
 )
 
+// Every avatar create field regardless of whether the upload handler is wired
+// yet — used to clear the model on open. The handler may resolve after mount, so
+// clearing only the wired (`createAvatarViews`) subset could leave a stale `File`
+// from a prior canceled create that resurfaces (and uploads) once it appears.
+const createAvatarFields = computed(() =>
+  createFields.value.filter((e) => e.fieldData.type === 'avatar')
+)
+
 function resolveInput(field: { formInputComponent: () => any }): any {
   try {
     return field.formInputComponent()
@@ -185,9 +193,10 @@ watch(
       for (const { key, field } of createInputViews.value) {
         createModel[key] = field.inputEmptyValue()
       }
-      // Seed avatar pickers too (not submittable, so excluded above) and clear
-      // any file left from a previous create.
-      for (const { key, field } of createAvatarViews.value) {
+      // Clear every avatar field's model (not submittable, so excluded above) —
+      // including ones whose handler hasn't resolved yet — so a file left from a
+      // previous create can't resurface and upload when the handler appears.
+      for (const { key, field } of createAvatarFields.value) {
         createModel[key] = field.inputEmptyValue()
       }
       serverErrors.value = {}

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -95,6 +95,11 @@ const createFields = computed(() => entries.value.filter((e) => e.fieldData.show
 // form rather than letting one unsupported field crash the create sheet.
 const createFieldViews = computed(() =>
   createFields.value
+    // An avatar field is editable only when an upload handler is wired (avatars
+    // persist out-of-band); without one, drop its picker from the form rather
+    // than present a control whose picked file would be silently discarded —
+    // mirroring the inline cell / sheet field, which hide the affordance too.
+    .filter((e) => e.fieldData.type !== 'avatar' || !!avatarUpload?.handler)
     .map((e) => ({ key: e.key, field: e.field, component: resolveInput(e.field) }))
     .filter((v) => v.component != null)
 )
@@ -112,7 +117,7 @@ const createInputViews = computed(() =>
 // new id), not sent in the create payload. Tracked separately so the form seeds
 // their model and the post-create step can upload whatever was picked.
 const createAvatarViews = computed(() =>
-  createFields.value.filter((e) => e.fieldData.type === 'avatar')
+  createFields.value.filter((e) => e.fieldData.type === 'avatar' && !!avatarUpload?.handler)
 )
 
 function resolveInput(field: { formInputComponent: () => any }): any {
@@ -265,12 +270,19 @@ async function uploadCreateAvatars(created: Record<string, any>): Promise<void> 
       continue
     }
     try {
-      await handler({ id, record: created, field: key, file })
+      const url = await handler({ id, record: created, field: key, file })
+      // Reflect the uploaded image on the created record immediately. When other
+      // writes are pending, `create()` shows the new row optimistically (no
+      // refetch) and `refresh()` below no-ops — so without this patch the row
+      // would sit with a blank avatar until the user hits the refresh banner.
+      edit?.patch(created, { [key]: url })
       uploaded = true
     } catch {
       snackbars.push({ mode: 'danger', text: t.avatar_upload_error })
     }
   }
+  // Best-effort full resync (no-ops while writes/creates are in flight); the
+  // per-record patch above already surfaced the avatar in that case.
   if (uploaded) {
     await edit?.refresh()
   }

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -224,9 +224,15 @@ async function onCreate() {
     for (const { key, field } of createInputViews.value) {
       values[key] = field.inputToPayload(createModel[key])
     }
+    // Snapshot the picked avatar file(s) before the slow create: the picker stays
+    // interactive during it, so the user could swap the image mid-flight — upload
+    // what was submitted, not whatever the model holds when create resolves.
+    const avatarFiles = createAvatarViews.value
+      .map(({ key }) => ({ key, file: createModel[key] }))
+      .filter((a): a is { key: string; file: File } => a.file instanceof File)
     const created = await edit!.create(values)
     // The record now exists, so its avatar(s) can be uploaded to the new id.
-    await uploadCreateAvatars(created)
+    await uploadCreateAvatars(created, avatarFiles)
     emit('close')
   } catch (e) {
     // Surface backend validation errors (e.g. a duplicate `unique` value) on the
@@ -252,39 +258,41 @@ async function onCreate() {
   }
 }
 
-// Upload any avatar image picked on the create form to the just-created record.
-// Avatars aren't part of the create payload (they need the new id and persist
-// out-of-band), so they're uploaded here via the consumer's handler and the
-// catalog is refreshed to reflect them. A failed upload doesn't fail the create
-// — the record exists — it just surfaces a snackbar.
-async function uploadCreateAvatars(created: Record<string, any>): Promise<void> {
-  const handler = avatarUpload?.handler
-  if (!handler || !created) {
+// Upload the avatar image(s) picked on the create form to the just-created
+// record. Avatars aren't part of the create payload (they need the new id and
+// persist out-of-band), so they're uploaded here via the catalog's handler,
+// which also patches the created record's URL. A failed upload doesn't fail the
+// create — the record exists — it just surfaces a snackbar. `files` is the set
+// snapshotted at submit time so a mid-flight picker change can't swap them.
+async function uploadCreateAvatars(
+  created: Record<string, any>,
+  files: { key: string; file: File }[]
+): Promise<void> {
+  if (!created || files.length === 0) {
     return
   }
-  const id = edit?.resolveId(created) ?? null
   let uploaded = false
-  for (const { key } of createAvatarViews.value) {
-    const file = createModel[key]
-    if (!(file instanceof File)) {
-      continue
-    }
+  for (const { key, file } of files) {
     try {
-      const url = await handler({ id, record: created, field: key, file })
-      // Reflect the uploaded image on the created record immediately. When other
-      // writes are pending, `create()` shows the new row optimistically (no
-      // refetch) and `refresh()` below no-ops — so without this patch the row
-      // would sit with a blank avatar until the user hits the refresh banner.
-      edit?.patch(created, { [key]: url })
+      // Uploads to the new id and patches `created`'s URL; when other writes are
+      // pending, `create()` shows the new row optimistically (no refetch) and the
+      // refresh below no-ops, so the patch is what surfaces the avatar then.
+      await edit?.uploadAvatar(created, key, file)
       uploaded = true
     } catch {
       snackbars.push({ mode: 'danger', text: t.avatar_upload_error })
     }
   }
-  // Best-effort full resync (no-ops while writes/creates are in flight); the
-  // per-record patch above already surfaced the avatar in that case.
+  // Best-effort full resync so the avatar shows on the (possibly refetched) row.
+  // It MUST NOT reject: the record + avatar already persisted, so letting a failed
+  // refresh throw would make `onCreate` treat the create as failed and risk a
+  // duplicate on retry. The per-record patch above already reflected the avatar.
   if (uploaded) {
-    await edit?.refresh()
+    try {
+      await edit?.refresh()
+    } catch {
+      // Ignore — best-effort.
+    }
   }
 }
 

--- a/lib/blocks/lens/components/LensSheetAvatarField.vue
+++ b/lib/blocks/lens/components/LensSheetAvatarField.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import SDataListItem from '../../../components/SDataListItem.vue'
+import { useTrans } from '../../../composables/Lang'
+import { useSnackbars } from '../../../stores/Snackbars'
+import { type FieldData } from '../FieldData'
+import { useLensAvatarUpload } from '../composables/LensAvatarUpload'
+import { useLensEdit } from '../composables/LensEdit'
+import { type AvatarField } from '../fields/AvatarField'
+import { type Field } from '../fields/Field'
+import LensAvatarInput from './LensAvatarInput.vue'
+
+const props = defineProps<{
+  field: Field<FieldData>
+  fieldKey: string
+  record: Record<string, any>
+}>()
+
+// The table only renders this component for `avatar` fields, so the field is
+// always an `AvatarField` — narrow it for the avatar-specific config getters.
+const avatarField = computed(() => props.field as AvatarField)
+
+const { t } = useTrans({
+  en: { upload_error: 'We couldn’t upload the image. Please try again.' },
+  ja: { upload_error: '画像をアップロードできませんでした。もう一度お試しください。' }
+})
+
+const edit = useLensEdit()
+const avatarUpload = useLensAvatarUpload()
+const snackbars = useSnackbars()
+
+// Editable only when the row passes the edit gate and an upload handler is wired
+// (avatars persist out-of-band); otherwise the avatar is shown read-only.
+const editable = computed(() =>
+  !!edit?.canEdit(props.record)
+  && (props.field as any).data?.showOnUpdate === true
+  && !!avatarUpload?.handler
+)
+
+const uploading = ref(false)
+
+// The value the picker shows: the row's current image URL, except while an
+// upload is in flight (then the local file preview the change handler set).
+const model = ref<File | string | null>(props.record[props.fieldKey] ?? null)
+
+watch(
+  () => props.record[props.fieldKey],
+  (value) => { if (!uploading.value) { model.value = value ?? null } }
+)
+
+async function onChange(value: File | string | null | undefined) {
+  // A string is the existing URL still selected — nothing to upload.
+  if (typeof value === 'string') {
+    model.value = value
+    return
+  }
+  if (!avatarUpload?.handler) {
+    return
+  }
+  const file = value ?? null
+  // Show the picked file (or the cleared empty state) immediately.
+  model.value = file
+  uploading.value = true
+  try {
+    const url = await avatarUpload.handler({
+      id: edit?.resolveId(props.record) ?? null,
+      record: props.record,
+      field: props.fieldKey,
+      file
+    })
+    edit?.patch(props.record, { [props.fieldKey]: url })
+    model.value = url
+  } catch {
+    model.value = props.record[props.fieldKey] ?? null
+    snackbars.push({ mode: 'danger', text: t.upload_error })
+  } finally {
+    uploading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="LensSheetAvatarField">
+    <SDataListItem v-if="editable">
+      <template #label>{{ field.label() }}</template>
+      <template #value>
+        <LensAvatarInput
+          :model-value="model"
+          :accept="avatarField.accept()"
+          :image-type="avatarField.imageType()"
+          :help="field.help() || undefined"
+          :disabled="uploading"
+          @update:model-value="onChange"
+        />
+      </template>
+    </SDataListItem>
+    <component :is="field.dataListItemComponent()" v-else :value="record[fieldKey]" />
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.LensSheetAvatarField {
+  position: relative;
+  border-bottom: 1px dashed var(--c-divider);
+}
+</style>

--- a/lib/blocks/lens/components/LensSheetAvatarField.vue
+++ b/lib/blocks/lens/components/LensSheetAvatarField.vue
@@ -37,6 +37,12 @@ const editable = computed(() =>
   && !!avatarUpload?.handler
 )
 
+// Materialize the read-only display component once (computed off `props.field`):
+// `dataListItemComponent()` mints a fresh definition each call, so resolving it
+// inline in the template would unmount/remount the avatar on every reactive row
+// update (e.g. an out-of-band `patch`), causing flicker.
+const displayComponent = computed(() => props.field.dataListItemComponent())
+
 const uploading = ref(false)
 
 // The value the picker shows: the row's current image URL, except while an
@@ -94,7 +100,7 @@ async function onChange(value: File | string | null | undefined) {
         />
       </template>
     </SDataListItem>
-    <component :is="field.dataListItemComponent()" v-else :value="record[fieldKey]" />
+    <component :is="displayComponent" v-else :value="record[fieldKey]" />
   </div>
 </template>
 

--- a/lib/blocks/lens/components/LensSheetAvatarField.vue
+++ b/lib/blocks/lens/components/LensSheetAvatarField.vue
@@ -64,23 +64,32 @@ async function onChange(value: File | string | null | undefined) {
     return
   }
   const file = value ?? null
+  // Capture the record being edited: the sheet can be closed and reopened on
+  // another row while this upload is in flight (only the input is disabled, not
+  // the sheet), so `props.record` may point elsewhere by the time we resolve.
+  const record = props.record
   // Show the picked file (or the cleared empty state) immediately.
   model.value = file
   uploading.value = true
   try {
-    const url = await avatarUpload.handler({
-      id: edit?.resolveId(props.record) ?? null,
-      record: props.record,
-      field: props.fieldKey,
-      file
-    })
-    edit?.patch(props.record, { [props.fieldKey]: url })
-    model.value = url
+    // The catalog uploads and patches the captured record's URL itself (with
+    // write accounting); only touch this component's picker if it still shows it.
+    const url = await edit?.uploadAvatar(record, props.fieldKey, file) ?? null
+    if (props.record === record) {
+      model.value = url
+    }
   } catch {
-    model.value = props.record[props.fieldKey] ?? null
+    if (props.record === record) {
+      model.value = record[props.fieldKey] ?? null
+    }
     snackbars.push({ mode: 'danger', text: t.upload_error })
   } finally {
     uploading.value = false
+    // If the sheet rebound to another row mid-upload, resync the picker to it
+    // (the `props.record` watcher skipped re-seeding while `uploading` was true).
+    if (props.record !== record) {
+      model.value = props.record[props.fieldKey] ?? null
+    }
   }
 }
 </script>

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -5,13 +5,14 @@ import { computed, markRaw } from 'vue'
 import STable from '../../../components/STable.vue'
 import { type DropdownSection } from '../../../composables/Dropdown'
 import { type TableCell, type TableColumns, useTable } from '../../../composables/Table'
-import { type FieldData } from '../FieldData'
+import { type AvatarFieldData, type FieldData } from '../FieldData'
 import { type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
 import { useFieldFactory } from '../composables/FieldFactory'
 import { useLensEdit } from '../composables/LensEdit'
 import { provideLensInlineEdit } from '../composables/LensInlineEdit'
 import { type Field } from '../fields/Field'
+import LensTableAvatarCell from './LensTableAvatarCell.vue'
 import LensTableEditableCell from './LensTableEditableCell.vue'
 
 const props = defineProps<{
@@ -44,6 +45,7 @@ const edit = useLensEdit()
 provideLensInlineEdit()
 
 const editableCellComponent = markRaw(LensTableEditableCell)
+const avatarCellComponent = markRaw(LensTableAvatarCell)
 
 const records = computed(() => props.result?.data ?? [])
 
@@ -150,6 +152,31 @@ const columns = computedAsync(async () => {
       props.inlineEditable
       && edit?.editable
       && key !== edit.indexField
+      && overriddenFieldData.type === 'avatar'
+      && overriddenFieldData.showOnUpdate === true
+    ) {
+      // Avatars get a dedicated cell: a hover overlay to change the image
+      // (uploaded out-of-band via the catalog's avatar-upload handler) plus an
+      // optional pencil that edits the display-name companions inline. The image
+      // and names are persisted differently, so the generic editable cell (a
+      // single optimistic field write) can't serve them.
+      const avatarData = overriddenFieldData as AvatarFieldData
+      column.cell = {
+        type: 'component',
+        component: avatarCellComponent,
+        props: {
+          field,
+          fieldKey: key,
+          nameEnKey: avatarData.nameEn ?? null,
+          nameJaKey: avatarData.nameJa ?? null,
+          nameFieldEn: makeEditableField(r, avatarData.nameEn),
+          nameFieldJa: makeEditableField(r, avatarData.nameJa)
+        }
+      }
+    } else if (
+      props.inlineEditable
+      && edit?.editable
+      && key !== edit.indexField
       && overriddenFieldData.showOnUpdate === true
       && field.isSubmittable()
       && field.supportsOptimisticUpdate()
@@ -236,6 +263,22 @@ function hasFormInput(field: Field<FieldData>): boolean {
   } catch {
     return false
   }
+}
+
+// Build a sibling field instance for inline editing from the current result's
+// field set — but only when it exists and is itself editable (`showOnUpdate`).
+// Used by the avatar cell to edit its display-name companions alongside the
+// image; a non-editable companion is omitted so its name can't be written.
+function makeEditableField(r: LensResult, key?: string | null): Field<FieldData> | null {
+  if (!key) {
+    return null
+  }
+  const fieldData = r.fields[key]
+  if (!fieldData || fieldData.showOnUpdate !== true) {
+    return null
+  }
+  const data = Object.assign(cloneDeep(fieldData), props.overrides?.[key] ?? {})
+  return fieldFactory.make(data)
 }
 </script>
 

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -266,9 +266,11 @@ function hasFormInput(field: Field<FieldData>): boolean {
 }
 
 // Build a sibling field instance for inline editing from the current result's
-// field set — but only when it exists and is itself editable (`showOnUpdate`).
-// Used by the avatar cell to edit its display-name companions alongside the
-// image; a non-editable companion is omitted so its name can't be written.
+// field set — but only when it exists, is itself editable (`showOnUpdate`), and
+// actually has a form input. Used by the avatar cell to edit its display-name
+// companions alongside the image; a non-editable or input-less companion (e.g.
+// an `id` / `slack_message` field, whose `formInputComponent()` throws) is
+// omitted so the name editor can't instantiate a broken input and crash.
 function makeEditableField(r: LensResult, key?: string | null): Field<FieldData> | null {
   if (!key) {
     return null
@@ -278,7 +280,8 @@ function makeEditableField(r: LensResult, key?: string | null): Field<FieldData>
     return null
   }
   const data = Object.assign(cloneDeep(fieldData), props.overrides?.[key] ?? {})
-  return fieldFactory.make(data)
+  const field = fieldFactory.make(data)
+  return hasFormInput(field) ? field : null
 }
 </script>
 

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -266,11 +266,12 @@ function hasFormInput(field: Field<FieldData>): boolean {
 }
 
 // Build a sibling field instance for inline editing from the current result's
-// field set — but only when it exists, is itself editable (`showOnUpdate`), and
-// actually has a form input. Used by the avatar cell to edit its display-name
-// companions alongside the image; a non-editable or input-less companion (e.g.
-// an `id` / `slack_message` field, whose `formInputComponent()` throws) is
-// omitted so the name editor can't instantiate a broken input and crash.
+// field set — but only when it's editable (`showOnUpdate`) and safe to edit the
+// same way the generic inline cell requires: submittable, optimistically
+// patchable, and with a real form input. Used by the avatar cell to edit its
+// display-name companions; this omits a companion that is non-editable, display
+// only (`content`), holds raw files (`file_upload`), or has no input (`id` /
+// `slack_message`), so the name editor can't send an unsafe value or crash.
 function makeEditableField(r: LensResult, key?: string | null): Field<FieldData> | null {
   if (!key) {
     return null
@@ -281,7 +282,10 @@ function makeEditableField(r: LensResult, key?: string | null): Field<FieldData>
   }
   const data = Object.assign(cloneDeep(fieldData), props.overrides?.[key] ?? {})
   const field = fieldFactory.make(data)
-  return hasFormInput(field) ? field : null
+  if (!field.isSubmittable() || !field.supportsOptimisticUpdate() || !hasFormInput(field)) {
+    return null
+  }
+  return field
 }
 </script>
 

--- a/lib/blocks/lens/components/LensTableAvatarCell.vue
+++ b/lib/blocks/lens/components/LensTableAvatarCell.vue
@@ -224,7 +224,7 @@ function onEditorKeydown(event: KeyboardEvent) {
 
 <template>
   <div ref="anchor" class="LensTableAvatarCell" :class="{ editing: editingNames }">
-    <div v-if="displayImage || displayName" class="avatar">
+    <div v-if="displayImage || displayName || canEditImage" class="avatar">
       <button
         class="image"
         type="button"

--- a/lib/blocks/lens/components/LensTableAvatarCell.vue
+++ b/lib/blocks/lens/components/LensTableAvatarCell.vue
@@ -1,0 +1,411 @@
+<script setup lang="ts">
+import IconCamera from '~icons/ph/camera'
+import IconPencilSimple from '~icons/ph/pencil-simple'
+import { useElementBounding } from '@vueuse/core'
+import { computed, nextTick, onUnmounted, reactive, ref, watch } from 'vue'
+import SAvatar from '../../../components/SAvatar.vue'
+import SButton from '../../../components/SButton.vue'
+import SSpinner from '../../../components/SSpinner.vue'
+import { useManualDropdownPosition } from '../../../composables/Dropdown'
+import { useTrans } from '../../../composables/Lang'
+import { useValidation } from '../../../composables/Validation'
+import { useSnackbars } from '../../../stores/Snackbars'
+import { type FieldData } from '../FieldData'
+import { useLensAvatarUpload } from '../composables/LensAvatarUpload'
+import { useLensEdit } from '../composables/LensEdit'
+import { useLensInlineEdit } from '../composables/LensInlineEdit'
+import { type AvatarField } from '../fields/AvatarField'
+import { type Field } from '../fields/Field'
+
+const props = defineProps<{
+  field: AvatarField
+  fieldKey: string
+  // The English / Japanese display-name companion fields, resolved by the table
+  // from the avatar field's `nameEn` / `nameJa` keys. Present only when the
+  // avatar declares them, so the names can be edited alongside the image.
+  nameEnKey?: string | null
+  nameJaKey?: string | null
+  nameFieldEn?: Field<FieldData> | null
+  nameFieldJa?: Field<FieldData> | null
+  // Injected by STable for a `component` cell: the cell value (image URL) and
+  // the full row record.
+  value: any
+  record: Record<string, any>
+}>()
+
+const { t } = useTrans({
+  en: { cancel: 'Cancel', save: 'Save', edit_image: 'Change image', edit_names: 'Edit name', upload_error: 'We couldn’t upload the image. Please try again.' },
+  ja: { cancel: 'キャンセル', save: '保存', edit_image: '画像を変更', edit_names: '名前を編集', upload_error: '画像をアップロードできませんでした。もう一度お試しください。' }
+})
+
+const edit = useLensEdit()
+const inline = useLensInlineEdit()
+const avatarUpload = useLensAvatarUpload()
+const snackbars = useSnackbars()
+
+const canEdit = computed(() => !!edit?.canEdit(props.record))
+
+// The image can be changed only when an upload handler is wired (avatars are
+// persisted out-of-band); without one the overlay affordance is hidden.
+const canEditImage = computed(() => canEdit.value && !!avatarUpload?.handler)
+
+const nameEntries = computed(() => {
+  const entries: { key: string; field: Field<FieldData> }[] = []
+  if (props.nameEnKey && props.nameFieldEn) {
+    entries.push({ key: props.nameEnKey, field: props.nameFieldEn })
+  }
+  if (props.nameJaKey && props.nameFieldJa) {
+    entries.push({ key: props.nameJaKey, field: props.nameFieldJa })
+  }
+  return entries
+})
+
+const canEditNames = computed(() => canEdit.value && nameEntries.value.length > 0)
+
+// --- Display (mirrors STableCellAvatar) -------------------------------------
+
+const base = computed<any>(() => props.field.tableCell(props.value, props.record))
+
+// While an upload is in flight, show a local preview of the picked file so the
+// new image appears immediately instead of waiting on the round-trip.
+const previewSrc = ref<string | null>(null)
+const displayImage = computed(() => previewSrc.value ?? base.value.image ?? null)
+const displayName = computed(() => base.value.name || null)
+
+// --- Image edit (file picker -> upload handler) -----------------------------
+
+const fileInput = ref<HTMLInputElement | null>(null)
+const uploading = ref(false)
+
+function pickImage() {
+  if (!canEditImage.value || uploading.value) {
+    return
+  }
+  fileInput.value?.click()
+}
+
+async function onFilePicked(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = (input.files ?? [])[0] ?? null
+  // Reset the input so picking the same file again still fires `change`.
+  input.value = ''
+  if (!file || !avatarUpload?.handler) {
+    return
+  }
+  await upload(file)
+}
+
+async function upload(file: File | null) {
+  if (!avatarUpload?.handler) {
+    return
+  }
+  uploading.value = true
+  previewSrc.value = file ? URL.createObjectURL(file) : null
+  try {
+    const url = await avatarUpload.handler({
+      id: edit?.resolveId(props.record) ?? null,
+      record: props.record,
+      field: props.fieldKey,
+      file
+    })
+    // Reflect the new image on the row (the catalog row and any open sheet share
+    // this object) via the edit context — out-of-band, not a Lens write. The
+    // value is a URL, never the raw file, so it renders safely.
+    edit?.patch(props.record, { [props.fieldKey]: url })
+  } catch {
+    // The handler is expected to surface its own failure, but guard with a
+    // generic message so a thrown upload never fails silently.
+    snackbars.push({ mode: 'danger', text: t.upload_error })
+  } finally {
+    if (previewSrc.value) {
+      URL.revokeObjectURL(previewSrc.value)
+      previewSrc.value = null
+    }
+    uploading.value = false
+  }
+}
+
+// --- Name edit (floating editor anchored to the cell) -----------------------
+
+const myKey = computed(() => `${edit?.resolveId(props.record)}:${props.fieldKey}`)
+const editingNames = computed(() => inline?.activeKey.value === myKey.value)
+
+const anchor = ref<HTMLElement | null>(null)
+const editorEl = ref<HTMLElement | null>(null)
+const bounds = useElementBounding(anchor)
+const { inset, update } = useManualDropdownPosition(anchor)
+
+const nameModel = reactive<Record<string, any>>({})
+
+// Materialize the name inputs once so the editor doesn't mint a fresh component
+// definition each render (which breaks Vue's patching).
+const nameInputs = computed(() =>
+  nameEntries.value.map((entry) => ({
+    key: entry.key,
+    field: entry.field,
+    component: entry.field.formInputComponent()
+  }))
+)
+
+const { validation, validate, reset } = useValidation(
+  () => nameModel,
+  () => Object.fromEntries(nameEntries.value.map((e) => [e.key, e.field.generateValidationRules()]))
+)
+
+const editorStyle = computed(() => ({
+  ...inset.value,
+  width: `${Math.max(bounds.width.value, 280)}px`
+}))
+
+// If the backing record is replaced while the name editor is open (a refresh
+// apply, a parent refresh, a requery), close it so a stale model can't be saved.
+watch(
+  () => nameEntries.value.map((e) => props.record[e.key]),
+  () => { if (editingNames.value) { inline?.stop() } },
+  { deep: true }
+)
+
+// STable virtualization can unmount this row while scrolling; clear the shared
+// active key on unmount so a remount doesn't reopen a blank editor.
+onUnmounted(() => {
+  if (inline?.activeKey.value === myKey.value) {
+    inline.stop()
+  }
+})
+
+function startNames() {
+  if (!canEditNames.value) {
+    return
+  }
+  for (const entry of nameEntries.value) {
+    nameModel[entry.key] = entry.field.payloadToInput(props.record[entry.key] ?? entry.field.inputEmptyValue())
+  }
+  reset()
+  inline?.start(myKey.value)
+  nextTick(() => {
+    update()
+    const el = editorEl.value?.querySelector('input, textarea, [contenteditable], [tabindex]') as HTMLElement | null
+    el?.focus()
+  })
+}
+
+function cancelNames() {
+  inline?.stop()
+}
+
+async function applyNames() {
+  if (!(await validate())) {
+    return
+  }
+  // The editable predicate can flip to reject this row while the editor is open.
+  if (!canEditNames.value) {
+    if (inline?.activeKey.value === myKey.value) {
+      inline.stop()
+    }
+    return
+  }
+  const values: Record<string, any> = {}
+  for (const entry of nameEntries.value) {
+    values[entry.key] = entry.field.inputToPayload(nameModel[entry.key])
+  }
+  edit!.save(props.record, values)
+  if (inline?.activeKey.value === myKey.value) {
+    inline.stop()
+  }
+}
+
+function onEditorKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    cancelNames()
+  }
+}
+</script>
+
+<template>
+  <div ref="anchor" class="LensTableAvatarCell" :class="{ editing: editingNames }">
+    <div v-if="displayImage || displayName" class="avatar">
+      <button
+        class="image"
+        type="button"
+        :class="{ editable: canEditImage }"
+        :disabled="!canEditImage || uploading"
+        :aria-label="`${t.edit_image} ${field.label()}`"
+        @click="pickImage"
+      >
+        <SAvatar size="mini" :avatar="displayImage" :name="displayName" />
+        <span v-if="canEditImage" class="image-overlay">
+          <SSpinner v-if="uploading" class="image-spinner" />
+          <IconCamera v-else class="image-icon" />
+        </span>
+      </button>
+      <span v-if="displayName" class="name">{{ displayName }}</span>
+    </div>
+
+    <input
+      v-if="canEditImage"
+      ref="fileInput"
+      class="file-input"
+      type="file"
+      :accept="field.accept()"
+      @change="onFilePicked"
+    >
+
+    <button
+      v-if="canEditNames"
+      class="edit"
+      type="button"
+      :aria-label="`${t.edit_names} ${field.label()}`"
+      @click="startNames"
+    >
+      <IconPencilSimple class="edit-icon" />
+    </button>
+
+    <Teleport v-if="editingNames" to="#sefirot-modals">
+      <div
+        ref="editorEl"
+        class="LensTableAvatarCellEditor"
+        :style="editorStyle"
+        @keydown="onEditorKeydown"
+      >
+        <component
+          :is="input.component"
+          v-for="input in nameInputs"
+          :key="input.key"
+          v-model="nameModel[input.key]"
+          :validation="validation[input.key]"
+        />
+        <div class="actions">
+          <SButton size="mini" :label="t.cancel" @click="cancelNames" />
+          <SButton size="mini" mode="info" :label="t.save" @click="applyNames" />
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.LensTableAvatarCell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  min-height: 40px;
+  padding: 8px 36px 8px 16px;
+}
+
+.avatar {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.image {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  border-radius: 50%;
+}
+
+.image.editable {
+  cursor: pointer;
+}
+
+.image:disabled {
+  cursor: default;
+}
+
+.image-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.image.editable:hover .image-overlay,
+.image:disabled .image-overlay {
+  opacity: 1;
+}
+
+.image-icon {
+  width: 12px;
+  height: 12px;
+}
+
+.image-spinner {
+  width: 12px;
+  height: 12px;
+}
+
+.name {
+  display: inline-block;
+  margin-left: 8px;
+  line-height: 24px;
+  font-size: var(--table-cell-font-size);
+  font-weight: var(--table-cell-font-weight);
+  color: var(--c-text-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.file-input {
+  display: none;
+}
+
+.edit {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  transform: translateY(-50%);
+  border-radius: 6px;
+  color: var(--c-text-2);
+  opacity: 0;
+  transition: opacity 0.1s, background-color 0.1s, color 0.1s;
+}
+
+.LensTableAvatarCell:hover .edit,
+.LensTableAvatarCell.editing .edit {
+  opacity: 1;
+}
+
+.edit:hover {
+  background-color: var(--c-bg-mute-1);
+  color: var(--c-text-1);
+}
+
+.edit-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.LensTableAvatarCellEditor {
+  position: fixed;
+  z-index: var(--z-index-sheet, 2000);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  background-color: var(--c-bg-1);
+  box-shadow: var(--shadow-depth-3);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+</style>

--- a/lib/blocks/lens/components/LensTableAvatarCell.vue
+++ b/lib/blocks/lens/components/LensTableAvatarCell.vue
@@ -51,12 +51,20 @@ const canEditImage = computed(() => canEdit.value && !!avatarUpload?.handler)
 
 const nameEntries = computed(() => {
   const entries: { key: string; field: Field<FieldData> }[] = []
-  if (props.nameEnKey && props.nameFieldEn) {
-    entries.push({ key: props.nameEnKey, field: props.nameFieldEn })
+  const seen = new Set<string>()
+  const add = (key: string | null | undefined, field: Field<FieldData> | null | undefined): void => {
+    // Skip a companion that isn't fetched on this row — editing the visible name
+    // would otherwise send an empty value for the unfetched sibling and clear it
+    // (e.g. `loadSelectable` exposes `name_ja` in `fields` while the select omits
+    // it). De-duplicate too: both languages may point at one shared name column.
+    if (!key || !field || seen.has(key) || !(key in props.record)) {
+      return
+    }
+    seen.add(key)
+    entries.push({ key, field })
   }
-  if (props.nameJaKey && props.nameFieldJa) {
-    entries.push({ key: props.nameJaKey, field: props.nameFieldJa })
-  }
+  add(props.nameEnKey, props.nameFieldEn)
+  add(props.nameJaKey, props.nameFieldJa)
   return entries
 })
 
@@ -96,22 +104,16 @@ async function onFilePicked(event: Event) {
 }
 
 async function upload(file: File | null) {
-  if (!avatarUpload?.handler) {
+  if (!canEditImage.value) {
     return
   }
   uploading.value = true
   previewSrc.value = file ? URL.createObjectURL(file) : null
   try {
-    const url = await avatarUpload.handler({
-      id: edit?.resolveId(props.record) ?? null,
-      record: props.record,
-      field: props.fieldKey,
-      file
-    })
-    // Reflect the new image on the row (the catalog row and any open sheet share
-    // this object) via the edit context — out-of-band, not a Lens write. The
-    // value is a URL, never the raw file, so it renders safely.
-    edit?.patch(props.record, { [props.fieldKey]: url })
+    // The catalog uploads (out-of-band) and patches the row's URL itself, with
+    // write accounting so a concurrent query change can't land stale rows over
+    // it; the value is a URL, never the raw file, so it renders safely.
+    await edit?.uploadAvatar(props.record, props.fieldKey, file)
   } catch {
     // The handler is expected to surface its own failure, but guard with a
     // generic message so a thrown upload never fails silently.
@@ -194,9 +196,26 @@ function cancelNames() {
 }
 
 async function applyNames() {
+  // Snapshot the companion values we're editing so we can detect the backing row
+  // being replaced (a refresh apply, a parent refresh, a requery, or a sibling
+  // save) during the async validate, and avoid clobbering the fresh state.
+  const edited = nameEntries.value.map((entry) => props.record[entry.key])
+
   if (!(await validate())) {
     return
   }
+
+  // A refresh / requery can swap a companion value during the validate microtask;
+  // the watcher above closes the editor but flushes asynchronously and can't abort
+  // this running apply, so re-check against the snapshot. If any changed, `model`
+  // predates the fresh value — bail rather than overwrite it.
+  if (nameEntries.value.some((entry, i) => props.record[entry.key] !== edited[i])) {
+    if (inline?.activeKey.value === myKey.value) {
+      inline.stop()
+    }
+    return
+  }
+
   // The editable predicate can flip to reject this row while the editor is open.
   if (!canEditNames.value) {
     if (inline?.activeKey.value === myKey.value) {

--- a/lib/blocks/lens/composables/LensAvatarUpload.ts
+++ b/lib/blocks/lens/composables/LensAvatarUpload.ts
@@ -1,0 +1,51 @@
+import { type InjectionKey, inject, provide } from 'vue'
+
+/**
+ * Payload handed to the avatar upload handler when the user picks (or clears)
+ * an avatar image inline, in the record sheet, or on the create form.
+ */
+export interface LensAvatarUploadPayload {
+  /** The record's resolved id. `null` while creating (no record exists yet). */
+  id: any
+
+  /** The full record being edited, or `null` while creating. */
+  record: Record<string, any> | null
+
+  /** The avatar field's key (e.g. `avatar`). */
+  field: string
+
+  /** The picked image file, or `null` when the image is being removed. */
+  file: File | null
+}
+
+/**
+ * Persist an avatar image change for a Lens record and resolve to the new
+ * image URL (or `null` when the image was removed).
+ *
+ * Avatars are stored out-of-band — a multipart upload the consuming app owns —
+ * rather than through the Lens create/update write, because the value the form
+ * holds is a raw `File` while the row renders a URL. So the catalog delegates
+ * the actual persistence to this consumer-provided handler and only reflects
+ * the resulting URL on the row. The handler should throw on failure; the caller
+ * surfaces it and keeps the previous image.
+ */
+export type LensAvatarUploadHandler = (payload: LensAvatarUploadPayload) => Promise<string | null>
+
+/**
+ * The injected avatar-upload context. A thin accessor (rather than the bare
+ * handler) so the handler can be read reactively — a catalog may resolve or
+ * change its `avatar-upload` prop after mount.
+ */
+export interface LensAvatarUploadContext {
+  readonly handler: LensAvatarUploadHandler | null
+}
+
+const LensAvatarUploadKey: InjectionKey<LensAvatarUploadContext> = Symbol('LensAvatarUpload')
+
+export function provideLensAvatarUpload(ctx: LensAvatarUploadContext): void {
+  provide(LensAvatarUploadKey, ctx)
+}
+
+export function useLensAvatarUpload(): LensAvatarUploadContext | null {
+  return inject(LensAvatarUploadKey, null)
+}

--- a/lib/blocks/lens/composables/LensEdit.ts
+++ b/lib/blocks/lens/composables/LensEdit.ts
@@ -36,6 +36,16 @@ export interface LensEditContext {
   save: (record: Record<string, any>, values: Record<string, any>) => void
 
   /**
+   * Reflect an out-of-band change on a record in memory, without persisting it
+   * through the Lens create/update write. Used for values the Lens write does
+   * not carry — e.g. an avatar uploaded via the consumer's handler, which is
+   * stored separately and only its resulting URL needs to show on the row. The
+   * catalog row and any open sheet share the record object, so the change
+   * appears immediately. The row identifier is never patched.
+   */
+  patch: (record: Record<string, any>, values: Record<string, any>) => void
+
+  /**
    * Create a new record. Blocking: resolves once the record is persisted and
    * the catalog has been refreshed with the canonical state.
    */
@@ -52,6 +62,14 @@ export interface LensEditContext {
 
   /** Open the record sheet in create mode. */
   openCreate: () => void
+
+  /**
+   * Re-run the current query against the server, preserving the catalog's
+   * in-memory state. Used to reflect an out-of-band change (e.g. an avatar
+   * uploaded through the consumer's handler, which the Lens write doesn't
+   * carry) once it has settled. No-ops while a write or create is in flight.
+   */
+  refresh: () => Promise<void>
 }
 
 const LensEditKey: InjectionKey<LensEditContext> = Symbol('LensEdit')

--- a/lib/blocks/lens/composables/LensEdit.ts
+++ b/lib/blocks/lens/composables/LensEdit.ts
@@ -36,14 +36,17 @@ export interface LensEditContext {
   save: (record: Record<string, any>, values: Record<string, any>) => void
 
   /**
-   * Reflect an out-of-band change on a record in memory, without persisting it
-   * through the Lens create/update write. Used for values the Lens write does
-   * not carry — e.g. an avatar uploaded via the consumer's handler, which is
-   * stored separately and only its resulting URL needs to show on the row. The
-   * catalog row and any open sheet share the record object, so the change
-   * appears immediately. The row identifier is never patched.
+   * Persist an avatar image for a record out-of-band — via the catalog's
+   * `avatar-upload` handler — and reflect the resulting URL on the row. The
+   * value the Lens create/update write doesn't carry (it's a `File` on edit, a
+   * URL on read), so it's uploaded separately and only the URL is patched onto
+   * the shared record object. Accounted for like a write: the query controls
+   * lock while it's in flight and a reconcile resyncs once it settles, so a
+   * concurrent refetch can't land stale rows over it. Patches the `record`
+   * passed at call time. Resolves to the new URL (or null when removed / no
+   * handler is wired); rejects if the handler throws.
    */
-  patch: (record: Record<string, any>, values: Record<string, any>) => void
+  uploadAvatar: (record: Record<string, any>, field: string, file: File | null) => Promise<string | null>
 
   /**
    * Create a new record. Blocking: resolves once the record is persisted and

--- a/lib/blocks/lens/fields/AvatarField.ts
+++ b/lib/blocks/lens/fields/AvatarField.ts
@@ -3,6 +3,7 @@ import SAvatar from '../../../components/SAvatar.vue'
 import { type TableCell } from '../../../composables/Table'
 import { type AvatarFieldData } from '../FieldData'
 import { type FilterOperator } from '../FilterOperator'
+import LensAvatarInput from '../components/LensAvatarInput.vue'
 import { type FilterInput } from '../filter-inputs/FilterInput'
 import { Field } from './Field'
 
@@ -10,7 +11,7 @@ export class AvatarField extends Field<AvatarFieldData> {
   override tableCell(v: any, r: any): TableCell {
     // The display name lives on a sibling key of the record (resolved by the
     // active language), not on the field value, which is the image URL.
-    const nameKey = this.ctx.lang === 'ja' ? this.data.nameJa : this.data.nameEn
+    const nameKey = this.nameKey()
     return {
       type: 'avatar',
       // The field value is the image URL itself. A missing value renders an
@@ -37,7 +38,59 @@ export class AvatarField extends Field<AvatarFieldData> {
     })
   }
 
+  // The avatar value is an image URL on read but a raw `File` on edit, and it's
+  // persisted out-of-band (the consumer's upload handler stores the file and
+  // returns a URL) rather than through the Lens create/update write. So it never
+  // contributes a value to those payloads — the dedicated avatar cell / sheet
+  // field / create form drive the upload themselves.
+  override isSubmittable(): boolean {
+    return false
+  }
+
+  // Editing routes through the dedicated avatar cell and sheet field (which call
+  // the upload handler), never the generic optimistic cell/field editors — those
+  // would patch the row with a raw `File` and crash the URL renderer.
+  override supportsOptimisticUpdate(): boolean {
+    return false
+  }
+
+  override inputEmptyValue(): any {
+    return null
+  }
+
   override formInputComponent(): any {
-    throw new Error('Not implemented.')
+    return this.defineFormInputComponent((props, { emit }) => {
+      return () => h(LensAvatarInput, {
+        'label': this.formInputLabel(),
+        'help': this.help() || undefined,
+        'accept': this.accept(),
+        'imageType': this.imageType(),
+        'modelValue': props.modelValue,
+        'validation': props.validation,
+        'onUpdate:modelValue': (value: any) => {
+          emit('update:modelValue', value)
+        }
+      })
+    })
+  }
+
+  /** The `accept` attribute for the file picker. */
+  accept(): string {
+    return this.data.accept || 'image/*'
+  }
+
+  /** The picker preview shape. */
+  imageType(): 'circle' | 'rectangle' {
+    return this.data.imageType || 'circle'
+  }
+
+  /** The companion name key resolved against the active language, if any. */
+  nameKey(): string | null {
+    return (this.ctx.lang === 'ja' ? this.data.nameJa : this.data.nameEn) ?? null
+  }
+
+  /** The configured English / Japanese display-name keys. */
+  nameKeys(): { en: string | null; ja: string | null } {
+    return { en: this.data.nameEn ?? null, ja: this.data.nameJa ?? null }
   }
 }

--- a/lib/components/SInputImage.vue
+++ b/lib/components/SInputImage.vue
@@ -63,12 +63,20 @@ function openFileSelect() {
 }
 
 function onFileSelect(e: Event) {
-  const file = ((e.target as HTMLInputElement).files ?? [])[0]
+  const input = e.target as HTMLInputElement
+  const file = (input.files ?? [])[0]
 
   emit('update:model-value', file ?? null)
   emit('change', file ?? null)
 
   file && props.validation?.$touch()
+
+  // Clear the native input after capturing the file, so re-selecting the *same*
+  // file fires `change` again (the browser suppresses it when the value is
+  // unchanged). Matters when a consumer rejects/undoes a pick (e.g. a failed
+  // upload) and the user re-picks the same image. The preview reads the model,
+  // not the input, so clearing it is safe.
+  input.value = ''
 }
 
 function onFileDelete() {

--- a/tests/blocks/lens/fields/AvatarField.spec.ts
+++ b/tests/blocks/lens/fields/AvatarField.spec.ts
@@ -142,8 +142,47 @@ describe('blocks/lens/fields/AvatarField', () => {
   })
 
   describe('formInputComponent', () => {
-    it('throws because avatars are display-only', () => {
-      expect(() => make().formInputComponent()).toThrow()
+    it('returns an avatar input component without throwing', () => {
+      expect(() => make().formInputComponent()).not.toThrow()
+      expect(make().formInputComponent()).toBeTruthy()
+    })
+  })
+
+  describe('write behavior', () => {
+    it('is not submittable — avatars persist out-of-band, not through the lens write', () => {
+      expect(make().isSubmittable()).toBe(false)
+    })
+
+    it('does not support the generic optimistic cell/field editors', () => {
+      expect(make().supportsOptimisticUpdate()).toBe(false)
+    })
+
+    it('uses null as the empty input value', () => {
+      expect(make().inputEmptyValue()).toBeNull()
+    })
+  })
+
+  describe('config', () => {
+    it('defaults accept to image/* and imageType to circle', () => {
+      expect(make().accept()).toBe('image/*')
+      expect(make().imageType()).toBe('circle')
+    })
+
+    it('honors a configured accept and imageType', () => {
+      const field = make({ accept: 'image/png', imageType: 'rectangle' })
+      expect(field.accept()).toBe('image/png')
+      expect(field.imageType()).toBe('rectangle')
+    })
+
+    it('exposes the configured display-name companion keys', () => {
+      const field = make({ nameEn: 'name_en', nameJa: 'name_ja' })
+      expect(field.nameKeys()).toEqual({ en: 'name_en', ja: 'name_ja' })
+      expect(field.nameKey()).toBe('name_en')
+    })
+
+    it('resolves the Japanese name key when the language is "ja"', () => {
+      const field = make({ nameEn: 'name_en', nameJa: 'name_ja' }, 'ja')
+      expect(field.nameKey()).toBe('name_ja')
     })
   })
 })


### PR DESCRIPTION
## Summary

Avatar fields in the Lens block were read-only. This makes them **editable inline, in the record sheet, and on the create form**, while keeping them fully customizable for any consuming admin.

Because an avatar's value is a raw `File` on edit but a URL on read, it is **persisted out-of-band** rather than through the Lens create/update write. The catalog delegates the actual upload to a consumer-provided handler and only reflects the resulting URL on the row.

## What's new

- **`AvatarField`** now has a real `formInputComponent` (an `SInputImage` wrapper, `LensAvatarInput`). It is `isSubmittable: false` and `supportsOptimisticUpdate: false` — its value never enters the Lens write payload.
- **Inline** — a dedicated `LensTableAvatarCell`:
  - a camera overlay on the image (on hover, when editable) opens the file picker → uploads → reflects the new URL on the row;
  - a pencil on the right edits the display-name companions (`nameEn`/`nameJa`) in a single multi-key `save`.
- **Sheet** — `LensSheetAvatarField` renders the avatar as its own editable picker row (uploads on change).
- **Create** — the avatar picker appears in the create form; the image is uploaded to the new record after it's created.
- **`LensCatalog` gains an `avatar-upload` prop** — the handler `(\{ id, record, field, file \}) => Promise<string | null>`, provided via a new `provideLensAvatarUpload` context. Without it, avatar fields stay read-only (the inline/sheet affordance and the create picker are hidden).
- **`edit.uploadAvatar(record, field, file)`** — uploads via the handler and reflects the returned URL on the live row. It's accounted for like an optimistic write — it locks the query controls while in flight, serializes uploads per record+field (last-issued wins), stays consistent with concurrent saves / deletes / detail-loads, and reconciles once it settles — so a concurrent change can't land stale rows over the patched URL.
- **`edit.refresh()`** — re-run the current query (best-effort resync after a create-time avatar upload).
- `AvatarFieldData` gains optional `accept`, `helpEn`/`helpJa`, `imageType` (defaults: `image/*`, circle).

## How a consumer wires it

```vue
<LensCatalog ... editable :avatar-upload="onAvatarUpload" />
```
```ts
const onAvatarUpload: LensAvatarUploadHandler = async ({ id, file }) => {
  const updated = await uploadAvatar(id, file) // app's own multipart endpoint
  return updated.avatarUrl
}
```
The backend marks the avatar field `editable()` so the affordances surface, but keeps the avatar out of its writable columns (the image is stored by the upload endpoint, not the Lens write).

## Tests

- `pnpm type`, `pnpm lint`, and the full `pnpm test` suite pass.
- `AvatarField.spec.ts` updated for the new editable behavior (form input, `isSubmittable`/`supportsOptimisticUpdate`, config getters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
