### PR TITLE
fix(lens): render exact labels for single select values

### DIFF
--- a/lib/blocks/lens/fields/SelectField.ts
+++ b/lib/blocks/lens/fields/SelectField.ts
@@ -145,9 +145,7 @@ export class SelectField extends Field<SelectFieldData> {
   }
 
   protected renderDataListItemValueForText(value: any): any {
-    if (this.data.multiple) {
-      value = Array.isArray(value) ? value : [value]
-    }
+    value = Array.isArray(value) ? value : [value]
 
     return this.optionsForValues(value).map((o) => this.labelForOption(o)).join(', ')
   }

--- a/tests/blocks/lens/fields/SelectField.spec.ts
+++ b/tests/blocks/lens/fields/SelectField.spec.ts
@@ -1,0 +1,77 @@
+import { mount } from '@vue/test-utils'
+import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
+import { type SelectFieldData } from 'sefirot/blocks/lens/FieldData'
+import { SelectField } from 'sefirot/blocks/lens/fields/SelectField'
+import { DataListStateKey } from 'sefirot/composables/DataList'
+import { computed } from 'vue'
+
+function ctx(lang: 'en' | 'ja' = 'en'): FieldContext {
+  return { lang }
+}
+
+function make(overrides: Partial<SelectFieldData> = {}): SelectField {
+  const data: SelectFieldData = {
+    type: 'select',
+    key: 'choice',
+    labelEn: 'Choice',
+    labelJa: 'Choice',
+    filterKey: 'choice',
+    sortable: true,
+    freeze: false,
+    width: 0,
+    required: false,
+    rules: [],
+    displayAs: 'text',
+    inputAs: 'dropdown',
+    placeholderEn: null,
+    placeholderJa: null,
+    helpEn: null,
+    helpJa: null,
+    options: [
+      {
+        mode: 'default',
+        value: 'foo',
+        labelEn: 'First',
+        labelJa: 'First'
+      },
+      {
+        mode: 'default',
+        value: 'foobar',
+        labelEn: 'Second',
+        labelJa: 'Second'
+      },
+      {
+        mode: 'default',
+        value: 'baz',
+        labelEn: 'Third',
+        labelJa: 'Third'
+      }
+    ],
+    multiple: false,
+    ...overrides
+  }
+
+  return new SelectField(ctx(), data)
+}
+
+function mountDataListItem(field: SelectField, value: any) {
+  return mount(field.dataListItemComponent(), {
+    props: { value },
+    global: {
+      provide: {
+        [DataListStateKey]: { labelWidth: computed(() => '100px') }
+      }
+    }
+  })
+}
+
+describe('blocks/lens/fields/SelectField', () => {
+  describe('dataListItemComponent', () => {
+    it('renders only the exact option label for a single value', () => {
+      const wrapper = mountDataListItem(make(), 'foobar')
+
+      expect(wrapper.text()).toContain('Second')
+      expect(wrapper.text()).not.toContain('First')
+    })
+  })
+})


### PR DESCRIPTION
When two options have overlapping values, e.g. `Proceed` and `NotProceed`, the sheet will render both labels for a `NotProceed` value.

This updates select label resolution so single values are normalized before option lookup, matching only the exact selected option. A regression test covers overlapping option values.