### PR TITLE
fix(lens): inline-editor keyboard handling — Enter/Cmd+Enter saves, Esc cancels

### DIFF
--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -5,6 +5,7 @@ import SButton from '../../../components/SButton.vue'
 import SDataListItem from '../../../components/SDataListItem.vue'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
+import { isTextLikeInput } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { type Field } from '../fields/Field'
@@ -135,6 +136,16 @@ async function apply() {
   })
   editing.value = false
 }
+
+function onEditorKeydown(event: KeyboardEvent) {
+  // Enter saves from a plain text-like input, matching the table editors — a
+  // textarea or a control that handles Enter itself keeps it. Escape is left to
+  // the surrounding sheet, which closes on it.
+  if (event.key === 'Enter' && isTextLikeInput(event.target)) {
+    event.preventDefault()
+    apply()
+  }
+}
 </script>
 
 <template>
@@ -156,7 +167,7 @@ async function apply() {
       </button>
     </div>
 
-    <div v-else class="form">
+    <div v-else class="form" @keydown="onEditorKeydown">
       <component :is="inputComponent" v-model="model" :validation="validation.input" />
       <div class="actions">
         <SButton size="mini" :label="t.cancel" @click="cancel" />

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -138,8 +138,20 @@ async function apply() {
 }
 
 function onEditorKeydown(event: KeyboardEvent) {
-  // Enter saves, matching the table editors. Escape is left to the surrounding
-  // sheet, which closes on it.
+  // Escape cancels this field's edit, and is stopped from bubbling to the sheet
+  // — which otherwise closes on Escape (via SSheet's window-level handler).
+  // While an IME is composing, Escape cancels the composition instead, so keep
+  // the editor open and only shield the sheet.
+  if (event.key === 'Escape') {
+    event.stopPropagation()
+    if (event.isComposing) {
+      return
+    }
+    event.preventDefault()
+    cancel()
+    return
+  }
+  // Enter saves, matching the table editors.
   if (isEditorSubmitKeydown(event)) {
     event.preventDefault()
     apply()

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import IconPencilSimple from '~icons/ph/pencil-simple'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import SButton from '../../../components/SButton.vue'
 import SDataListItem from '../../../components/SDataListItem.vue'
 import { useTrans } from '../../../composables/Lang'
@@ -91,11 +91,22 @@ const { validation, validate, reset } = useValidation(
   () => ({ input: props.field.generateValidationRules() })
 )
 
+const formEl = ref<HTMLElement | null>(null)
+
 function start() {
   const raw = props.record[props.fieldKey]
   model.value = props.field.payloadToInput(raw ?? props.field.inputEmptyValue())
   reset()
   editing.value = true
+  // Focus the input on open (matching the inline table editor): better UX, and
+  // it routes the editor's keydowns — notably Escape — through the form handler
+  // so Escape cancels the edit rather than closing the sheet.
+  nextTick(() => {
+    const el = formEl.value?.querySelector(
+      'input, textarea, [contenteditable], [tabindex]'
+    ) as HTMLElement | null
+    el?.focus()
+  })
 }
 
 function cancel() {
@@ -177,7 +188,7 @@ function onEditorKeydown(event: KeyboardEvent) {
       </button>
     </div>
 
-    <div v-else class="form" @keydown="onEditorKeydown">
+    <div v-else ref="formEl" class="form" @keydown="onEditorKeydown">
       <component :is="inputComponent" v-model="model" :validation="validation.input" />
       <div class="actions">
         <SButton size="mini" :label="t.cancel" @click="cancel" />

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -5,7 +5,7 @@ import SButton from '../../../components/SButton.vue'
 import SDataListItem from '../../../components/SDataListItem.vue'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
-import { isEditorSubmitKeydown } from '../../../support/Dom'
+import { isEditorCancelKeydown, isEditorSubmitKeydown } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { type Field } from '../fields/Field'
@@ -144,11 +144,10 @@ function onEditorKeydown(event: KeyboardEvent) {
   // the editor open and only shield the sheet.
   if (event.key === 'Escape') {
     event.stopPropagation()
-    if (event.isComposing) {
-      return
+    if (isEditorCancelKeydown(event)) {
+      event.preventDefault()
+      cancel()
     }
-    event.preventDefault()
-    cancel()
     return
   }
   // Enter saves, matching the table editors.

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -5,7 +5,7 @@ import SButton from '../../../components/SButton.vue'
 import SDataListItem from '../../../components/SDataListItem.vue'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
-import { isEditorCancelKeydown, isEditorSubmitKeydown } from '../../../support/Dom'
+import { dispatchEditorKeydown, focusFirstEditable } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { type Field } from '../fields/Field'
@@ -101,12 +101,7 @@ function start() {
   // Focus the input on open (matching the inline table editor): better UX, and
   // it routes the editor's keydowns — notably Escape — through the form handler
   // so Escape cancels the edit rather than closing the sheet.
-  nextTick(() => {
-    const el = formEl.value?.querySelector(
-      'input, textarea, [contenteditable], [tabindex]'
-    ) as HTMLElement | null
-    el?.focus()
-  })
+  nextTick(() => focusFirstEditable(formEl.value))
 }
 
 function cancel() {
@@ -149,23 +144,9 @@ async function apply() {
 }
 
 function onEditorKeydown(event: KeyboardEvent) {
-  // Escape cancels this field's edit, and is stopped from bubbling to the sheet
-  // — which otherwise closes on Escape (via SSheet's window-level handler).
-  // While an IME is composing, Escape cancels the composition instead, so keep
-  // the editor open and only shield the sheet.
-  if (event.key === 'Escape') {
-    event.stopPropagation()
-    if (isEditorCancelKeydown(event)) {
-      event.preventDefault()
-      cancel()
-    }
-    return
-  }
-  // Enter saves, matching the table editors.
-  if (isEditorSubmitKeydown(event)) {
-    event.preventDefault()
-    apply()
-  }
+  // `shield` keeps Escape from reaching the surrounding sheet, which otherwise
+  // closes on it (via SSheet's window-level handler).
+  dispatchEditorKeydown(event, { cancel, submit: apply, shield: true })
 }
 </script>
 

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -5,7 +5,7 @@ import SButton from '../../../components/SButton.vue'
 import SDataListItem from '../../../components/SDataListItem.vue'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
-import { isTextLikeInput } from '../../../support/Dom'
+import { isEditorSubmitKeydown } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { type Field } from '../fields/Field'
@@ -138,10 +138,9 @@ async function apply() {
 }
 
 function onEditorKeydown(event: KeyboardEvent) {
-  // Enter saves from a plain text-like input, matching the table editors — a
-  // textarea or a control that handles Enter itself keeps it. Escape is left to
-  // the surrounding sheet, which closes on it.
-  if (event.key === 'Enter' && isTextLikeInput(event.target)) {
+  // Enter saves, matching the table editors. Escape is left to the surrounding
+  // sheet, which closes on it.
+  if (isEditorSubmitKeydown(event)) {
     event.preventDefault()
     apply()
   }

--- a/lib/blocks/lens/components/LensTableAvatarCell.vue
+++ b/lib/blocks/lens/components/LensTableAvatarCell.vue
@@ -10,6 +10,7 @@ import { useManualDropdownPosition } from '../../../composables/Dropdown'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
 import { useSnackbars } from '../../../stores/Snackbars'
+import { isTextLikeInput } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { useLensInlineEdit } from '../composables/LensInlineEdit'
@@ -249,6 +250,14 @@ function onEditorKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape') {
     event.preventDefault()
     cancelNames()
+    return
+  }
+  // Enter saves only from a plain text-like input (the name fields), matching the
+  // generic editable cell — a textarea or a control that handles Enter itself
+  // keeps it.
+  if (event.key === 'Enter' && isTextLikeInput(event.target)) {
+    event.preventDefault()
+    applyNames()
   }
 }
 </script>

--- a/lib/blocks/lens/components/LensTableAvatarCell.vue
+++ b/lib/blocks/lens/components/LensTableAvatarCell.vue
@@ -10,7 +10,7 @@ import { useManualDropdownPosition } from '../../../composables/Dropdown'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
 import { useSnackbars } from '../../../stores/Snackbars'
-import { isEditorCancelKeydown, isEditorSubmitKeydown } from '../../../support/Dom'
+import { dispatchEditorKeydown, focusFirstEditable } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { useLensInlineEdit } from '../composables/LensInlineEdit'
@@ -199,8 +199,7 @@ function startNames() {
   inline?.start(myKey.value)
   nextTick(() => {
     update()
-    const el = editorEl.value?.querySelector('input, textarea, [contenteditable], [tabindex]') as HTMLElement | null
-    el?.focus()
+    focusFirstEditable(editorEl.value)
   })
 }
 
@@ -247,15 +246,7 @@ async function applyNames() {
 }
 
 function onEditorKeydown(event: KeyboardEvent) {
-  if (isEditorCancelKeydown(event)) {
-    event.preventDefault()
-    cancelNames()
-    return
-  }
-  if (isEditorSubmitKeydown(event)) {
-    event.preventDefault()
-    applyNames()
-  }
+  dispatchEditorKeydown(event, { cancel: cancelNames, submit: applyNames })
 }
 </script>
 

--- a/lib/blocks/lens/components/LensTableAvatarCell.vue
+++ b/lib/blocks/lens/components/LensTableAvatarCell.vue
@@ -10,7 +10,7 @@ import { useManualDropdownPosition } from '../../../composables/Dropdown'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
 import { useSnackbars } from '../../../stores/Snackbars'
-import { isTextLikeInput } from '../../../support/Dom'
+import { isEditorSubmitKeydown } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { useLensInlineEdit } from '../composables/LensInlineEdit'
@@ -252,10 +252,7 @@ function onEditorKeydown(event: KeyboardEvent) {
     cancelNames()
     return
   }
-  // Enter saves only from a plain text-like input (the name fields), matching the
-  // generic editable cell — a textarea or a control that handles Enter itself
-  // keeps it.
-  if (event.key === 'Enter' && isTextLikeInput(event.target)) {
+  if (isEditorSubmitKeydown(event)) {
     event.preventDefault()
     applyNames()
   }

--- a/lib/blocks/lens/components/LensTableAvatarCell.vue
+++ b/lib/blocks/lens/components/LensTableAvatarCell.vue
@@ -10,7 +10,7 @@ import { useManualDropdownPosition } from '../../../composables/Dropdown'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
 import { useSnackbars } from '../../../stores/Snackbars'
-import { isEditorSubmitKeydown } from '../../../support/Dom'
+import { isEditorCancelKeydown, isEditorSubmitKeydown } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { useLensInlineEdit } from '../composables/LensInlineEdit'
@@ -247,7 +247,7 @@ async function applyNames() {
 }
 
 function onEditorKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape') {
+  if (isEditorCancelKeydown(event)) {
     event.preventDefault()
     cancelNames()
     return

--- a/lib/blocks/lens/components/LensTableEditableCell.vue
+++ b/lib/blocks/lens/components/LensTableEditableCell.vue
@@ -10,7 +10,7 @@ import { useManualDropdownPosition } from '../../../composables/Dropdown'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
 import { day } from '../../../support/Day'
-import { isTextLikeInput } from '../../../support/Dom'
+import { isEditorSubmitKeydown } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { useLensInlineEdit } from '../composables/LensInlineEdit'
@@ -224,11 +224,7 @@ function onEditorKeydown(event: KeyboardEvent) {
     cancel()
     return
   }
-  // Enter saves only from a plain text-like input. A textarea inserts a
-  // newline, and controls that handle Enter themselves (e.g. a dropdown that
-  // opens its menu on Enter) must keep it — otherwise a keyboard user submits
-  // the old value instead of choosing an option.
-  if (event.key === 'Enter' && isTextLikeInput(event.target)) {
+  if (isEditorSubmitKeydown(event)) {
     event.preventDefault()
     apply()
   }

--- a/lib/blocks/lens/components/LensTableEditableCell.vue
+++ b/lib/blocks/lens/components/LensTableEditableCell.vue
@@ -10,6 +10,7 @@ import { useManualDropdownPosition } from '../../../composables/Dropdown'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
 import { day } from '../../../support/Day'
+import { isTextLikeInput } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { useLensInlineEdit } from '../composables/LensInlineEdit'
@@ -231,15 +232,6 @@ function onEditorKeydown(event: KeyboardEvent) {
     event.preventDefault()
     apply()
   }
-}
-
-function isTextLikeInput(target: EventTarget | null): boolean {
-  const el = target as HTMLElement | null
-  if (!el || el.tagName !== 'INPUT') {
-    return false
-  }
-  const type = (el as HTMLInputElement).type
-  return ['text', 'search', 'url', 'email', 'tel', 'password', 'number'].includes(type)
 }
 </script>
 

--- a/lib/blocks/lens/components/LensTableEditableCell.vue
+++ b/lib/blocks/lens/components/LensTableEditableCell.vue
@@ -10,7 +10,7 @@ import { useManualDropdownPosition } from '../../../composables/Dropdown'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
 import { day } from '../../../support/Day'
-import { isEditorCancelKeydown, isEditorSubmitKeydown } from '../../../support/Dom'
+import { dispatchEditorKeydown, focusFirstEditable } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { useLensInlineEdit } from '../composables/LensInlineEdit'
@@ -160,10 +160,7 @@ function start() {
   inline?.start(myKey.value)
   nextTick(() => {
     update()
-    const el = editorEl.value?.querySelector(
-      'input, textarea, [contenteditable], [tabindex]'
-    ) as HTMLElement | null
-    el?.focus()
+    focusFirstEditable(editorEl.value)
   })
 }
 
@@ -219,15 +216,7 @@ async function apply() {
 }
 
 function onEditorKeydown(event: KeyboardEvent) {
-  if (isEditorCancelKeydown(event)) {
-    event.preventDefault()
-    cancel()
-    return
-  }
-  if (isEditorSubmitKeydown(event)) {
-    event.preventDefault()
-    apply()
-  }
+  dispatchEditorKeydown(event, { cancel, submit: apply })
 }
 </script>
 

--- a/lib/blocks/lens/components/LensTableEditableCell.vue
+++ b/lib/blocks/lens/components/LensTableEditableCell.vue
@@ -10,7 +10,7 @@ import { useManualDropdownPosition } from '../../../composables/Dropdown'
 import { useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
 import { day } from '../../../support/Day'
-import { isEditorSubmitKeydown } from '../../../support/Dom'
+import { isEditorCancelKeydown, isEditorSubmitKeydown } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
 import { useLensInlineEdit } from '../composables/LensInlineEdit'
@@ -219,7 +219,7 @@ async function apply() {
 }
 
 function onEditorKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape') {
+  if (isEditorCancelKeydown(event)) {
     event.preventDefault()
     cancel()
     return

--- a/lib/blocks/lens/fields/Field.ts
+++ b/lib/blocks/lens/fields/Field.ts
@@ -273,6 +273,15 @@ export abstract class Field<T extends FieldData> {
 
   /**
    * Returns the form input component for the field.
+   *
+   * Several field types currently `throw new Error('Not implemented.')` here —
+   * they're shown read-only and have no inline/sheet editor yet. When making one
+   * editable, mind the inline editor's keyboard handling: if the input is a
+   * composite control with its own nested text input (e.g. a dropdown search
+   * filter), that nested input must keep Enter/Escape from bubbling to the
+   * editor (see `SDropdownSectionFilter` and `support/Dom`'s
+   * `dispatchEditorKeydown`), or typing a value and pressing Enter would
+   * submit/cancel the whole editor.
    */
   abstract formInputComponent(): any
 

--- a/lib/components/SDropdownSectionFilter.vue
+++ b/lib/components/SDropdownSectionFilter.vue
@@ -70,7 +70,9 @@ function onClick(option: DropdownSectionFilterOption, value: any) {
 <template>
   <div class="SDropdownSectionFilter">
     <div v-if="search" class="search">
-      <input ref="input" v-model="query" class="input" :placeholder="t.i_ph">
+      <!-- Keep Enter inside the filter: it drives the dropdown, and must not
+           bubble to an enclosing editor/form as a submit. -->
+      <input ref="input" v-model="query" class="input" :placeholder="t.i_ph" @keydown.enter.stop>
     </div>
 
     <ul v-if="filteredOptions.length" class="list">

--- a/lib/support/Dom.ts
+++ b/lib/support/Dom.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether the event target is a plain text-like `<input>` — the controls where
+ * pressing Enter should submit an inline editor. Excludes textareas (Enter
+ * inserts a newline) and richer controls that handle Enter themselves (e.g. a
+ * dropdown that opens its menu on Enter), so a keyboard user isn't forced to
+ * submit instead of operating the control.
+ */
+export function isTextLikeInput(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null
+
+  if (!el || el.tagName !== 'INPUT') {
+    return false
+  }
+
+  const type = (el as HTMLInputElement).type
+
+  return ['text', 'search', 'url', 'email', 'tel', 'password', 'number'].includes(type)
+}

--- a/lib/support/Dom.ts
+++ b/lib/support/Dom.ts
@@ -26,9 +26,16 @@ export function isTextLikeInput(target: EventTarget | null): boolean {
  *
  * Shift+Enter is left for newlines, and Alt/Option+Enter has no consistent
  * submit meaning (Excel uses it for an in-cell newline), so neither submits.
+ * The Enter that commits an IME composition (e.g. CJK input) never submits.
  */
 export function isEditorSubmitKeydown(event: KeyboardEvent): boolean {
   if (event.key !== 'Enter') {
+    return false
+  }
+
+  // Ignore the Enter that commits an IME composition (e.g. CJK input): it
+  // confirms the candidate rather than submitting.
+  if (event.isComposing) {
     return false
   }
 

--- a/lib/support/Dom.ts
+++ b/lib/support/Dom.ts
@@ -16,3 +16,21 @@ export function isTextLikeInput(target: EventTarget | null): boolean {
 
   return ['text', 'search', 'url', 'email', 'tel', 'password', 'number'].includes(type)
 }
+
+/**
+ * Whether an Enter keydown should submit an inline editor. Ctrl/Cmd+Enter
+ * submits from any control — it's the near-universal "submit" gesture (GitHub,
+ * Gmail, Slack, …) and never clashes with a textarea's newline or a control that
+ * handles bare Enter itself (e.g. a dropdown opening its menu). Bare Enter
+ * submits only from a plain text-like input (see {@link isTextLikeInput}).
+ *
+ * Shift+Enter is left for newlines, and Alt/Option+Enter has no consistent
+ * submit meaning (Excel uses it for an in-cell newline), so neither submits.
+ */
+export function isEditorSubmitKeydown(event: KeyboardEvent): boolean {
+  if (event.key !== 'Enter') {
+    return false
+  }
+
+  return event.ctrlKey || event.metaKey || isTextLikeInput(event.target)
+}

--- a/lib/support/Dom.ts
+++ b/lib/support/Dom.ts
@@ -91,9 +91,19 @@ export function dispatchEditorKeydown(
 
 /**
  * Focus the first focusable editor control (an input, textarea, contenteditable,
- * or any `[tabindex]`) inside the container — used to focus an inline editor
- * when it opens.
+ * or any `[tabindex]`) inside the container — used to focus an inline editor when
+ * it opens.
+ *
+ * Candidates inside `skip` (default `.actions`, the editor's action row) are
+ * ignored, so focus never lands on a Cancel/Save button — those are `[tabindex]`
+ * elements too — when the field input has no focusable control of its own (e.g.
+ * a radio/checkbox group). In that case nothing is focused. Pass `skip: ''` to
+ * disable.
  */
-export function focusFirstEditable(container: HTMLElement | null): void {
-  container?.querySelector<HTMLElement>('input, textarea, [contenteditable], [tabindex]')?.focus()
+export function focusFirstEditable(container: HTMLElement | null, skip = '.actions'): void {
+  const candidates = Array.from(
+    container?.querySelectorAll<HTMLElement>('input, textarea, [contenteditable], [tabindex]') ?? []
+  )
+
+  candidates.find((el) => !skip || !el.closest(skip))?.focus()
 }

--- a/lib/support/Dom.ts
+++ b/lib/support/Dom.ts
@@ -41,3 +41,12 @@ export function isEditorSubmitKeydown(event: KeyboardEvent): boolean {
 
   return event.ctrlKey || event.metaKey || isTextLikeInput(event.target)
 }
+
+/**
+ * Whether a keydown should cancel an inline editor: Escape, except the Escape
+ * that cancels an in-progress IME composition (which reverts the candidate and
+ * should leave the editor open).
+ */
+export function isEditorCancelKeydown(event: KeyboardEvent): boolean {
+  return event.key === 'Escape' && !event.isComposing
+}

--- a/lib/support/Dom.ts
+++ b/lib/support/Dom.ts
@@ -50,3 +50,50 @@ export function isEditorSubmitKeydown(event: KeyboardEvent): boolean {
 export function isEditorCancelKeydown(event: KeyboardEvent): boolean {
   return event.key === 'Escape' && !event.isComposing
 }
+
+/**
+ * Dispatch a keydown for an inline editor (opened from a cell or sheet field):
+ * cancel on Escape, submit on Enter — using the IME- and modifier-aware rules
+ * in {@link isEditorCancelKeydown} / {@link isEditorSubmitKeydown}.
+ *
+ * `shield` is for an editor nested in a surface that itself closes on Escape
+ * (e.g. a sheet): Escape is always kept from propagating to that surface — even
+ * the Escape that only cancels an IME composition (where the edit stays open) —
+ * so the surface can't close underneath the editor.
+ *
+ * NOTE for future inline/sheet-editable fields: several field types currently
+ * throw on `formInputComponent()` (not yet editable). When making one editable,
+ * if its input is a composite control with its own nested text input (e.g. a
+ * dropdown's search filter), that nested input must keep Enter/Escape from
+ * bubbling to this handler — see `SDropdownSectionFilter` — otherwise typing a
+ * value and pressing Enter would submit/cancel the whole editor.
+ */
+export function dispatchEditorKeydown(
+  event: KeyboardEvent,
+  handlers: { cancel: () => void; submit: () => void; shield?: boolean }
+): void {
+  if (event.key === 'Escape') {
+    if (handlers.shield) {
+      event.stopPropagation()
+    }
+    if (isEditorCancelKeydown(event)) {
+      event.preventDefault()
+      handlers.cancel()
+    }
+    return
+  }
+
+  if (isEditorSubmitKeydown(event)) {
+    event.preventDefault()
+    handlers.submit()
+  }
+}
+
+/**
+ * Focus the first focusable editor control (an input, textarea, contenteditable,
+ * or any `[tabindex]`) inside the container — used to focus an inline editor
+ * when it opens.
+ */
+export function focusFirstEditable(container: HTMLElement | null): void {
+  container?.querySelector<HTMLElement>('input, textarea, [contenteditable], [tabindex]')?.focus()
+}

--- a/tests/support/Dom.spec.ts
+++ b/tests/support/Dom.spec.ts
@@ -1,0 +1,32 @@
+import * as Dom from 'sefirot/support/Dom'
+
+function input(type: string): HTMLInputElement {
+  const el = document.createElement('input')
+  el.type = type
+  return el
+}
+
+describe('support/Dom', () => {
+  describe('isTextLikeInput', () => {
+    it('returns true for plain text-like input types', () => {
+      for (const type of ['text', 'search', 'url', 'email', 'tel', 'password', 'number']) {
+        expect(Dom.isTextLikeInput(input(type))).toBe(true)
+      }
+    })
+
+    it('returns false for non-text input types', () => {
+      for (const type of ['checkbox', 'radio', 'file', 'range', 'color', 'date']) {
+        expect(Dom.isTextLikeInput(input(type))).toBe(false)
+      }
+    })
+
+    it('returns false for a textarea (Enter inserts a newline)', () => {
+      expect(Dom.isTextLikeInput(document.createElement('textarea'))).toBe(false)
+    })
+
+    it('returns false for non-input elements and null', () => {
+      expect(Dom.isTextLikeInput(document.createElement('div'))).toBe(false)
+      expect(Dom.isTextLikeInput(null)).toBe(false)
+    })
+  })
+})

--- a/tests/support/Dom.spec.ts
+++ b/tests/support/Dom.spec.ts
@@ -70,4 +70,18 @@ describe('support/Dom', () => {
       expect(Dom.isEditorSubmitKeydown(keydown(input('text'), { key: 'Tab' } as Partial<KeyboardEvent>))).toBe(false)
     })
   })
+
+  describe('isEditorCancelKeydown', () => {
+    it('cancels on Escape', () => {
+      expect(Dom.isEditorCancelKeydown(keydown(input('text'), { key: 'Escape' } as Partial<KeyboardEvent>))).toBe(true)
+    })
+
+    it('does not cancel while an IME is composing (Escape reverts the candidate)', () => {
+      expect(Dom.isEditorCancelKeydown(keydown(input('text'), { key: 'Escape', isComposing: true } as Partial<KeyboardEvent>))).toBe(false)
+    })
+
+    it('does not cancel on other keys', () => {
+      expect(Dom.isEditorCancelKeydown(keydown(input('text'), { key: 'Enter' }))).toBe(false)
+    })
+  })
 })

--- a/tests/support/Dom.spec.ts
+++ b/tests/support/Dom.spec.ts
@@ -10,7 +10,7 @@ function keydown(
   target: EventTarget | null,
   init: Partial<KeyboardEvent> = {}
 ): KeyboardEvent {
-  return { key: 'Enter', ctrlKey: false, metaKey: false, altKey: false, shiftKey: false, target, ...init } as KeyboardEvent
+  return { key: 'Enter', ctrlKey: false, metaKey: false, altKey: false, shiftKey: false, isComposing: false, target, ...init } as KeyboardEvent
 }
 
 describe('support/Dom', () => {
@@ -58,6 +58,11 @@ describe('support/Dom', () => {
       const textarea = document.createElement('textarea')
       expect(Dom.isEditorSubmitKeydown(keydown(textarea, { shiftKey: true }))).toBe(false)
       expect(Dom.isEditorSubmitKeydown(keydown(textarea, { altKey: true }))).toBe(false)
+    })
+
+    it('does not submit while an IME is composing (the committing Enter), even with a modifier', () => {
+      expect(Dom.isEditorSubmitKeydown(keydown(input('text'), { isComposing: true }))).toBe(false)
+      expect(Dom.isEditorSubmitKeydown(keydown(input('text'), { isComposing: true, metaKey: true }))).toBe(false)
     })
 
     it('does not submit on non-Enter keys', () => {

--- a/tests/support/Dom.spec.ts
+++ b/tests/support/Dom.spec.ts
@@ -84,4 +84,67 @@ describe('support/Dom', () => {
       expect(Dom.isEditorCancelKeydown(keydown(input('text'), { key: 'Enter' }))).toBe(false)
     })
   })
+
+  describe('dispatchEditorKeydown', () => {
+    function dispatch(init: Partial<KeyboardEvent> & { shield?: boolean } = {}) {
+      const { shield, ...eventInit } = init
+      const calls = { cancel: 0, submit: 0, preventDefault: 0, stopPropagation: 0 }
+      const event = {
+        ...keydown(input('text'), eventInit),
+        preventDefault: () => { calls.preventDefault++ },
+        stopPropagation: () => { calls.stopPropagation++ }
+      } as KeyboardEvent
+      Dom.dispatchEditorKeydown(event, {
+        cancel: () => { calls.cancel++ },
+        submit: () => { calls.submit++ },
+        shield
+      })
+      return calls
+    }
+
+    it('submits on Enter from a text input', () => {
+      expect(dispatch({ key: 'Enter' })).toMatchObject({ submit: 1, cancel: 0, preventDefault: 1 })
+    })
+
+    it('cancels on Escape', () => {
+      expect(dispatch({ key: 'Escape' } as Partial<KeyboardEvent>)).toMatchObject({ cancel: 1, submit: 0, preventDefault: 1 })
+    })
+
+    it('does not cancel on Escape while composing, and does not shield by default', () => {
+      expect(dispatch({ key: 'Escape', isComposing: true } as Partial<KeyboardEvent>))
+        .toMatchObject({ cancel: 0, preventDefault: 0, stopPropagation: 0 })
+    })
+
+    it('shields Escape from the surrounding surface, cancelling when not composing', () => {
+      expect(dispatch({ key: 'Escape', shield: true } as Partial<KeyboardEvent> & { shield?: boolean }))
+        .toMatchObject({ stopPropagation: 1, cancel: 1, preventDefault: 1 })
+    })
+
+    it('shields the composing Escape too, without cancelling the edit', () => {
+      expect(dispatch({ key: 'Escape', isComposing: true, shield: true } as Partial<KeyboardEvent> & { shield?: boolean }))
+        .toMatchObject({ stopPropagation: 1, cancel: 0, preventDefault: 0 })
+    })
+
+    it('ignores other keys', () => {
+      expect(dispatch({ key: 'a' } as Partial<KeyboardEvent>)).toMatchObject({ cancel: 0, submit: 0 })
+    })
+  })
+
+  describe('focusFirstEditable', () => {
+    it('focuses the first focusable control in the container', () => {
+      const container = document.createElement('div')
+      const el = document.createElement('input')
+      container.append(el)
+      document.body.append(container)
+
+      Dom.focusFirstEditable(container)
+      expect(document.activeElement).toBe(el)
+
+      container.remove()
+    })
+
+    it('does nothing for a null container', () => {
+      expect(() => Dom.focusFirstEditable(null)).not.toThrow()
+    })
+  })
 })

--- a/tests/support/Dom.spec.ts
+++ b/tests/support/Dom.spec.ts
@@ -146,5 +146,38 @@ describe('support/Dom', () => {
     it('does nothing for a null container', () => {
       expect(() => Dom.focusFirstEditable(null)).not.toThrow()
     })
+
+    it('skips candidates inside the default `.actions` row (e.g. Cancel/Save)', () => {
+      const container = document.createElement('div')
+      const action = document.createElement('div')
+      action.className = 'actions'
+      const button = document.createElement('div')
+      button.setAttribute('tabindex', '0')
+      action.append(button)
+      container.append(action)
+      document.body.append(container)
+
+      Dom.focusFirstEditable(container)
+      expect(document.activeElement).not.toBe(button)
+
+      container.remove()
+    })
+
+    it('focuses the field input before the skipped action row', () => {
+      const container = document.createElement('div')
+      const el = document.createElement('input')
+      const action = document.createElement('div')
+      action.className = 'actions'
+      const button = document.createElement('div')
+      button.setAttribute('tabindex', '0')
+      action.append(button)
+      container.append(el, action)
+      document.body.append(container)
+
+      Dom.focusFirstEditable(container)
+      expect(document.activeElement).toBe(el)
+
+      container.remove()
+    })
   })
 })

--- a/tests/support/Dom.spec.ts
+++ b/tests/support/Dom.spec.ts
@@ -6,6 +6,13 @@ function input(type: string): HTMLInputElement {
   return el
 }
 
+function keydown(
+  target: EventTarget | null,
+  init: Partial<KeyboardEvent> = {}
+): KeyboardEvent {
+  return { key: 'Enter', ctrlKey: false, metaKey: false, altKey: false, shiftKey: false, target, ...init } as KeyboardEvent
+}
+
 describe('support/Dom', () => {
   describe('isTextLikeInput', () => {
     it('returns true for plain text-like input types', () => {
@@ -27,6 +34,35 @@ describe('support/Dom', () => {
     it('returns false for non-input elements and null', () => {
       expect(Dom.isTextLikeInput(document.createElement('div'))).toBe(false)
       expect(Dom.isTextLikeInput(null)).toBe(false)
+    })
+  })
+
+  describe('isEditorSubmitKeydown', () => {
+    it('submits on bare Enter from a text-like input', () => {
+      expect(Dom.isEditorSubmitKeydown(keydown(input('text')))).toBe(true)
+    })
+
+    it('does not submit on bare Enter from a textarea or other control', () => {
+      expect(Dom.isEditorSubmitKeydown(keydown(document.createElement('textarea')))).toBe(false)
+      expect(Dom.isEditorSubmitKeydown(keydown(document.createElement('div')))).toBe(false)
+    })
+
+    it('submits on Ctrl/Cmd+Enter from any control', () => {
+      const textarea = document.createElement('textarea')
+      expect(Dom.isEditorSubmitKeydown(keydown(textarea, { ctrlKey: true }))).toBe(true)
+      expect(Dom.isEditorSubmitKeydown(keydown(textarea, { metaKey: true }))).toBe(true)
+      expect(Dom.isEditorSubmitKeydown(keydown(document.createElement('div'), { metaKey: true }))).toBe(true)
+    })
+
+    it('does not submit on Shift+Enter or Alt+Enter from a textarea (reserved for newlines)', () => {
+      const textarea = document.createElement('textarea')
+      expect(Dom.isEditorSubmitKeydown(keydown(textarea, { shiftKey: true }))).toBe(false)
+      expect(Dom.isEditorSubmitKeydown(keydown(textarea, { altKey: true }))).toBe(false)
+    })
+
+    it('does not submit on non-Enter keys', () => {
+      expect(Dom.isEditorSubmitKeydown(keydown(input('text'), { key: 'a' } as Partial<KeyboardEvent>))).toBe(false)
+      expect(Dom.isEditorSubmitKeydown(keydown(input('text'), { key: 'Tab' } as Partial<KeyboardEvent>))).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## Problem

Pressing **Enter** in an inline editor opened from the pencil didn't save/apply it — in both the avatar name popover (table) and the sheet field editor. Users had to click **Save/Apply**.

## Cause

Only the generic table-cell editor (`LensTableEditableCell`) wired Enter:
- `LensTableAvatarCell` (the avatar name-companion popover) handled **only Escape**.
- `LensSheetField` (the sheet field editor) had **no keydown handling at all**.

## Fix

Enter now saves in all three inline editors, with a single shared rule (`support/Dom`'s `isEditorSubmitKeydown`):

- **Bare Enter** submits from a plain text-like `<input>`. A textarea (Enter inserts a newline) or a control that handles Enter itself (e.g. a dropdown opening its menu) keeps it.
- **Ctrl/Cmd+Enter** submits from **any** control — the near-universal submit gesture (GitHub, Gmail, Slack, …). This lets you submit from a textarea/dropdown without clashing with their bare-Enter behavior.
- **Shift+Enter** and **Alt/Option+Enter** are left for newlines (Alt+Enter has no consistent submit meaning across apps — Excel uses it for an in-cell newline).
- The **Enter that commits an IME composition** (e.g. CJK input) never submits (`event.isComposing`).

Per-editor:
- `LensTableAvatarCell` — `onEditorKeydown` now submits via `isEditorSubmitKeydown` (Escape still cancels).
- `LensSheetField` — new keydown handler: Enter submits via `isEditorSubmitKeydown`; **Escape cancels the field edit** and is stopped from bubbling so the surrounding `SSheet` does not also close. While an IME is composing, Escape cancels the composition and the editor stays open.
- `LensTableEditableCell` — refactored onto the shared helper (behavior unchanged for bare Enter; gains Ctrl/Cmd+Enter).

## Tests
- `tests/support/Dom.spec.ts` covers `isTextLikeInput` and `isEditorSubmitKeydown` (bare Enter by input type, Ctrl/Cmd+Enter from any control, Shift/Alt+Enter excluded, non-Enter keys). The editor components have no unit tests (they import `~icons`, which the test env doesn't resolve), so this follows the existing convention.
- `pnpm check` (vue-tsc + eslint + vitest, 1231 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review follow-ups
- **Dropdown filter no longer submits on Enter.** A dropdown's filter `<input>` (`SDropdownSectionFilter`) renders inline (not teleported), so Enter typed in it bubbled to the editor's form handler and submitted. It now stops Enter at the filter (`@keydown.enter.stop`) — Enter drives the dropdown, not an enclosing submit. Fixes it for the table editable cell too, without coupling the editor handler to dropdown internals.
- **Table editors' Escape is now IME-aware**, matching the sheet: the Escape that reverts an in-progress IME composition leaves the editor open. Centralized via a shared `isEditorCancelKeydown` helper used by all three editors.

- **Sheet field editor now focuses its input on open** (matching the inline table editor). The sheet wasn't auto-focusing, so the editor's keydowns didn't reach the form handler — meaning Escape only cancelled-instead-of-closing when the input happened to be focused. Focusing on open fixes that (and is better UX).

### Audit: other input components with nested text-like inputs
Checked every inline-editable Lens field's input component. Only the dropdown's filter had a nested secondary `<input>` that leaked Enter (fixed above). The rest are fine:
- `SInputText` (Text/Link), `SInputDate` (Date) — a single **primary** text input; bare Enter-to-save is correct. (v-calendar's popover teleports out of the form and is a button grid, no nested text input.)
- `SInputCheckboxes` / `SInputRadios` / `SInputFileUpload` — no text-like input.
- `LensAvatarInput` — file picker; avatar edits go through the dedicated blocking-save path, not the generic editor.
- Number/Decimal/Datetime/Boolean/Related/Slack/Id fields throw on `formInputComponent` (not inline-editable); `LensFormOverrideNumber` is only used in the filter/override form, never the pencil editor.


### Shared helpers + future-fields note
- Extracted the duplicated keydown + focus logic from the three inline editors into `support/Dom`: `dispatchEditorKeydown(event, { cancel, submit, shield })` (centralizes the IME / Ctrl+Cmd / sheet-shield rules) and `focusFirstEditable(container)`.
- Documented on `Field.formInputComponent` the inline-editor keyboard gotcha (nested text inputs must keep Enter/Escape from bubbling), for when the currently read-only field types gain inline/sheet editing.

- **Autofocus skips the editor's action row.** `focusFirstEditable` ignores `.actions` (Cancel/Save are `SButton` = `role=button`+`tabindex`, so they'd otherwise be focus candidates). A field whose input has no focusable control of its own (radio/checkbox group) now focuses nothing instead of landing on Cancel — where Enter/Space would dismiss the edit.
