### PR TITLE
feat(lens): sort the avatar column by its name companion

### DIFF
--- a/lib/blocks/lens/fields/AvatarField.ts
+++ b/lib/blocks/lens/fields/AvatarField.ts
@@ -29,6 +29,13 @@ export class AvatarField extends Field<AvatarFieldData> {
     return {}
   }
 
+  // Sort by the display-name companion (resolved by the active language), since
+  // the field value itself is the image URL. With no companion configured there's
+  // nothing meaningful to sort on, so the field stays unsortable (no sort menu).
+  protected override sortKey(): string | null {
+    return this.nameKey()
+  }
+
   override dataListItemComponent(): any {
     return this.defineDataListItemComponent((value) => {
       // Render nothing for a missing image so SDataListItem shows its empty

--- a/lib/blocks/lens/fields/Field.ts
+++ b/lib/blocks/lens/fields/Field.ts
@@ -82,11 +82,24 @@ export abstract class Field<T extends FieldData> {
   }
 
   /**
+   * The field key sorts are emitted under — the catalog sends it to the backend,
+   * which orders by that field's column. Defaults to the field's own key; a
+   * subtype whose own value isn't meaningful to sort on can redirect it (e.g. an
+   * avatar sorts by its display-name companion). A `null` makes the field
+   * unsortable, so no sort menu is shown.
+   */
+  protected sortKey(): string | null {
+    return this.data.key
+  }
+
+  /**
    * Renders the table sort menu for the field. The sort maybe null when
-   * the field `sortable` option is false.
+   * the field `sortable` option is false (or it has no sortable key).
    */
   tableSortMenu(onSortUpdated: (sort: LensQuerySort) => void): DropdownSection | null {
-    if (!this.data.sortable) {
+    const sortKey = this.sortKey()
+
+    if (!this.data.sortable || sortKey === null) {
       return null
     }
 
@@ -100,8 +113,8 @@ export abstract class Field<T extends FieldData> {
     return {
       type: 'menu',
       options: [
-        { label: t.sort_asc, onClick: () => onSortUpdated?.([this.data.key, 'asc']) },
-        { label: t.sort_desc, onClick: () => onSortUpdated?.([this.data.key, 'desc']) }
+        { label: t.sort_asc, onClick: () => onSortUpdated?.([sortKey, 'asc']) },
+        { label: t.sort_desc, onClick: () => onSortUpdated?.([sortKey, 'desc']) }
       ]
     }
   }

--- a/tests/blocks/lens/fields/AvatarField.spec.ts
+++ b/tests/blocks/lens/fields/AvatarField.spec.ts
@@ -117,8 +117,30 @@ describe('blocks/lens/fields/AvatarField', () => {
       expect(make().tableSortMenu(() => {})).toBeNull()
     })
 
-    it('exposes a sort menu when the field opts in via sortable', () => {
-      expect(make({ sortable: true }).tableSortMenu(() => {})).not.toBeNull()
+    it('has no sort menu when sortable but no name companion is configured', () => {
+      // The avatar value is the image URL; with no name companion there is
+      // nothing meaningful to sort on.
+      expect(make({ sortable: true }).tableSortMenu(() => {})).toBeNull()
+    })
+
+    it('sorts by the name companion (active language) when sortable', () => {
+      const captured: any[] = []
+      const menu = make({ sortable: true, nameEn: 'name_en', nameJa: 'name_ja' })
+        .tableSortMenu((s) => captured.push(s)) as any
+
+      expect(menu).not.toBeNull()
+      menu.options[0].onClick()
+      menu.options[1].onClick()
+      expect(captured).toEqual([['name_en', 'asc'], ['name_en', 'desc']])
+    })
+
+    it('sorts by the Japanese companion when the language is "ja"', () => {
+      const captured: any[] = []
+      const menu = make({ sortable: true, nameEn: 'name_en', nameJa: 'name_ja' }, 'ja')
+        .tableSortMenu((s) => captured.push(s)) as any
+
+      menu.options[0].onClick()
+      expect(captured).toEqual([['name_ja', 'asc']])
     })
   })
 


### PR DESCRIPTION
## What

An `avatar` field can now be sorted — by its display-name companion (`nameEn`/`nameJa`, resolved by the active language) rather than the image URL, which isn't meaningful to order on.

## How

- Added a protected `Field.sortKey(): string | null` seam (default: the field's own key). `tableSortMenu` now emits `[sortKey, dir]` and gates on `sortable && sortKey !== null`.
- `AvatarField` overrides `sortKey()` → `nameKey()` (the active-language companion, or `null`). So a sortable avatar **with** a name companion sorts by that column; **without** one it shows no sort menu (nothing meaningful to sort on); a non-sortable avatar shows none, as before.
- Non-avatar fields are unchanged — their `sortKey()` is the field key (never `null`), so behavior and the emitted tuple are identical.
- **No backend change:** anima's `SortBuilder` already orders by any known field key's `column`, so the emitted companion key sorts by the name column out of the box.

## Note (acceptable UX wrinkle)

Because the emitted sort is keyed by the companion field, the applied-sort chip reflects the *name* field's label (e.g. "Name: EN") rather than "Avatar", and the table's sort arrow tracks the companion column — which won't be visible if that column is hidden via `showOnIndex(false)`. The rows still sort by name correctly.

## Testing

`pnpm check` green — type, lint, **1212 tests**. Updated `AvatarField.spec` to cover: no menu when sortable without a companion, and sorting by the active-language companion (`name_en` / `name_ja`).

Reviewed via a 2-lens adversarial pass (regression-across-fields / correctness + e2e) → ship; the only non-cosmetic note was a pre-existing latent issue in `LensCatalogStateSort` unrelated to this change, flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)