### PR TITLE
feat(lens): let create-form slots contribute extra payload keys

### DIFF
--- a/lib/blocks/lens/LensCreateExtension.ts
+++ b/lib/blocks/lens/LensCreateExtension.ts
@@ -1,0 +1,43 @@
+/**
+ * A create-form extension contributed by a sheet slot (`#before` / `#after`).
+ *
+ * The catalog's create form builds its payload from the entity's own Lens
+ * fields. A page may need to create related data that isn't a Lens field (e.g. a
+ * collaborator's social links, written server-side alongside the record). Such a
+ * slot registers an extension via the `registerCreateExtension` slot prop: on
+ * submit the sheet runs every registered extension to validate the slot's own
+ * inputs and merge its extra keys into the create payload.
+ */
+export interface LensCreateContribution {
+  /**
+   * Whether the slot's own inputs passed validation. When any registered
+   * extension reports `false`, the create is aborted (the sheet stays open so
+   * each slot can show its own errors).
+   */
+  valid: boolean
+
+  /**
+   * Extra key/value pairs merged into the create payload (e.g.
+   * `{ social_links: [...] }`). Ignored when `valid` is `false`.
+   */
+  values: Record<string, any>
+}
+
+/**
+ * A function the sheet calls on create-submit. It validates the slot's inputs
+ * and returns its contribution; it may be async (validation usually is). It
+ * should report `valid: false` rather than throw — a throw propagates to the
+ * sheet's submit handler as an unexpected error.
+ */
+export type LensCreateExtension = () =>
+  | LensCreateContribution
+  | Promise<LensCreateContribution>
+
+/**
+ * Register a {@link LensCreateExtension} with the sheet's create form. Returns a
+ * disposer that unregisters it — call it on unmount (the create slot content
+ * unmounts with the sheet, so a component-lifecycle cleanup suffices).
+ */
+export type RegisterLensCreateExtension = (
+  extension: LensCreateExtension
+) => () => void

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -11,6 +11,7 @@ import { usePower } from '../../../composables/Power'
 import { useValidation } from '../../../composables/Validation'
 import { useSnackbars } from '../../../stores/Snackbars'
 import { type FieldData } from '../FieldData'
+import { type LensCreateExtension } from '../LensCreateExtension'
 import { useFieldFactory } from '../composables/FieldFactory'
 import { useLensEdit } from '../composables/LensEdit'
 import { extractServerErrors, extractServerMessage } from '../validation/ServerErrors'
@@ -177,6 +178,19 @@ watch(
   { immediate: true }
 )
 
+// Create-form extensions registered by sheet slots (`#before` / `#after`) — a
+// page's custom inputs that aren't Lens fields (e.g. social links written
+// server-side alongside the record). On submit each is run to validate its own
+// inputs and contribute extra keys to the create payload. Registered on mount and
+// disposed on unmount; the create slot content unmounts with the sheet, so a
+// component-lifecycle cleanup keeps this empty between creates.
+const createExtensions = new Set<LensCreateExtension>()
+
+function registerCreateExtension(extension: LensCreateExtension): () => void {
+  createExtensions.add(extension)
+  return () => { createExtensions.delete(extension) }
+}
+
 async function onCreate() {
   // Guard re-entry: set `saving` before the first await so a fast double-click on
   // Create can't start a second submission (and create a duplicate record) while
@@ -197,12 +211,31 @@ async function onCreate() {
   serverErrors.value = {}
 
   try {
-    if (!(await validate())) {
+    // Validate the built-in fields and every registered slot extension, running
+    // them all even when something already failed, so each section surfaces its
+    // own errors on a single submit rather than one at a time. A valid extension
+    // contributes extra keys to the payload; any failure aborts the create.
+    const fieldsValid = await validate()
+    const contributions: Record<string, any>[] = []
+    let extensionsValid = true
+    for (const extend of createExtensions) {
+      const { valid, values } = await extend()
+      if (valid) {
+        contributions.push(values)
+      } else {
+        extensionsValid = false
+      }
+    }
+    if (!fieldsValid || !extensionsValid) {
       return
     }
     const values: Record<string, any> = {}
     for (const { key, field } of createInputViews.value) {
       values[key] = field.inputToPayload(createModel[key])
+    }
+    // Merge each extension's contribution (e.g. `social_links`) into the payload.
+    for (const extra of contributions) {
+      Object.assign(values, extra)
     }
     // A picked avatar `File` rides `values`; `edit.create` sends the payload
     // multipart when one is present, so the avatar persists with the new record.
@@ -266,9 +299,11 @@ function requestClose() {
 // that hosts the catalog, so it cannot `inject` the edit context (which is
 // provided inside `LensCatalog`, a child of that page). Expose the pieces a
 // slot needs as slot props instead: the resolved record id, a record-bound
-// partial `save`, and the entity key. This keeps the generic sheet free of
-// one-off concerns (avatar upload, social links, linked records) while still
-// letting a page implement them.
+// partial `save`, the entity key, the sheet `mode` (so a slot can render
+// different content for create vs view), and `registerCreateExtension` (so a
+// create-mode slot can contribute extra keys to the create payload). This keeps
+// the generic sheet free of one-off concerns (avatar upload, social links,
+// linked records) while still letting a page implement them.
 
 const resolvedId = computed(() => (props.record && edit ? edit.resolveId(props.record) : null))
 
@@ -293,6 +328,9 @@ const slotProps = computed(() => ({
   record: props.record ?? null,
   id: resolvedId.value,
   entity: props.entity,
+  // The sheet's current mode, so a slot can branch its content (e.g. show
+  // editable inputs only while creating, and a read/edit view otherwise).
+  mode: props.mode,
   // Surfaced so custom editors can disable their save controls until the full
   // record has loaded; `save` also hard-refuses while loading/error as a guard.
   loading: props.loading ?? false,
@@ -301,7 +339,11 @@ const slotProps = computed(() => ({
   // editor can disable its own controls for a rejected row; `save` enforces it
   // regardless, but otherwise the refusal is only visible as a silent no-op.
   canEdit: !!props.record && !!edit?.canEdit(props.record),
-  save: saveRecord
+  save: saveRecord,
+  // Let a create-mode slot register inputs that contribute extra keys to the
+  // create payload (see LensCreateExtension). Stable identity; a no-op in view
+  // mode (a slot only registers while the create form is shown).
+  registerCreateExtension
 }))
 </script>
 


### PR DESCRIPTION
## What

The Lens sheet's **create form** builds its POST payload from the entity's own fields. But a page sometimes needs to create related data that isn't a Lens field — e.g. a record's external links that the server persists alongside the record.

This adds a generic **create-extension hook** to the sheet slots so a slot can validate its own inputs and contribute extra keys to the create payload.

## How

- New `lib/blocks/lens/LensCreateExtension.ts` — `LensCreateContribution` (`{ valid, values }`), `LensCreateExtension` (the collect callback), and `RegisterLensCreateExtension` (the register signature).
- `LensSheet` keeps a small `Set` of registered extensions exposed via the new `registerCreateExtension` slot prop. On submit, `onCreate` validates the built-in fields **and** every registered extension (running them all so each surfaces its own errors on a single submit), aborts if any reports `valid: false`, and merges each contribution's `values` into the payload.
- Slot props (`#before` / `#after`) gain:
  - `mode` — so a slot can branch its content for create vs view.
  - `registerCreateExtension` — register/dispose a contributor (the create slot unmounts with the sheet, so a component-lifecycle cleanup suffices).

## Notes

- Purely **additive / backwards-compatible**: entities with no extension (the common case) take the same path as before — an empty registry contributes nothing.
- An extension is expected to report `valid: false` rather than throw (documented on the type).

## Verification

- `pnpm check` (vue-tsc + eslint + 1245 tests) passes.
- Wired up end-to-end in a consumer's create form and confirmed the extra keys ride the create POST and persist; the existing view/update flows are unaffected.