### PR TITLE
fix(lens): guard the sort chip against an unknown field key

### DIFF
--- a/lib/blocks/lens/components/LensCatalogStateSort.vue
+++ b/lib/blocks/lens/components/LensCatalogStateSort.vue
@@ -39,9 +39,17 @@ const orderTextDict = {
 }
 
 function getFieldName(sort: LensQuerySort): string {
-  return lang === 'ja'
-    ? props.fields[sort[0]].labelJa
-    : props.fields[sort[0]].labelEn
+  // A still-applied sort can reference a field that's not in the field set — a
+  // stale saved/URL sort, or a sort emitted under a companion key (e.g. an
+  // avatar sorting by its display-name field). Fall back to the raw key rather
+  // than crash, mirroring how the filter chip handles an unknown field.
+  const field = props.fields[sort[0]]
+
+  if (!field) {
+    return sort[0]
+  }
+
+  return lang === 'ja' ? field.labelJa : field.labelEn
 }
 
 function getOrderText(sort: LensQuerySort): string {


### PR DESCRIPTION
## Problem

`LensCatalogStateSort.getFieldName` dereferenced `props.fields[sort[0]].labelEn/labelJa` with no existence check. A still-applied sort can reference a key that isn't in the current field set — a stale or hand-edited `?sort=` URL param (the URL-sync guard validates only the tuple *shape*, not that the key exists), or a sort emitted under a companion key — and the chip then crashes dereferencing `undefined`.

## Fix

Fall back to the raw sort key when the field isn't in `props.fields`, mirroring how the filter chip (`LensCatalogStateFilterCondition`) already handles an unknown field.

## Scope

Pre-existing and independent of the avatar-sort change (#753) — surfaced while reviewing it. Note: in a correctly configured avatar sort the key is always present (`result.fields` carries every entity field definition regardless of `select`/`showOnIndex`), so this is hardening against stale/misconfigured sorts rather than a bug in that feature.

## Testing

`pnpm check` green — type, lint, 1210 tests. (These catalog state chips have no component spec harness — `~icons` virtual imports aren't resolved in the test env — so this follows the existing coverage, matching the already-guarded filter chip.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)