### PR TITLE
feat(lens): trust the definition for the input blank

### DIFF
--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -61,6 +61,16 @@ export interface FieldDataBase {
   showOnDetail?: boolean
   showOnCreate?: boolean
   showOnUpdate?: boolean
+  /**
+   * The server-declared blank for the field's input, as a wire-format
+   * payload value — the server owns this entirely: types whose blank isn't
+   * null (a multiple select's `[]`) declare it here, and an entity may set
+   * its own (e.g. `'draft'` for a status select). Feeds `inputEmptyValue`:
+   * the create form seeds from it, and an editor opening on a null stored
+   * value falls back to it. Null or absent (backends predating the key)
+   * means a null blank.
+   */
+  emptyValue?: any
 }
 
 export interface AvatarFieldData extends FieldDataBase {

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -94,9 +94,6 @@ const { validation, validate, reset } = useValidation(
 const formEl = ref<HTMLElement | null>(null)
 
 function start() {
-  // `inputEmptyValue()` is already input-format (the definition's blank runs
-  // through `payloadToInput` inside it), so only a real stored value converts —
-  // re-converting the blank would double-run non-idempotent converters.
   const raw = props.record[props.fieldKey]
   model.value = raw != null ? props.field.payloadToInput(raw) : props.field.inputEmptyValue()
   reset()

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -94,8 +94,11 @@ const { validation, validate, reset } = useValidation(
 const formEl = ref<HTMLElement | null>(null)
 
 function start() {
+  // `inputEmptyValue()` is already input-format (the definition's blank runs
+  // through `payloadToInput` inside it), so only a real stored value converts —
+  // re-converting the blank would double-run non-idempotent converters.
   const raw = props.record[props.fieldKey]
-  model.value = props.field.payloadToInput(raw ?? props.field.inputEmptyValue())
+  model.value = raw != null ? props.field.payloadToInput(raw) : props.field.inputEmptyValue()
   reset()
   editing.value = true
   // Focus the input on open (matching the inline table editor): better UX, and

--- a/lib/blocks/lens/components/LensTableAvatarCell.vue
+++ b/lib/blocks/lens/components/LensTableAvatarCell.vue
@@ -193,8 +193,6 @@ function startNames() {
     return
   }
   for (const entry of nameEntries.value) {
-    // `inputEmptyValue()` is already input-format; only a real stored value
-    // converts (see LensSheetField for the same split).
     const raw = props.record[entry.key]
     nameModel[entry.key] = raw != null ? entry.field.payloadToInput(raw) : entry.field.inputEmptyValue()
   }

--- a/lib/blocks/lens/components/LensTableAvatarCell.vue
+++ b/lib/blocks/lens/components/LensTableAvatarCell.vue
@@ -193,7 +193,10 @@ function startNames() {
     return
   }
   for (const entry of nameEntries.value) {
-    nameModel[entry.key] = entry.field.payloadToInput(props.record[entry.key] ?? entry.field.inputEmptyValue())
+    // `inputEmptyValue()` is already input-format; only a real stored value
+    // converts (see LensSheetField for the same split).
+    const raw = props.record[entry.key]
+    nameModel[entry.key] = raw != null ? entry.field.payloadToInput(raw) : entry.field.inputEmptyValue()
   }
   reset()
   inline?.start(myKey.value)

--- a/lib/blocks/lens/components/LensTableEditableCell.vue
+++ b/lib/blocks/lens/components/LensTableEditableCell.vue
@@ -156,7 +156,11 @@ function start() {
   }
 
   inputComponent.value = props.field.formInputComponent()
-  model.value = props.field.payloadToInput(props.value ?? props.field.inputEmptyValue())
+  // `inputEmptyValue()` is already input-format; only a real cell value
+  // converts (see LensSheetField for the same split).
+  model.value = props.value != null
+    ? props.field.payloadToInput(props.value)
+    : props.field.inputEmptyValue()
   reset()
   inline?.start(myKey.value)
   nextTick(() => {

--- a/lib/blocks/lens/components/LensTableEditableCell.vue
+++ b/lib/blocks/lens/components/LensTableEditableCell.vue
@@ -156,11 +156,8 @@ function start() {
   }
 
   inputComponent.value = props.field.formInputComponent()
-  // `inputEmptyValue()` is already input-format; only a real cell value
-  // converts (see LensSheetField for the same split).
-  model.value = props.value != null
-    ? props.field.payloadToInput(props.value)
-    : props.field.inputEmptyValue()
+  const raw = props.value
+  model.value = raw != null ? props.field.payloadToInput(raw) : props.field.inputEmptyValue()
   reset()
   inline?.start(myKey.value)
   nextTick(() => {

--- a/lib/blocks/lens/fields/AvatarField.ts
+++ b/lib/blocks/lens/fields/AvatarField.ts
@@ -56,10 +56,6 @@ export class AvatarField extends Field<AvatarFieldData> {
     return false
   }
 
-  override inputEmptyValue(): any {
-    return null
-  }
-
   override formInputComponent(): any {
     return this.defineFormInputComponent((props, { emit }) => {
       return () => h(LensInputAvatar, {

--- a/lib/blocks/lens/fields/Field.ts
+++ b/lib/blocks/lens/fields/Field.ts
@@ -255,10 +255,21 @@ export abstract class Field<T extends FieldData> {
   }
 
   /**
-   * Returns the value should be used when the input is empty.
+   * The value an empty input starts from: the definition's `emptyValue`, a
+   * wire-format payload value run through `payloadToInput`. The server owns
+   * the blank entirely — field types with a non-null blank (a multiple
+   * select's `[]`, say) declare it in their definition, so there are no
+   * per-type overrides here. Only null/undefined fall back to a null blank,
+   * so `false` and `0` are real values.
+   *
+   * Feeds the create-form seeding and the editors' null fallback alike, so
+   * a non-blank `emptyValue` also pre-fills the editor of a record whose
+   * stored value is null.
    */
   inputEmptyValue(): any {
-    return null
+    return this.data.emptyValue != null
+      ? this.payloadToInput(this.data.emptyValue)
+      : null
   }
 
   /**

--- a/lib/blocks/lens/fields/FileUploadField.ts
+++ b/lib/blocks/lens/fields/FileUploadField.ts
@@ -49,10 +49,6 @@ export class FileUploadField extends Field<FileUploadFieldData> {
     })
   }
 
-  override inputEmptyValue(): any {
-    return []
-  }
-
   override formInputComponent(): any {
     return this.defineFormInputComponent((props, { emit }) => {
       return () => h(SInputFileUpload, {

--- a/lib/blocks/lens/fields/SelectField.ts
+++ b/lib/blocks/lens/fields/SelectField.ts
@@ -150,10 +150,6 @@ export class SelectField extends Field<SelectFieldData> {
     return this.optionsForValues(value).map((o) => this.labelForOption(o)).join(', ')
   }
 
-  override inputEmptyValue(): any {
-    return this.data.multiple ? [] : null
-  }
-
   override formInputComponent(): any {
     switch (this.data.inputAs) {
       case 'dropdown':

--- a/tests/blocks/lens/fields/BooleanField.spec.ts
+++ b/tests/blocks/lens/fields/BooleanField.spec.ts
@@ -133,4 +133,12 @@ describe('blocks/lens/fields/BooleanField', () => {
       expect(() => make().dataListItemComponent()).not.toThrow()
     })
   })
+
+  describe('inputEmptyValue', () => {
+    it('starts from a falsy server-declared emptyValue instead of falling back', () => {
+      // Only null/undefined defer to the type blank — `false` is a real seed.
+      expect(make({ emptyValue: false }).inputEmptyValue()).toBe(false)
+      expect(make().inputEmptyValue()).toBeNull()
+    })
+  })
 })

--- a/tests/blocks/lens/fields/DateField.spec.ts
+++ b/tests/blocks/lens/fields/DateField.spec.ts
@@ -1,0 +1,45 @@
+import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
+import { type DateFieldData } from 'sefirot/blocks/lens/FieldData'
+import { DateField } from 'sefirot/blocks/lens/fields/DateField'
+import { day } from 'sefirot/support/Day'
+
+function ctx(lang: 'en' | 'ja' = 'en'): FieldContext {
+  return { lang }
+}
+
+function make(overrides: Partial<DateFieldData> = {}): DateField {
+  const data: DateFieldData = {
+    type: 'date',
+    key: 'published_at',
+    labelEn: 'Published at',
+    labelJa: '公開日',
+    filterKey: 'published_at',
+    sortable: true,
+    freeze: false,
+    width: 0,
+    required: false,
+    rules: [],
+    placeholderEn: null,
+    placeholderJa: null,
+    helpEn: null,
+    helpJa: null,
+    ...overrides
+  }
+  return new DateField(ctx(), data)
+}
+
+describe('blocks/lens/fields/DateField', () => {
+  describe('inputEmptyValue', () => {
+    it('stays null with no declared emptyValue', () => {
+      // Guards the payloadToInput(undefined) drift: `day(undefined)` is *now*,
+      // so a careless fallback rewrite would seed create forms with today.
+      expect(make().inputEmptyValue()).toBeNull()
+    })
+
+    it('converts a wire-format date seed to the Day the input expects', () => {
+      const seeded = make({ emptyValue: '2026-01-15' }).inputEmptyValue()
+
+      expect(day('2026-01-15').isSame(seeded, 'day')).toBe(true)
+    })
+  })
+})

--- a/tests/blocks/lens/fields/SelectField.spec.ts
+++ b/tests/blocks/lens/fields/SelectField.spec.ts
@@ -74,4 +74,18 @@ describe('blocks/lens/fields/SelectField', () => {
       expect(wrapper.text()).not.toContain('First')
     })
   })
+
+  describe('inputEmptyValue', () => {
+    it('trusts the definition for the blank — the server owns it', () => {
+      // A multiple select's definition carries `emptyValue: []`; without a
+      // declared value the blank is null, with no client-side type fallback.
+      expect(make().inputEmptyValue()).toBeNull()
+      expect(make({ multiple: true, emptyValue: [] }).inputEmptyValue()).toEqual([])
+    })
+
+    it('starts from a server-declared initial value', () => {
+      expect(make({ emptyValue: 'foobar' }).inputEmptyValue()).toBe('foobar')
+      expect(make({ multiple: true, emptyValue: ['foo'] }).inputEmptyValue()).toEqual(['foo'])
+    })
+  })
 })


### PR DESCRIPTION
## What

Field definitions may now carry **`emptyValue`** — the blank an empty input starts from, as a wire-format payload value. `inputEmptyValue()` reads it through `payloadToInput` (so e.g. a date-string blank becomes the `Day` the input expects) with **no per-type client fallbacks left**: the server owns the blank entirely, including the multiple-select and file-upload `[]` — their `inputEmptyValue` overrides (and the avatar's) are removed.

```ts
inputEmptyValue(): any {
  return this.data.emptyValue != null
    ? this.payloadToInput(this.data.emptyValue)
    : null
}
```

## Behavior

- Only `null`/`undefined` mean "null blank" — `false` and `0` are real values (pinned by tests).
- The blank feeds both **create-form seeding** and the **editors' null fallback**, so a server-declared initial value (say a status select defaulting to `'draft'`) pre-fills the create form *and* an editor opening on a record whose stored value is null.
- `FieldDataBase.emptyValue?: any` is optional, so definitions predating the key stay type-valid — they fall back to null blanks. Note that means a backend that doesn't serialize the key gives multiple selects / file pickers a `null` model instead of `[]`: this release effectively expects definitions to carry the blank.

## Tests

New/updated specs: select trusts the wire (`emptyValue: []` for multiple, no client-side type fallback), server-declared seeds, the falsy-seed case (`false` must seed, not fall back), and a DateField drift guard (`day(undefined)` is *now* — a careless fallback rewrite would seed date inputs with today). `vue-tsc`, ESLint, and the lens vitest suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)