### PR TITLE
refactor(lens): type LensInputSelect v-model as the domain model

### DIFF
--- a/lib/blocks/lens/components/LensInputSelect.vue
+++ b/lib/blocks/lens/components/LensInputSelect.vue
@@ -42,8 +42,10 @@ export interface Props<T = any, Multiple extends boolean = false> {
   // negotiates language from the request headers.
   settings?: LensQuerySettings
 
-  // Whether multiple models can be selected.
-  multiple?: Multiple
+  // Whether multiple models can be selected. Typed `boolean & Multiple` (equal to
+  // `Multiple`) so Vue keeps runtime Boolean casting for a bare `multiple` while
+  // `Multiple` still drives the arity-conditional model type. See SInputSelectSearch.
+  multiple?: boolean & Multiple
 
   // Build a model from a raw result row.
   toModel: (row: Record<string, any>) => T

--- a/lib/blocks/lens/components/LensInputSelect.vue
+++ b/lib/blocks/lens/components/LensInputSelect.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T, Multiple extends boolean = false">
 import SInputSelectSearch, { type Option } from '../../../components/SInputSelectSearch.vue'
 import { useMutation } from '../../../composables/Api'
 import { useLang } from '../../../composables/Lang'
@@ -8,26 +8,26 @@ import { isAuthError } from '../validation/ServerErrors'
 export type { Color, Size } from '../../../components/SInputBase.vue'
 export type { Option }
 
-// A lens-backed search-select. Combines the search (a lens query), the fetch (no
-// repo needed), and the row → option mapping (no ops needed) into one component:
-// the consumer configures the entity and how a row becomes an option, and the
-// component searches the server as the user types via SInputSelectSearch.
+// A lens-backed search-select that works entirely in the consumer's own model
+// type. It searches the server as the user types (via SInputSelectSearch): each
+// result row is turned into a model by `toModel`, and each model is rendered as
+// its dropdown/chip option by `toOption`. The v-model is those models — a `T[]`
+// when `multiple`, otherwise `T | null`.
 //
-// Selection UI props (multiple, nullable, disabled, placeholder, size, label,
-// validation, position, closeOnSelect, debounce, …) fall through to
-// SInputSelectSearch as attributes.
-export interface Props {
+// Remaining selection UI props (nullable, disabled, placeholder, size, label,
+// validation, position, closeOnSelect, debounce, …) fall through as attributes.
+export interface Props<T = any, Multiple extends boolean = false> {
   // The lens search endpoint (e.g. `/api/admin/lens/search`).
   endpoint: string
 
   // The entity to search.
   entity: string
 
-  // Columns to fetch for each row, projected into an option by `toOption`.
+  // Columns to fetch for each row, passed to `toModel`.
   select: string[]
 
-  // Columns matched against the typed query — OR-ed together with `contains`.
-  // An empty query fetches the initial (unfiltered) page. Named to match
+  // Columns matched against the typed query — OR-ed together with `contains`. An
+  // empty query fetches the initial (unfiltered) page. Named to match
   // LensCatalog's `queryKeys`.
   queryKeys: string[]
 
@@ -38,24 +38,27 @@ export interface Props {
   // Page size of each search. The server enforces its own perPage ceiling.
   perPage?: number
 
-  // Per-request settings (e.g. language). Usually unneeded — the server negotiates
-  // language from the request headers.
+  // Per-request settings (e.g. language). Usually unneeded — the server
+  // negotiates language from the request headers.
   settings?: LensQuerySettings
 
-  // Map a raw result row to an option. The selected option(s) are the model, so
-  // include everything the consumer needs back (e.g. a related record), plus the
-  // `value` / `label` (and `image` for an avatar option) the select renders.
-  toOption: (row: Record<string, any>) => Option
+  // Whether multiple models can be selected.
+  multiple?: Multiple
+
+  // Build a model from a raw result row.
+  toModel: (row: Record<string, any>) => T
+
+  // Render a model as its dropdown/chip option (`value` is the identity).
+  toOption: (item: T) => Option
 }
 
-const props = defineProps<Props>()
+const props = defineProps<Props<T, Multiple>>()
 
-// Pass the selection through to SInputSelectSearch. Typed loosely so a consumer
-// can bind a ref of its own richer option type (see SInputSelectSearch).
-const model = defineModel<any>({ required: true })
+// The selected model(s): a `T[]` when `multiple`, otherwise `T | null`.
+const model = defineModel<Multiple extends true ? T[] : T | null>({ required: true })
 
-// Don't let lens-config attributes that happen to share a name leak onto the
-// child; only the explicitly-forwarded selection props (via `$attrs`) should.
+// Don't let lens-config attributes leak onto the child; only the explicitly
+// forwarded selection props (via `$attrs`) should.
 defineOptions({ inheritAttrs: false })
 
 // Default the request language to the active app language (like LensCatalog), so
@@ -77,16 +80,23 @@ const { execute } = useMutation((http, query: string) =>
   })
 )
 
-// Read every config field through `props` at call time so a reactive change
-// (e.g. a locale-dependent sort or label) takes effect on the next search.
-async function fetch(query: string): Promise<Option[]> {
+// Read every config field through `props` at call time so a reactive change (e.g.
+// a locale-dependent sort or label) takes effect on the next search.
+async function fetch(query: string): Promise<T[]> {
   const res = await execute(query)
-  return res.data.map(props.toOption)
+  return res.data.map(props.toModel)
 }
 </script>
 
 <template>
-  <SInputSelectSearch v-model="model" :fetch :rethrow="isAuthError" v-bind="$attrs">
+  <SInputSelectSearch
+    v-model="model"
+    :fetch
+    :to-option
+    :multiple
+    :rethrow="isAuthError"
+    v-bind="$attrs"
+  >
     <template v-if="$slots.info" #info><slot name="info" /></template>
   </SInputSelectSearch>
 </template>

--- a/lib/components/SInputSelectSearch.vue
+++ b/lib/components/SInputSelectSearch.vue
@@ -49,8 +49,12 @@ export interface Props<T = any, Multiple extends boolean = false> extends BasePr
   // the app's re-auth flow. By default every rejection is swallowed.
   rethrow?: (error: unknown) => boolean
   // Whether multiple items can be selected. The model is then an array of items;
-  // otherwise it is a single item or `null`.
-  multiple?: Multiple
+  // otherwise it is a single item or `null`. Typed `boolean & Multiple` (equal to
+  // `Multiple`, since it extends `boolean`) rather than a bare `Multiple`: the
+  // intersection keeps Vue's runtime Boolean casting (a bare `multiple` attribute
+  // would otherwise arrive as `''` and read as false), while `Multiple` still
+  // drives the arity-conditional model type.
+  multiple?: boolean & Multiple
   // Whether the (single) value can be cleared, or the (multiple) selection emptied.
   nullable?: boolean
   disabled?: boolean

--- a/lib/components/SInputSelectSearch.vue
+++ b/lib/components/SInputSelectSearch.vue
@@ -1,8 +1,8 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T, Multiple extends boolean = false">
 import IconCaretDown from '~icons/ph/caret-down'
 import IconCaretUp from '~icons/ph/caret-up'
 import IconCheck from '~icons/ph/check'
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { type Ref, computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import { useManualDropdownPosition } from '../composables/Dropdown'
 import { useFlyout } from '../composables/Flyout'
 import { useTrans } from '../composables/Lang'
@@ -32,20 +32,25 @@ export interface OptionAvatar extends OptionBase {
   image?: string | null
 }
 
-export interface Props extends BaseProps {
+export interface Props<T = any, Multiple extends boolean = false> extends BaseProps {
   placeholder?: string
-  // Fetch the options matching `query` from the server. Called when the dropdown
+  // Fetch the items matching `query` from the server. Called when the dropdown
   // opens (with the current query, usually empty for the initial list) and again,
-  // debounced, on each keystroke. Out-of-order responses are discarded, so it does
-  // not need to guard against races itself.
-  fetch: (query: string) => Promise<Option[]>
+  // debounced, on each keystroke. Out-of-order responses are discarded, so it
+  // does not need to guard against races itself.
+  fetch: (query: string) => Promise<T[]>
+  // Render an item as its dropdown option and, once selected, as its chip. The
+  // option's `value` is the item's identity — selection, de-duplication and
+  // removal all key off it. Applied to fetched items and to the bound model
+  // alike, so a seeded selection renders without appearing in any fetch.
+  toOption: (item: T) => Option
   // Decide whether a `fetch` rejection should propagate (be re-thrown) instead of
   // being swallowed into an empty list — e.g. to let auth/session failures reach
   // the app's re-auth flow. By default every rejection is swallowed.
   rethrow?: (error: unknown) => boolean
-  // Whether multiple options can be selected. The model is then an array of the
-  // selected options; otherwise it is a single option or `null`.
-  multiple?: boolean
+  // Whether multiple items can be selected. The model is then an array of items;
+  // otherwise it is a single item or `null`.
+  multiple?: Multiple
   // Whether the (single) value can be cleared, or the (multiple) selection emptied.
   nullable?: boolean
   disabled?: boolean
@@ -60,12 +65,18 @@ export interface Props extends BaseProps {
 // `closeOnSelect` defaults to `undefined` (not Vue's usual absent-Boolean → false)
 // so the `?? !multiple` fallback in onSelect can tell "omitted" from an explicit
 // `false`, keeping the single-select-closes / multiple-stays-open default.
-const props = withDefaults(defineProps<Props>(), { closeOnSelect: undefined })
+const props = withDefaults(defineProps<Props<T, Multiple>>(), { closeOnSelect: undefined })
 
-// The selected option(s). A single `Option | null`, or an `Option[]` when
-// `multiple`. Typed loosely (like SInputDropdown) so a consumer can bind a ref of
-// its own richer option type without v-model variance friction.
-const model = defineModel<any>({ required: true })
+// The selection: an array of items when `multiple`, otherwise a single item or
+// `null`. Items are the consumer's own model type; the option rendered for each
+// is derived on demand via `toOption`, so nothing extra is stored on the model.
+const model = defineModel<Multiple extends true ? T[] : T | null>({ required: true })
+
+// Write the model regardless of arity. The public type is arity-conditional, so
+// the concrete array / single value is cast at this single boundary.
+function commit(value: T[] | T | null): void {
+  model.value = value as typeof model.value
+}
 
 const { t } = useTrans({
   en: {
@@ -91,10 +102,10 @@ const { inset, update: updatePosition } = useManualDropdownPosition(
 )
 
 const query = ref('')
-const options = ref<Option[]>([])
+const items = ref([]) as Ref<T[]>
 const loading = ref(false)
 
-// Monotonic token so only the latest fetch may assign `options` / clear `loading`.
+// Monotonic token so only the latest fetch may assign `items` / clear `loading`.
 // With a debounced, user-driven search several requests can overlap; an older one
 // resolving late must not clobber the newer result.
 let fetchSeq = 0
@@ -104,20 +115,38 @@ const classes = computed(() => [
   { disabled: props.disabled }
 ])
 
-const selected = computed<Option | Option[] | null>(() => {
+// The selected items as a flat array, regardless of arity, for internal handling.
+const selectedItems = computed<T[]>(() => {
   if (props.multiple) {
-    return Array.isArray(model.value) ? (model.value as Option[]) : []
+    return Array.isArray(model.value) ? (model.value as T[]) : []
   }
-  return (model.value as Option | null) ?? null
+  return model.value != null ? [model.value as T] : []
 })
 
-const hasSelected = computed(() =>
-  props.multiple ? (selected.value as Option[]).length > 0 : selected.value !== null
+// The identities currently selected, for O(1) active / de-dup checks.
+const selectedValues = computed(
+  () => new Set(selectedItems.value.map((item) => props.toOption(item).value))
 )
+
+// The option(s) rendered for the current selection: an array of chips when
+// multiple, a single chip otherwise (matching SInputDropdownItem's `item`).
+const selectedOptions = computed<Option | Option[] | null>(() => {
+  if (props.multiple) {
+    return selectedItems.value.map((item) => props.toOption(item))
+  }
+  return model.value != null ? props.toOption(model.value as T) : null
+})
+
+// The fetched items paired with their rendered option, for the dropdown list.
+const optionItems = computed(() =>
+  items.value.map((item) => ({ item, option: props.toOption(item) }))
+)
+
+const hasSelected = computed(() => selectedItems.value.length > 0)
 
 const removable = computed(() => {
   if (props.multiple) {
-    return !!props.nullable || (selected.value as Option[]).length > 1
+    return !!props.nullable || selectedItems.value.length > 1
   }
   return !!props.nullable
 })
@@ -128,12 +157,12 @@ async function runFetch(q: string): Promise<void> {
   try {
     const res = await props.fetch(q)
     if (seq === fetchSeq) {
-      options.value = res
+      items.value = res
     }
   } catch (e) {
     // A failed search yields no options (the empty state shows)…
     if (seq === fetchSeq) {
-      options.value = []
+      items.value = []
     }
     // …unless the consumer wants this failure propagated (e.g. an auth/session
     // error that must reach the app's re-auth flow rather than look like "no
@@ -199,14 +228,14 @@ function onOpen() {
 watch(isOpen, (value) => {
   // On close: drop any pending refetch, invalidate any in-flight fetch (so a late
   // response can't repopulate the list while closed), and clear the query /
-  // options / loading. Reopening then starts fresh instead of briefly rendering
+  // items / loading. Reopening then starts fresh instead of briefly rendering
   // the previous query's results (which would be selectable). The selected chips
-  // are unaffected — they render from the model, not from `options`.
+  // are unaffected — they render from the model, not from the fetched `items`.
   if (!value) {
     cancelPendingFetch()
     fetchSeq++
     query.value = ''
-    options.value = []
+    items.value = []
     loading.value = false
   }
 })
@@ -223,36 +252,32 @@ watch(() => props.disabled, (disabled) => {
 })
 
 function isActive(value: any): boolean {
-  if (props.multiple) {
-    return (selected.value as Option[]).some((o) => o.value === value)
-  }
-  return (selected.value as Option | null)?.value === value
+  return selectedValues.value.has(value)
 }
 
-function onSelect(option: Option): void {
+function onSelect(item: T): void {
+  const option = props.toOption(item)
   if (props.disabled || option.disabled) {
     return
   }
 
   props.validation?.$touch()
 
+  const value = option.value
+
   if (props.multiple) {
-    const current = (model.value as Option[] | null) ?? []
-    const exists = current.some((o) => o.value === option.value)
-    const next = exists
-      ? current.filter((o) => o.value !== option.value)
-      : [...current, option]
+    const current = selectedItems.value
+    const next = selectedValues.value.has(value)
+      ? current.filter((i) => props.toOption(i).value !== value)
+      : [...current, item]
     // Keep at least one unless clearing is allowed (mirrors SInputDropdown).
     if (next.length !== 0 || props.nullable) {
-      model.value = next
+      commit(next)
     }
-  } else {
-    const currentValue = (model.value as Option | null)?.value
-    if (currentValue !== option.value) {
-      model.value = option
-    } else if (props.nullable) {
-      model.value = null
-    }
+  } else if (!selectedValues.value.has(value)) {
+    commit(item)
+  } else if (props.nullable) {
+    commit(null)
   }
 
   if (props.closeOnSelect ?? !props.multiple) {
@@ -265,10 +290,9 @@ function onRemove(value: any): void {
   props.validation?.$touch()
 
   if (props.multiple) {
-    const current = (model.value as Option[] | null) ?? []
-    model.value = current.filter((o) => o.value !== value)
+    commit(selectedItems.value.filter((item) => props.toOption(item).value !== value))
   } else {
-    model.value = null
+    commit(null)
   }
 }
 
@@ -335,7 +359,7 @@ function focusNext(event: any): void {
         <div class="box-content">
           <SInputDropdownItem
             v-if="hasSelected"
-            :item="selected!"
+            :item="selectedOptions!"
             :size="size ?? 'small'"
             :removable
             :disabled="disabled ?? false"
@@ -369,11 +393,11 @@ function focusNext(event: any): void {
             >
             <!-- A refetch while options are already shown keeps the (stale) list
                  visible; this spinner signals that newer results are loading. -->
-            <SSpinner v-if="loading && options.length" class="search-spinner" />
+            <SSpinner v-if="loading && items.length" class="search-spinner" />
           </div>
 
-          <ul v-if="options.length" ref="list" class="list">
-            <li v-for="option in options" :key="option.value" class="item">
+          <ul v-if="items.length" ref="list" class="list">
+            <li v-for="{ item, option } in optionItems" :key="option.value" class="item">
               <button
                 class="button"
                 :class="{ active: isActive(option.value) }"
@@ -382,7 +406,7 @@ function focusNext(event: any): void {
                 tabindex="0"
                 @keyup.up.prevent="focusPrev"
                 @keyup.down.prevent="focusNext"
-                @click="onSelect(option)"
+                @click="onSelect(item)"
               >
                 <span v-if="multiple" class="checkbox">
                   <span class="checkbox-box">

--- a/tests/components/SInputSelectSearch.spec.ts
+++ b/tests/components/SInputSelectSearch.spec.ts
@@ -1,0 +1,72 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import SInputSelectSearch, { type Option } from 'sefirot/components/SInputSelectSearch.vue'
+
+interface Foo { id: number; name: string }
+
+const items: Foo[] = [
+  { id: 1, name: 'Alpha' },
+  { id: 2, name: 'Bravo' }
+]
+
+const fetch = async (): Promise<Foo[]> => items
+// `foo: any` — mount() can't infer the component's generic `T`, so it defaults to
+// `unknown`; a `Foo` param would be contravariantly incompatible with that.
+const toOption = (foo: any): Option => ({ value: foo.id, label: foo.name })
+
+// Mount with a two-way `modelValue` binding so selections feed back into the prop,
+// mirroring a real `v-model`.
+// Props cast to `any`: mount()'s strict prop typing against a generic SFC (with a
+// required model + a self-referential update handler) is more trouble than it's
+// worth here — the assertions below exercise the runtime behavior.
+function factory(props: Record<string, unknown>) {
+  const wrapper = mount(SInputSelectSearch, {
+    props: {
+      fetch,
+      toOption,
+      'onUpdate:modelValue': (value: unknown): void => {
+        wrapper.setProps({ modelValue: value })
+      },
+      ...props
+    } as any
+  })
+  return wrapper
+}
+
+async function open(wrapper: ReturnType<typeof factory>) {
+  await wrapper.find('.box').trigger('click')
+  await flushPromises()
+}
+
+describe('components/SInputSelectSearch', () => {
+  // `multiple` is a generic-typed prop (`boolean & Multiple`); the intersection is
+  // what preserves Vue's Boolean casting. A bare attribute arrives as '', which must
+  // still be read as `true` — otherwise the control silently falls back to single.
+  it('casts a bare `multiple` attribute to true and selects into an array', async () => {
+    const wrapper = factory({ modelValue: [], multiple: '' })
+
+    await open(wrapper)
+
+    // Multiple mode renders checkboxes, not radios.
+    expect(wrapper.find('.list .checkbox').exists()).toBe(true)
+    expect(wrapper.find('.list .radio').exists()).toBe(false)
+
+    const buttons = wrapper.findAll('.list .button')
+    await buttons[0].trigger('click')
+    await buttons[1].trigger('click')
+
+    expect(wrapper.props('modelValue')).toStrictEqual([items[0], items[1]])
+  })
+
+  it('defaults to single select (radios) and replaces the model on select', async () => {
+    const wrapper = factory({ modelValue: null })
+
+    await open(wrapper)
+
+    expect(wrapper.find('.list .radio').exists()).toBe(true)
+    expect(wrapper.find('.list .checkbox').exists()).toBe(false)
+
+    await wrapper.findAll('.list .button')[1].trigger('click')
+
+    expect(wrapper.props('modelValue')).toStrictEqual(items[1])
+  })
+})


### PR DESCRIPTION
Reworks the (experimental) `LensInputSelect` / `SInputSelectSearch` so the v-model is the consumer's **domain model**, not the render `Option`. Breaking change to both components — no other in-repo consumers.

## Why

The old shape forced consumers to stuff their model into the option (`toOption` returning `{ value, label, image, ...theWholeModel }`) and then dig it back out of the selection. That was verbose and leaked render concerns into the data.

## What it is now

**`SInputSelectSearch<T, Multiple>`** — generic over the item/model type `T`:
- `fetch(query) => Promise<T[]>` returns model items (not options).
- `toOption(item: T) => Option` renders each item — used for **both** the dropdown list and the selected chips. `option.value` is the item's identity (selection, de-dup, removal all key off it).
- v-model is `Multiple extends true ? T[] : T | null`.
- Selection moves `T`s directly; because chips render via `toOption(model)`, a **seeded selection renders without ever appearing in a fetch**.

**`LensInputSelect<T, Multiple>`** — the lens wrapper:
- adds `toModel(row) => T` (builds the fetch: `rows.map(toModel)`), forwards `toOption` + `multiple`.
- v-model is the domain models — `T[]` when `multiple`, else `T | null`.

## Before / after (lens consumer)

```ts
// before — model IS the option; the domain model is smuggled inside it
const picked = ref<CollaboratorOption | null>(null)
<LensInputSelect
  v-model="picked"
  :to-option="(row) => ({ type: 'avatar', value: row.id, label: row.name,
                          image: row.avatar, collaborator: buildCollaborator(row) })"
/>
// ...then read picked.value.collaborator

// after — model IS the domain model
const picked = ref<Collaborator | null>(null)
<LensInputSelect
  v-model="picked"
  :to-model="(row) => buildCollaborator(row)"
  :to-option="(c) => ({ type: 'avatar', value: c.id, label: c.name, image: c.avatar })"
/>
// ...read picked.value directly
```

## Typing

The `multiple` prop drives an arity-conditional model type (same pattern as `SInputRadios`' `Nullable`). Verified with a throwaway consumer + `vue-tsc`: single mode infers `T | null`, `multiple` infers `T[]`, and `T` is inferred from `toOption`/`toModel` (a `T[]` bound to a single-mode instance is a type error, so it's not passing vacuously via the `any` default).

`multiple` is typed **`boolean & Multiple`**, not a bare `Multiple`. A generic-typed prop compiles to a runtime prop with `type: null`, which drops Vue's Boolean casting — a bare `<... multiple>` would arrive as `''` (falsy) and silently force single-select. The intersection equals `Multiple` at the type level (it extends `boolean`), so the conditional model type is unchanged, but the compiler now emits `{ type: Boolean }` and casting is restored. Covered by a runtime test.

## Known limitations (low, unchanged behavior)

- Single mode: re-clicking the already-selected item is a no-op (or clears, when `nullable`) — the intentional toggle semantic from `SInputDropdown`. So if the same entity is re-fetched with a newer label mid-session, the stored object (and its chip label) isn't refreshed.
- `onRemove` keys off identity, so a model seeded with two items sharing one `toOption().value` (a contract violation — identities must be unique) would drop both chips at once. Not reachable via the lens wrapper.

## Checks

`pnpm check` green — vue-tsc, eslint, and vitest (incl. a new `SInputSelectSearch` spec covering the bare-`multiple` casting). Also ran an adversarial multi-agent review (the two limitations above were its only confirmed findings, both low).