### PR TITLE
fix(lens): key selection by record identity on read-only catalogs

### DIFF
--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -74,6 +74,11 @@ export interface Props {
   // normally. The value remains accessible via `record[indexField]` in
   // `cell-clicked` events and through the `selected` model regardless.
   //
+  // When omitted, the identifier defaults to `id`, and the `selected`
+  // model is keyed by it on any catalog — editable or not — whenever the
+  // loaded rows carry it (server-default selects typically do). Only rows
+  // without the identifier fall back to positional selection keys.
+  //
   // If the caller's `select` is empty or `null` (i.e. "use server
   // defaults"), the index field is **not** auto-appended — that would
   // narrow the result to just that single column on backends that treat
@@ -584,33 +589,59 @@ const tableSelect = computed(() => {
 const idField = computed(() => props.indexField ?? 'id')
 
 // Whether the currently loaded rows actually carry the effective row identifier.
-// Editing / opening a row needs it (`resolveId`), but rows fetched while
-// `editable` was still false — or before an `indexField` change settled — won't
-// have it until the triggered refetch lands. Editing is gated on this (see the
-// `editable` getter) so a quick save in that window can't post `id: undefined`.
-// An empty result has nothing to edit, so it doesn't block.
+// Editing / opening a row needs it (`resolveId`), and the table's selection key
+// only switches onto it when present (`tableIndexField` below). Rows fetched
+// while `editable` was still false — or before an `indexField` change settled —
+// won't have it until the triggered refetch lands. Editing is gated on this (see
+// the `editable` getter) so a quick save in that window can't post
+// `id: undefined`. An empty result has nothing to edit or select, so it
+// doesn't block.
 const rowsCarryIndexField = computed(() => {
   const rows = result.value?.data
   if (!rows || rows.length === 0) { return true }
   return idField.value in rows[0]
 })
 
-// The row-identifier the table uses as its selection key. An explicit
-// `indexField`, or `id` for editable catalogs (which always carry it). Without
-// this, an editable catalog that relies on the default would leave the table on
-// positional selection keys, so an optimistic create/delete that shifts rows
-// would leave `selected` pointing at the wrong records. Mirrors `edit.indexField`.
+// The row-identifier the table uses as its selection key: the effective
+// `idField`, on any catalog whose loaded rows carry it. Without this, a catalog
+// relying on the default `id` would leave the table on positional selection
+// keys, so anything that shifts rows — an optimistic create/delete, a page
+// change, a re-sort, a refresh-banner apply — would leave `selected` pointing
+// at the wrong records. Editable or not: a read-only catalog with
+// `v-model:selected` (a picker dialog, say) needs identity keys just as much,
+// and a server-default select typically already carries `id`. Mirrors
+// `edit.indexField`.
 //
-// Gated on `rowsCarryIndexField`: when `editable` flips true (or `indexField`
-// changes) the on-screen rows don't carry the new key until the triggered refetch
-// lands. Switching STable onto it during that window keys every row's selection to
-// `undefined` — wiping the current selection and making any row-select emit
-// `[undefined]` (so parent bulk actions act on no/wrong records). Stay on the
-// previous positional key until the loaded rows carry it, matching the
-// `edit.editable` gate so selection and editing flip together.
+// Gated on `rowsCarryIndexField`: while the loaded rows don't carry the key —
+// an explicit `select` that omits it, or an `indexField` change (on an editable
+// catalog the triggered refetch below brings the new key in; a read-only
+// catalog stays positional until a fetch happens to include it) — switching
+// STable onto it would key every row's selection to `undefined`, wiping the
+// current selection and making any row-select emit `[undefined]` (so parent
+// bulk actions act on no/wrong records). Stay on the positional key until the
+// loaded rows carry it.
 const tableIndexField = computed(() => {
-  const field = props.indexField ?? (props.editable ? 'id' : undefined)
-  return field && rowsCarryIndexField.value ? field : undefined
+  return rowsCarryIndexField.value ? idField.value : undefined
+})
+
+// `selected` keys live in `tableIndexField`'s domain — record identity vs row
+// position. If that domain changes while rows are on screen (a view change
+// dropping the identifier column, one re-adding it, a runtime `indexField`
+// swap), the held keys mean nothing under the new domain — but STable's
+// selection pruning keeps any that happen to *collide* with it (a numeric id
+// surviving as a row position, or vice versa), silently re-pointing the
+// selection at wrong rows for the parent's bulk actions. Clear it instead.
+//
+// A flip settling on a fetch that follows an empty table (`hadRows` false —
+// first load, or a filter state with no matches) doesn't count: nothing was
+// selectable under the previous domain, so anything already in `selected` is a
+// parent-provided seed targeting the domain being settled, and must survive it.
+let hadRows = false
+watch([tableIndexField, () => result.value?.data], ([field], [prevField]) => {
+  if (field !== prevField && hadRows && selected.value?.length) {
+    selected.value = []
+  }
+  hadRows = (result.value?.data?.length ?? 0) > 0
 })
 
 // The `indexField` is appended to the request `select` so the server
@@ -622,10 +653,16 @@ const tableIndexField = computed(() => {
 //
 // Editable catalogs must carry a row identifier so updates / deletes can
 // address each row; when no `indexField` is configured the identifier
-// defaults to `id`. When the caller has no concrete select list, nothing
-// is added either — leaving the request empty lets the server use its own
-// defaults (which include `id`, so the read-only sheet still opens). See
-// `indexField` prop docs above.
+// defaults to `id`. Read-only catalogs get no *default* identifier appended
+// (an explicit `indexField` is always included, per its prop doc): the
+// selection key (`tableIndexField` above) is opportunistic — it keys by the
+// identifier when the rows already carry it (server defaults typically
+// include `id`) and stays positional when an explicit `select` omits it,
+// rather than growing every read-only request by an extra column. When the
+// caller has no concrete select list, nothing is added either — leaving the
+// request empty lets the server use its own defaults (which typically
+// include `id`, so the read-only sheet still opens). See `indexField` prop
+// docs above.
 function withIndexField(fields: string[]): string[] {
   if (fields.length === 0) { return [] }
   const field = props.indexField ?? (props.editable ? 'id' : null)

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -236,9 +236,10 @@ const table = useTable({
   orders,
   columns,
   // A getter (not a snapshot) so the selection key stays reactive: `indexField`
-  // can change after mount — e.g. an editable catalog resolves permissions async
-  // and flips from positional keys to `id`. STable reads this inside a computed,
-  // so the getter establishes the dependency and selection re-keys correctly.
+  // can change after mount — e.g. rows landing without the identifier flip the
+  // catalog from identity keys back to positional, and an `indexField` change
+  // settling re-keys it. STable reads this inside a computed, so the getter
+  // establishes the dependency and selection re-keys correctly.
   get indexField() { return props.indexField },
   borderless: true
 })


### PR DESCRIPTION
## What

`LensCatalog`'s selection key (`tableIndexField`, passed to `STable` as `index-field`) defaulted to `id` **only when the catalog was `editable`**. A read-only catalog relying on defaults keyed `v-model:selected` by row *position* — so anything that shifted rows (a page change, a re-sort, a refresh-banner apply) silently left the selection pointing at the wrong records.

## Behavior

- Selection is now keyed by the effective identifier (`indexField`, defaulting to `id`) on **any** catalog whose loaded rows carry it, editable or not. A read-only picker dialog with `v-model:selected` gets identity keys out of the box.
- Rows without the identifier — an explicit `select` that omits it — keep the positional fallback, exactly as before.
- **No request payloads change**: the identifier is still only auto-appended to the request `select` for editable catalogs (or an explicit `indexField`). Read-only catalogs use what the rows already carry — server-default selects typically include `id`.
- **New guard**: since a read-only catalog can now lose or gain the key mid-session (a view change dropping the identifier column, one re-adding it, a runtime `indexField` swap), the selection is cleared when the key domain flips (identity ↔ positional) over loaded rows. Without this, `STable`'s selection pruning keeps held keys that happen to *collide* with the new domain — a numeric id surviving as a row position — silently re-pointing the selection for the parent's bulk actions. Parent-provided seeds survive first-fetch settling: the flip only counts after rows were actually on screen.

## Compatibility

- Catalogs passing an explicit `index-field` (or using positional keys knowingly on id-less selects): unchanged.
- Editable catalogs: expression-equivalent to the old code — no behavior change beyond the new guard, which also protects them (the same collision window previously existed when `editable` flipped async over an explicit-select catalog).
- Consumers that relied on positional `selected` values on a default-select read-only catalog will now receive id values — the intended fix.

## Verification

Verified by mounting the real `STable` under a parent replicating the catalog's wiring: without the guard, selecting id `2` and then landing id-less rows leaves `selected = [2]` re-interpreted as row position 2 (the bug); with the guard, the selection clears and no emission ever carries the stale key (the guard is a pre-flush parent watcher, so the child's prune always sees the already-cleared model). Seed-preservation, pagination (key unchanged → selection retained), runtime `indexField` swaps, and the empty-page corner (degrades to pre-fix behavior, nothing worse) were each probed through the exact reactive graph. `vue-tsc`, ESLint, and the vitest lens suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)