### PR TITLE
feat(lens): follow-ups for sheet inline editing

### DIFF
--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -14,6 +14,7 @@ import { type FieldData } from '../FieldData'
 import { type LensCreateExtension } from '../LensCreateExtension'
 import { useFieldFactory } from '../composables/FieldFactory'
 import { useLensEdit } from '../composables/LensEdit'
+import { provideLensInlineEdit } from '../composables/LensInlineEdit'
 import { extractServerErrors, extractServerMessage } from '../validation/ServerErrors'
 import LensSheetAvatarField from './LensSheetAvatarField.vue'
 import LensSheetField from './LensSheetField.vue'
@@ -65,6 +66,11 @@ const { t } = useTrans({
 const edit = useLensEdit()
 const factory = useFieldFactory()
 const snackbars = useSnackbars()
+
+// One field editor open at a time across the sheet: fields derive their
+// `editing` state from this shared context (mirroring the table's inline
+// cells), so opening an editor closes any other.
+provideLensInlineEdit()
 
 // Provide the data-list label width directly (instead of wrapping rows in
 // SDataList) so each LensSheetField wrapper doesn't make its SDataListItem a

--- a/lib/blocks/lens/components/LensSheetField.vue
+++ b/lib/blocks/lens/components/LensSheetField.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import IconArrowBendDownLeft from '~icons/ph/arrow-bend-down-left'
-import IconCommand from '~icons/ph/command'
-import IconControl from '~icons/ph/control'
+import IconChevronUp from '~icons/lucide/chevron-up'
+import IconCommand from '~icons/lucide/command'
+import IconCornerDownLeft from '~icons/lucide/corner-down-left'
 import IconPencilSimple from '~icons/ph/pencil-simple'
-import { type Component, computed, nextTick, ref, watch } from 'vue'
+import { type Component, computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import SButton from '../../../components/SButton.vue'
 import SDataListItem from '../../../components/SDataListItem.vue'
 import { useTrans } from '../../../composables/Lang'
@@ -16,6 +16,7 @@ import {
 } from '../../../support/Dom'
 import { type FieldData } from '../FieldData'
 import { useLensEdit } from '../composables/LensEdit'
+import { useLensInlineEdit } from '../composables/LensInlineEdit'
 import { type Field } from '../fields/Field'
 
 const props = defineProps<{
@@ -79,20 +80,40 @@ const canEdit = computed(() =>
   && props.field.supportsOptimisticUpdate()
 )
 
-const editing = ref(false)
+// The editor's visible label. The input's own label — the one that carries the
+// required marker — is visually hidden (the row label stands in for it), so
+// re-attach the marker here.
+const editorLabel = computed(() =>
+  (props.field as any).data?.required ? `${props.field.label()} *` : props.field.label()
+)
+
+// One sheet editor open at a time: `editing` derives from the sheet-scoped
+// inline-edit context (provided by LensSheet), so opening another field's
+// editor closes this one — mirroring the table's inline cells.
+const inline = useLensInlineEdit()
+const editing = computed(() => inline?.activeKey.value === props.fieldKey)
 const model = ref<any>(null)
 const activeEditorTarget = ref<EventTarget | null>(null)
+
+// The sheet can close (or flip to create mode) while an editor is open; the
+// field unmounts but the shared key would survive and reopen this field's
+// editor on the next mount. Release it if it's still ours.
+onUnmounted(() => {
+  if (editing.value) {
+    inline?.stop()
+  }
+})
 
 // If the backing record is replaced/rebound while this editor is open (the
 // refresh banner, a parent `refresh()`, or a `/show` merge filling detail keys),
 // the `model` captured in `start()` is stale; applying it would overwrite the
 // freshly bound value. Close the editor so the user re-opens against the current
-// value. Our own optimistic save also mutates this value, but `apply()` sets
-// `editing = false` synchronously right after, so this async watcher sees it
-// already closed; user typing only touches the local `model`, never the record.
+// value. Our own optimistic save also mutates this value, but `apply()` stops
+// the edit synchronously right after, so this async watcher sees it already
+// closed; user typing only touches the local `model`, never the record.
 watch(
   () => props.record[props.fieldKey],
-  () => { if (editing.value) { editing.value = false } }
+  () => { if (editing.value) { inline?.stop() } }
 )
 
 const { validation, validate, reset } = useValidation(
@@ -102,21 +123,28 @@ const { validation, validate, reset } = useValidation(
 
 const formEl = ref<HTMLElement | null>(null)
 
-const submitShortcut = computed(() => editorSubmitShortcutForTarget(activeEditorTarget.value))
+// No hint while nothing inside the form is focused (e.g. a radio-group editor,
+// whose options aren't keyboard-focusable): keydowns don't route through the
+// form then, so no shortcut would actually work.
+const submitShortcut = computed(() =>
+  activeEditorTarget.value ? editorSubmitShortcutForTarget(activeEditorTarget.value) : null
+)
 const submitShortcutModifierIcon = computed<Component | null>(() => {
   return submitShortcut.value === 'command-enter'
     ? IconCommand
     : submitShortcut.value === 'control-enter'
-      ? IconControl
+      ? IconChevronUp
       : null
 })
-const submitShortcutLabel = computed(() => shortcutLabel(submitShortcut.value))
+const submitShortcutLabel = computed(() =>
+  submitShortcut.value ? shortcutLabel(submitShortcut.value) : null
+)
 
 function start() {
   const raw = props.record[props.fieldKey]
   model.value = raw != null ? props.field.payloadToInput(raw) : props.field.inputEmptyValue()
   reset()
-  editing.value = true
+  inline?.start(props.fieldKey)
   // Focus the input on open (matching the inline table editor): better UX, and
   // it routes the editor's keydowns — notably Escape — through the form handler
   // so Escape cancels the edit rather than closing the sheet.
@@ -127,7 +155,7 @@ function start() {
 }
 
 function cancel() {
-  editing.value = false
+  inline?.stop()
 }
 
 async function apply() {
@@ -154,7 +182,11 @@ async function apply() {
   // is open (e.g. a refresh marks it locked). Re-check before persisting so an
   // already-open editor can't save a row the policy now rejects.
   if (!canEdit.value) {
-    editing.value = false
+    // Only release the shared key if it's still ours: another field's editor
+    // may have opened during the awaited validation above.
+    if (editing.value) {
+      inline?.stop()
+    }
     return
   }
 
@@ -162,7 +194,9 @@ async function apply() {
   edit!.save(props.record, {
     [props.fieldKey]: props.field.inputToPayload(model.value)
   })
-  editing.value = false
+  if (editing.value) {
+    inline?.stop()
+  }
 }
 
 function onEditorKeydown(event: KeyboardEvent) {
@@ -177,6 +211,15 @@ function onEditorFocusin(event: FocusEvent) {
   }
 
   activeEditorTarget.value = event.target
+}
+
+function onEditorFocusout(event: FocusEvent) {
+  // Focus moving within the form (including onto the action buttons) keeps the
+  // hint stable; focus leaving the editor entirely clears it, so the hint can't
+  // keep advertising a control that's no longer focused.
+  if (!(event.relatedTarget instanceof HTMLElement && formEl.value?.contains(event.relatedTarget))) {
+    activeEditorTarget.value = null
+  }
 }
 
 function syncActiveEditorTarget() {
@@ -222,9 +265,16 @@ function shortcutLabel(shortcut: EditorSubmitShortcut): string {
       </button>
     </div>
 
-    <div v-else ref="formEl" class="form" @keydown="onEditorKeydown" @focusin="onEditorFocusin">
+    <div
+      v-else
+      ref="formEl"
+      class="form"
+      @keydown="onEditorKeydown"
+      @focusin="onEditorFocusin"
+      @focusout="onEditorFocusout"
+    >
       <SDataListItem>
-        <template #label>{{ field.label() }}</template>
+        <template #label>{{ editorLabel }}</template>
         <template #value>
           <div class="editor">
             <div class="editor-input">
@@ -237,25 +287,22 @@ function shortcutLabel(shortcut: EditorSubmitShortcut): string {
             </div>
             <div class="actions">
               <SButton size="mini" :label="t.cancel" @click="cancel" />
-              <button
-                class="apply-action"
-                type="button"
-                :aria-label="`${t.apply} (${submitShortcutLabel})`"
-                @click="apply"
-              >
+              <SButton size="mini" mode="info" @click="apply">
                 <span class="apply-content">
-                  <span class="apply-label">{{ t.apply }}</span>
-                  <span class="shortcut" :title="submitShortcutLabel" aria-hidden="true">
-                    <component
-                      :is="submitShortcutModifierIcon"
-                      v-if="submitShortcutModifierIcon"
-                      class="shortcut-icon"
-                    />
-                    <span v-if="submitShortcutModifierIcon" class="shortcut-plus">+</span>
-                    <IconArrowBendDownLeft class="shortcut-icon" />
-                  </span>
+                  <span>{{ t.apply }}</span>
+                  <template v-if="submitShortcut">
+                    <span class="visually-hidden">({{ submitShortcutLabel }})</span>
+                    <span class="shortcut" :title="submitShortcutLabel ?? undefined" aria-hidden="true">
+                      <component
+                        :is="submitShortcutModifierIcon"
+                        v-if="submitShortcutModifierIcon"
+                        class="shortcut-icon"
+                      />
+                      <IconCornerDownLeft class="shortcut-icon" />
+                    </span>
+                  </template>
                 </span>
-              </button>
+              </SButton>
             </div>
           </div>
         </template>
@@ -279,14 +326,17 @@ function shortcutLabel(shortcut: EditorSubmitShortcut): string {
   isolation: isolate;
 }
 
-.display :deep(.value),
-.display :deep(.empty) {
+/* Scope the hover chrome to the data-list row's own cell: display renderers
+   can nest their own `.value` (e.g. `SDescPill`), which must not grow a second
+   hover border. */
+.display :deep(.SDataListItem > .content > .value),
+.display :deep(.SDataListItem > .content > .empty) {
   position: relative;
   z-index: 0;
 }
 
-.LensSheetField.is-editable .display :deep(.value)::before,
-.LensSheetField.is-editable .display :deep(.empty)::before {
+.LensSheetField.is-editable .display :deep(.SDataListItem > .content > .value)::before,
+.LensSheetField.is-editable .display :deep(.SDataListItem > .content > .empty)::before {
   content: "";
   position: absolute;
   inset: -6px 0 -6px -16px;
@@ -300,8 +350,8 @@ function shortcutLabel(shortcut: EditorSubmitShortcut): string {
   transition: opacity 0.1s;
 }
 
-.LensSheetField.is-editable:hover .display :deep(.value)::before,
-.LensSheetField.is-editable:hover .display :deep(.empty)::before {
+.LensSheetField.is-editable:hover .display :deep(.SDataListItem > .content > .value)::before,
+.LensSheetField.is-editable:hover .display :deep(.SDataListItem > .content > .empty)::before {
   opacity: 1;
 }
 
@@ -316,13 +366,12 @@ function shortcutLabel(shortcut: EditorSubmitShortcut): string {
   width: 32px;
   height: 32px;
   transform: translateY(-50%);
-  border: 1px solid var(--input-border-color);
   border-radius: 8px;
   color: var(--c-text-2);
   background-color: var(--c-bg-1);
   box-shadow: var(--shadow-depth-1);
   opacity: 0;
-  transition: opacity 0.1s, border-color 0.1s, background-color 0.1s, color 0.1s;
+  transition: opacity 0.1s, background-color 0.1s, color 0.1s;
 }
 
 .LensSheetField.is-editable:hover .edit {
@@ -330,7 +379,6 @@ function shortcutLabel(shortcut: EditorSubmitShortcut): string {
 }
 
 .edit:hover {
-  border-color: var(--input-hover-border-color);
   background-color: var(--c-bg-mute-1);
   color: var(--c-text-1);
 }
@@ -362,8 +410,22 @@ function shortcutLabel(shortcut: EditorSubmitShortcut): string {
   padding: 8px;
 }
 
-.editor-input :deep(.SInputBase > .label) {
-  display: none;
+/* Visually hidden but kept in the accessibility tree (`display: none` would
+   drop it): the input's own label keeps naming the input for screen readers
+   while the row label stands in for it visually, and the shortcut text keeps
+   reaching screen readers alongside the icon-only hint. */
+.editor-input :deep(.SInputBase > .label),
+.visually-hidden {
+  position: absolute;
+  margin: -1px;
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  min-height: 0;
+  border: 0;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .actions {
@@ -376,76 +438,24 @@ function shortcutLabel(shortcut: EditorSubmitShortcut): string {
   border-top: 1px solid var(--c-divider);
 }
 
-.apply-action {
-  --button-border-color: var(--button-fill-info-border-color);
-  --button-text-color: var(--button-fill-info-text-color);
-  --button-content-color: var(--button-fill-info-content-color);
-  --button-bg-color: var(--button-fill-info-bg-color);
-  --button-hover-border-color: var(--button-fill-info-hover-border-color);
-  --button-hover-text-color: var(--button-fill-info-hover-text-color);
-  --button-hover-bg-color: var(--button-fill-info-hover-bg-color);
-  --button-active-border-color: var(--button-fill-info-active-border-color);
-  --button-active-text-color: var(--button-fill-info-active-text-color);
-  --button-active-bg-color: var(--button-fill-info-active-bg-color);
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 10px;
-  min-width: 28px;
-  min-height: 28px;
-  border: 1px solid var(--button-border-color);
-  border-radius: 8px;
-  color: var(--button-text-color);
-  background-color: var(--button-bg-color);
-  font-size: var(--button-font-size, var(--button-mini-font-size));
-  font-weight: 500;
-  line-height: normal;
-  letter-spacing: 0;
-  text-align: center;
-  white-space: nowrap;
-  transition: color 0.25s, border-color 0.25s, background-color 0.25s;
-}
-
-.apply-action:hover {
-  border-color: var(--button-hover-border-color);
-  color: var(--button-hover-text-color);
-  background-color: var(--button-hover-bg-color);
-}
-
-.apply-action:active {
-  border-color: var(--button-active-border-color);
-  color: var(--button-active-text-color);
-  background-color: var(--button-active-bg-color);
-}
-
 .apply-content {
   display: inline-flex;
   align-items: center;
-  height: 100%;
   gap: 6px;
-  color: var(--button-content-color);
-}
-
-.apply-label {
-  line-height: 20px;
 }
 
 .shortcut {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
-  color: currentColor;
+  gap: 1px;
+  padding: 2px 3px;
+  border-radius: 5px;
+  background-color: color-mix(in oklab, currentColor 16%, transparent);
 }
 
 .shortcut-icon {
-  width: 16px;
-  height: 16px;
-}
-
-.shortcut-plus {
-  line-height: 16px;
-  font-size: 11px;
-  font-weight: 600;
+  width: 12px;
+  height: 12px;
+  opacity: 0.9;
 }
 </style>

--- a/lib/blocks/lens/composables/LensInlineEdit.ts
+++ b/lib/blocks/lens/composables/LensInlineEdit.ts
@@ -1,14 +1,16 @@
 import { type InjectionKey, type Ref, inject, provide, ref } from 'vue'
 
 /**
- * Tracks which table cell currently has its inline editor open, so that
- * opening one editor closes any other. The key is `${recordId}:${fieldKey}`.
+ * Tracks which inline editor is currently open within the providing scope, so
+ * that opening one editor closes any other. The table provides an instance for
+ * its cells (keyed `${recordId}:${fieldKey}`) and the record sheet provides
+ * its own for its fields (keyed by field key) — the scopes are independent.
  */
 export interface LensInlineEditContext {
-  /** The key of the cell currently being edited, or null. */
+  /** The key of the editor currently open, or null. */
   activeKey: Ref<string | null>
 
-  /** Open the editor for the given cell key (closing any other). */
+  /** Open the editor for the given key (closing any other). */
   start: (key: string) => void
 
   /** Close the active editor. */

--- a/lib/components/SButton.vue
+++ b/lib/components/SButton.vue
@@ -60,11 +60,13 @@ const emit = defineEmits<{
 
 const _leadIcon = computed(() => props.leadIcon ?? props.icon)
 
+const slots = useSlots()
+
 const classes = computed(() => [
   props.size ?? 'medium',
   props.type ?? 'fill',
   props.mode ?? 'default',
-  { 'has-label': !!props.label },
+  { 'has-label': !!props.label || !!slots.default },
   { 'has-lead-icon': !!_leadIcon.value },
   { 'has-trail-icon': !!props.trailIcon },
   { loading: props.loading },
@@ -76,8 +78,6 @@ const classes = computed(() => [
 const computedTag = computed(() => {
   return props.tag ? props.tag : props.href ? SLink : 'button'
 })
-
-const slots = useSlots()
 
 const hasTooltip = computed(() => {
   return !!(
@@ -118,7 +118,8 @@ function onClick(): void {
         <span v-if="_leadIcon" class="icon" :class="iconMode">
           <component :is="_leadIcon" class="icon-svg" />
         </span>
-        <span v-if="label" class="label" :class="labelMode" v-html="label" />
+        <span v-if="$slots.default" class="label" :class="labelMode"><slot /></span>
+        <span v-else-if="label" class="label" :class="labelMode" v-html="label" />
         <span v-if="trailIcon" class="icon" :class="iconMode">
           <component :is="trailIcon" class="icon-svg" />
         </span>

--- a/lib/components/SButton.vue
+++ b/lib/components/SButton.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { type Component, type MaybeRef, computed, unref, useSlots } from 'vue'
 import { type Position } from '../composables/Tooltip'
+import { useHasSlotContent } from '../composables/Utils'
 import { type ColorMode } from '../support/Color'
 import SFragment from './SFragment.vue'
 import SLink from './SLink.vue'
@@ -60,13 +61,15 @@ const emit = defineEmits<{
 
 const _leadIcon = computed(() => props.leadIcon ?? props.icon)
 
-const slots = useSlots()
+// Rendered content, not slot presence: a slot that renders empty falls back
+// to the `label` prop (and an icon-only button keeps its icon-only padding).
+const hasDefaultSlot = useHasSlotContent()
 
 const classes = computed(() => [
   props.size ?? 'medium',
   props.type ?? 'fill',
   props.mode ?? 'default',
-  { 'has-label': !!props.label || !!slots.default },
+  { 'has-label': !!props.label || hasDefaultSlot.value },
   { 'has-lead-icon': !!_leadIcon.value },
   { 'has-trail-icon': !!props.trailIcon },
   { loading: props.loading },
@@ -78,6 +81,8 @@ const classes = computed(() => [
 const computedTag = computed(() => {
   return props.tag ? props.tag : props.href ? SLink : 'button'
 })
+
+const slots = useSlots()
 
 const hasTooltip = computed(() => {
   return !!(
@@ -118,7 +123,7 @@ function onClick(): void {
         <span v-if="_leadIcon" class="icon" :class="iconMode">
           <component :is="_leadIcon" class="icon-svg" />
         </span>
-        <span v-if="$slots.default" class="label" :class="labelMode"><slot /></span>
+        <span v-if="hasDefaultSlot" class="label" :class="labelMode"><slot /></span>
         <span v-else-if="label" class="label" :class="labelMode" v-html="label" />
         <span v-if="trailIcon" class="icon" :class="iconMode">
           <component :is="trailIcon" class="icon-svg" />

--- a/lib/components/SDataListItem.vue
+++ b/lib/components/SDataListItem.vue
@@ -55,15 +55,27 @@ function hasSlotContent(name = 'default'): boolean {
 }
 
 function onValueClick(event: MouseEvent): void {
-  if (!props.valueAction || isInteractiveEventTarget(event.target)) {
+  if (!props.valueAction || isInteractiveClick(event)) {
     return
   }
 
   emit('click:value', event)
 }
 
-function isInteractiveEventTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement && !!target.closest([
+// Whether the click landed on interactive content (a link, button, input, …)
+// inside the cell, which handles the click itself. The `closest()` match is
+// bounded to the cell (`currentTarget`): an interactive *ancestor* of the
+// whole list — a tabindexed scroll container, say — must not swallow every
+// cell click.
+function isInteractiveClick(event: MouseEvent): boolean {
+  const cell = event.currentTarget
+  const target = event.target
+
+  if (!(cell instanceof HTMLElement) || !(target instanceof HTMLElement)) {
+    return false
+  }
+
+  const interactive = target.closest([
     'a',
     'button',
     'input',
@@ -77,6 +89,8 @@ function isInteractiveEventTarget(target: EventTarget | null): boolean {
     '[role="switch"]',
     '[tabindex]:not([tabindex="-1"])'
   ].join(','))
+
+  return !!interactive && cell.contains(interactive)
 }
 </script>
 

--- a/lib/components/SDropdownSectionFilter.vue
+++ b/lib/components/SDropdownSectionFilter.vue
@@ -28,6 +28,7 @@ const { t } = useTrans({
 })
 
 const input = ref<HTMLElement | null>(null)
+const list = ref<HTMLUListElement | null>(null)
 const query = ref('')
 
 const enabledOptions = computed(() => {
@@ -53,8 +54,16 @@ function isActive(value: any) {
   return Array.isArray(selected) ? selected.includes(value) : selected === value
 }
 
+// Move focus from the search input into the first option (ArrowDown from the
+// search field).
+function focusFirstOption() {
+  list.value?.querySelector<HTMLElement>('.button')?.focus()
+}
+
 function focusPrev(event: any) {
-  event.target.parentNode.previousElementSibling?.firstElementChild?.focus()
+  // ArrowUp from the first option returns focus to the search input (if any).
+  const prev = event.target.parentNode.previousElementSibling?.firstElementChild
+  prev ? prev.focus() : input.value?.focus()
 }
 
 function focusNext(event: any) {
@@ -70,12 +79,23 @@ function onClick(option: DropdownSectionFilterOption, value: any) {
 <template>
   <div class="SDropdownSectionFilter">
     <div v-if="search" class="search">
-      <!-- Keep Enter inside the filter: it drives the dropdown, and must not
-           bubble to an enclosing editor/form as a submit. -->
-      <input ref="input" v-model="query" class="input" :placeholder="t.i_ph" @keydown.enter.stop>
+      <!-- Keep bare Enter inside the filter: it drives the dropdown, and must
+           not bubble to an enclosing editor/form as a submit. Modified Enter
+           (`.exact`) passes through — Cmd/Ctrl+Enter is the universal submit
+           gesture and should reach the editor. ArrowDown moves focus into the
+           option list. -->
+      <input
+        ref="input"
+        v-model="query"
+        class="input"
+        :placeholder="t.i_ph"
+        @keydown.enter.exact.stop.prevent
+        @keydown.down.prevent
+        @keyup.down.prevent="focusFirstOption"
+      >
     </div>
 
-    <ul v-if="filteredOptions.length" class="list">
+    <ul v-if="filteredOptions.length" ref="list" class="list">
       <li v-for="option in filteredOptions" :key="option.label" class="item">
         <button
           class="button"
@@ -153,6 +173,13 @@ function onClick(option: DropdownSectionFilterOption, value: any) {
 
   &:hover {
     background-color: var(--c-bg-mute-1);
+  }
+
+  /* The global reset strips `button:focus` outlines, so keyboard focus
+     (arrowing through the options) needs its own visible ring. */
+  &:focus-visible {
+    outline: 2px solid var(--input-focus-border-color);
+    outline-offset: -2px;
   }
 }
 

--- a/lib/components/SDropdownSectionFilter.vue
+++ b/lib/components/SDropdownSectionFilter.vue
@@ -7,6 +7,7 @@ import {
   type DropdownSectionFilterSelectedValue
 } from '../composables/Dropdown'
 import { useTrans } from '../composables/Lang'
+import { stopNonSubmitEnterKeydown } from '../support/Dom'
 import SDropdownSectionFilterItem from './SDropdownSectionFilterItem.vue'
 
 const props = defineProps<{
@@ -79,17 +80,12 @@ function onClick(option: DropdownSectionFilterOption, value: any) {
 <template>
   <div class="SDropdownSectionFilter">
     <div v-if="search" class="search">
-      <!-- Keep bare Enter inside the filter: it drives the dropdown, and must
-           not bubble to an enclosing editor/form as a submit. Modified Enter
-           (`.exact`) passes through — Cmd/Ctrl+Enter is the universal submit
-           gesture and should reach the editor. ArrowDown moves focus into the
-           option list. -->
       <input
         ref="input"
         v-model="query"
         class="input"
         :placeholder="t.i_ph"
-        @keydown.enter.exact.stop.prevent
+        @keydown.enter="stopNonSubmitEnterKeydown"
         @keydown.down.prevent
         @keyup.down.prevent="focusFirstOption"
       >

--- a/lib/components/SInputAsyncDropdown.vue
+++ b/lib/components/SInputAsyncDropdown.vue
@@ -76,6 +76,7 @@ const { t } = useTrans({
 })
 
 const container = ref<HTMLDivElement>()
+const box = ref<HTMLDivElement | null>(null)
 const input = ref<HTMLInputElement | null>(null)
 const list = ref<HTMLUListElement | null>(null)
 
@@ -209,6 +210,33 @@ function onOpen() {
   nextTick(() => input.value?.focus())
 }
 
+// Clicking (or Enter on) the box toggles the flyout — closing returns focus to
+// the box so keyboard interaction continues from the control instead of
+// falling to `document.body`. ArrowDown stays open-only (see the template).
+function onToggle() {
+  if (isOpen.value) {
+    close()
+    box.value?.focus()
+    return
+  }
+  onOpen()
+}
+
+// Escape while the flyout is open belongs to the flyout: close it and return
+// focus to the box, keeping the keydown from an enclosing surface (an inline
+// editor would cancel, a sheet would close). A closed dropdown leaves Escape
+// to those surfaces. The Escape that cancels an IME composition never
+// operates the flyout.
+function onEscapeKeydown(event: KeyboardEvent) {
+  if (!isOpen.value || event.isComposing) {
+    return
+  }
+  event.stopPropagation()
+  event.preventDefault()
+  close()
+  box.value?.focus()
+}
+
 watch(isOpen, (value) => {
   // On close: drop any pending refetch, invalidate any in-flight fetch (so a late
   // response can't repopulate the list while closed), and clear the query /
@@ -264,8 +292,12 @@ function onSelect(item: T): void {
     commit(null)
   }
 
+  // Return focus to the box on a selection that closes the flyout, so keyboard
+  // interaction (reopening, an editor's submit shortcut) continues from the
+  // control rather than falling to `document.body`.
   if (props.closeOnSelect ?? !props.multiple) {
     close()
+    box.value?.focus()
   }
 }
 
@@ -330,14 +362,15 @@ function focusNext(event: any): void {
     :hide-error
     :hide-warning
   >
-    <div ref="container" class="container">
+    <div ref="container" class="container" @keydown.esc="onEscapeKeydown">
       <div
+        ref="box"
         class="box"
         role="button"
         tabindex="0"
-        @click="onOpen"
+        @click="onToggle"
         @keydown.down.prevent
-        @keyup.enter="onOpen"
+        @keyup.enter="onToggle"
         @keyup.down="onOpen"
       >
         <div class="box-content">
@@ -362,16 +395,18 @@ function focusNext(event: any): void {
       <div v-if="isOpen" class="dropdown" :style="inset">
         <div class="dropdown-content">
           <div class="search">
-            <!-- Keep Enter inside the search field: it drives the dropdown and
-                 must neither bubble to an enclosing form (`.stop`) nor trigger the
-                 browser's implicit form submission (`.prevent`). ArrowDown moves
-                 focus into the option list. -->
+            <!-- Keep bare Enter inside the search field: it drives the dropdown
+                 and must neither bubble to an enclosing editor/form (`.stop`) nor
+                 trigger the browser's implicit form submission (`.prevent`).
+                 Modified Enter (`.exact`) passes through — Cmd/Ctrl+Enter is the
+                 universal submit gesture and should reach the editor. ArrowDown
+                 moves focus into the option list. -->
             <input
               ref="input"
               v-model="query"
               class="search-input"
               :placeholder="t.ph"
-              @keydown.enter.stop.prevent
+              @keydown.enter.exact.stop.prevent
               @keydown.down.prevent
               @keyup.down.prevent="focusFirstOption"
             >
@@ -441,6 +476,13 @@ function focusNext(event: any): void {
 
   &:hover {
     border-color: var(--input-hover-border-color);
+  }
+
+  /* Keyboard focus shows via the border (the input-family idiom), not the
+     UA's default ring. */
+  &:focus-visible {
+    outline: none;
+    border-color: var(--input-focus-border-color);
   }
 }
 
@@ -542,6 +584,13 @@ function focusNext(event: any): void {
 
   &:hover:not(:disabled) {
     background-color: var(--c-bg-mute-1);
+  }
+
+  /* The global reset strips `button:focus` outlines, so keyboard focus
+     (arrowing through the options) needs its own visible ring. */
+  &:focus-visible {
+    outline: 2px solid var(--input-focus-border-color);
+    outline-offset: -2px;
   }
 
   &:disabled {

--- a/lib/components/SInputAsyncDropdown.vue
+++ b/lib/components/SInputAsyncDropdown.vue
@@ -6,6 +6,7 @@ import { type Ref, computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import { useManualDropdownPosition } from '../composables/Dropdown'
 import { useFlyout } from '../composables/Flyout'
 import { useTrans } from '../composables/Lang'
+import { stopNonSubmitEnterKeydown } from '../support/Dom'
 import { type Option } from '../support/InputDropdown'
 import SDropdownSectionFilterItem from './SDropdownSectionFilterItem.vue'
 import SInputBase, { type Props as BaseProps } from './SInputBase.vue'
@@ -212,7 +213,10 @@ function onOpen() {
 
 // Clicking (or Enter on) the box toggles the flyout — closing returns focus to
 // the box so keyboard interaction continues from the control instead of
-// falling to `document.body`. ArrowDown stays open-only (see the template).
+// falling to `document.body`. ArrowDown stays open-only, and the Enter binding
+// is `.exact`: a Cmd/Ctrl+Enter submit starts on keydown, and if the editor
+// stays open (failed validation), the same gesture's keyup must not reopen the
+// flyout (see the template).
 function onToggle() {
   if (isOpen.value) {
     close()
@@ -370,7 +374,7 @@ function focusNext(event: any): void {
         tabindex="0"
         @click="onToggle"
         @keydown.down.prevent
-        @keyup.enter="onToggle"
+        @keyup.enter.exact="onToggle"
         @keyup.down="onOpen"
       >
         <div class="box-content">
@@ -395,18 +399,12 @@ function focusNext(event: any): void {
       <div v-if="isOpen" class="dropdown" :style="inset">
         <div class="dropdown-content">
           <div class="search">
-            <!-- Keep bare Enter inside the search field: it drives the dropdown
-                 and must neither bubble to an enclosing editor/form (`.stop`) nor
-                 trigger the browser's implicit form submission (`.prevent`).
-                 Modified Enter (`.exact`) passes through — Cmd/Ctrl+Enter is the
-                 universal submit gesture and should reach the editor. ArrowDown
-                 moves focus into the option list. -->
             <input
               ref="input"
               v-model="query"
               class="search-input"
               :placeholder="t.ph"
-              @keydown.enter.exact.stop.prevent
+              @keydown.enter="stopNonSubmitEnterKeydown"
               @keydown.down.prevent
               @keyup.down.prevent="focusFirstOption"
             >

--- a/lib/components/SInputAsyncDropdown.vue
+++ b/lib/components/SInputAsyncDropdown.vue
@@ -211,12 +211,9 @@ function onOpen() {
   nextTick(() => input.value?.focus())
 }
 
-// Clicking (or Enter on) the box toggles the flyout — closing returns focus to
-// the box so keyboard interaction continues from the control instead of
-// falling to `document.body`. ArrowDown stays open-only, and the Enter binding
-// is `.exact`: a Cmd/Ctrl+Enter submit starts on keydown, and if the editor
-// stays open (failed validation), the same gesture's keyup must not reopen the
-// flyout (see the template).
+// Clicking (or Enter on — see onEnterToggle) the box toggles the flyout —
+// closing returns focus to the box so keyboard interaction continues from the
+// control instead of falling to `document.body`. ArrowDown stays open-only.
 function onToggle() {
   if (isOpen.value) {
     close()
@@ -224,6 +221,17 @@ function onToggle() {
     return
   }
   onOpen()
+}
+
+// Bare Enter toggles on keydown, not keyup: a Cmd/Ctrl+Enter submit (handled
+// on keydown by an enclosing editor) sheds its modifier before the Enter keyup
+// when the modifier is released first, and that keyup must not reopen the
+// flyout — acting on keydown sidesteps release order entirely. Key repeat is
+// ignored so holding Enter doesn't flap the flyout.
+function onEnterToggle(event: KeyboardEvent) {
+  if (!event.repeat) {
+    onToggle()
+  }
 }
 
 // Escape while the flyout is open belongs to the flyout: close it and return
@@ -374,7 +382,7 @@ function focusNext(event: any): void {
         tabindex="0"
         @click="onToggle"
         @keydown.down.prevent
-        @keyup.enter.exact="onToggle"
+        @keydown.enter.exact="onEnterToggle"
         @keyup.down="onOpen"
       >
         <div class="box-content">

--- a/lib/components/SInputDropdown.vue
+++ b/lib/components/SInputDropdown.vue
@@ -88,7 +88,10 @@ async function onOpen() {
 
 // Clicking (or Enter on) the box toggles the flyout — closing returns focus to
 // the box so keyboard interaction continues from the control instead of
-// falling to `document.body`. ArrowDown stays open-only (see the template).
+// falling to `document.body`. ArrowDown stays open-only, and the Enter binding
+// is `.exact`: a Cmd/Ctrl+Enter submit starts on keydown, and if the editor
+// stays open (failed validation), the same gesture's keyup must not reopen the
+// flyout (see the template).
 function onToggle() {
   if (isOpen.value) {
     close()
@@ -163,7 +166,7 @@ function onSelect(value: T) {
         tabindex="0"
         @click="onToggle"
         @keydown.down.prevent
-        @keyup.enter="onToggle"
+        @keyup.enter.exact="onToggle"
         @keyup.down="onOpen"
       >
         <div class="box-content">

--- a/lib/components/SInputDropdown.vue
+++ b/lib/components/SInputDropdown.vue
@@ -86,12 +86,9 @@ async function onOpen() {
   }
 }
 
-// Clicking (or Enter on) the box toggles the flyout — closing returns focus to
-// the box so keyboard interaction continues from the control instead of
-// falling to `document.body`. ArrowDown stays open-only, and the Enter binding
-// is `.exact`: a Cmd/Ctrl+Enter submit starts on keydown, and if the editor
-// stays open (failed validation), the same gesture's keyup must not reopen the
-// flyout (see the template).
+// Clicking (or Enter on — see onEnterToggle) the box toggles the flyout —
+// closing returns focus to the box so keyboard interaction continues from the
+// control instead of falling to `document.body`. ArrowDown stays open-only.
 function onToggle() {
   if (isOpen.value) {
     close()
@@ -99,6 +96,17 @@ function onToggle() {
     return
   }
   onOpen()
+}
+
+// Bare Enter toggles on keydown, not keyup: a Cmd/Ctrl+Enter submit (handled
+// on keydown by an enclosing editor) sheds its modifier before the Enter keyup
+// when the modifier is released first, and that keyup must not reopen the
+// flyout — acting on keydown sidesteps release order entirely. Key repeat is
+// ignored so holding Enter doesn't flap the flyout.
+function onEnterToggle(event: KeyboardEvent) {
+  if (!event.repeat) {
+    onToggle()
+  }
 }
 
 // Escape while the flyout is open belongs to the flyout: close it and return
@@ -166,7 +174,7 @@ function onSelect(value: T) {
         tabindex="0"
         @click="onToggle"
         @keydown.down.prevent
-        @keyup.enter.exact="onToggle"
+        @keydown.enter.exact="onEnterToggle"
         @keyup.down="onOpen"
       >
         <div class="box-content">

--- a/lib/components/SInputDropdown.vue
+++ b/lib/components/SInputDropdown.vue
@@ -38,6 +38,7 @@ const { t } = useTrans({
 })
 
 const container = ref<HTMLDivElement>()
+const box = ref<HTMLDivElement>()
 
 const { isOpen, open, close } = useFlyout(container)
 const { inset, update: updatePosition } = useManualDropdownPosition(
@@ -85,6 +86,33 @@ async function onOpen() {
   }
 }
 
+// Clicking (or Enter on) the box toggles the flyout — closing returns focus to
+// the box so keyboard interaction continues from the control instead of
+// falling to `document.body`. ArrowDown stays open-only (see the template).
+function onToggle() {
+  if (isOpen.value) {
+    close()
+    box.value?.focus()
+    return
+  }
+  onOpen()
+}
+
+// Escape while the flyout is open belongs to the flyout: close it and return
+// focus to the box, keeping the keydown from an enclosing surface (an inline
+// editor would cancel, a sheet would close). A closed dropdown leaves Escape
+// to those surfaces. The Escape that cancels an IME composition never
+// operates the flyout.
+function onEscapeKeydown(event: KeyboardEvent) {
+  if (!isOpen.value || event.isComposing) {
+    return
+  }
+  event.stopPropagation()
+  event.preventDefault()
+  close()
+  box.value?.focus()
+}
+
 function onSelect(value: T) {
   props.validation?.$touch()
 
@@ -99,7 +127,13 @@ function onSelect(value: T) {
     model.value = null
   }
 
-  props.closeOnClick && close()
+  // Return focus to the box on a selection that closes the flyout, so
+  // keyboard interaction (reopening, an editor's submit shortcut) continues
+  // from the control rather than falling to `document.body`.
+  if (props.closeOnClick) {
+    close()
+    box.value?.focus()
+  }
 }
 </script>
 
@@ -121,14 +155,15 @@ function onSelect(value: T) {
     :hide-error
     :hide-warning
   >
-    <div ref="container" class="container">
+    <div ref="container" class="container" @keydown.esc="onEscapeKeydown">
       <div
+        ref="box"
         class="box"
         role="button"
         tabindex="0"
-        @click="onOpen"
+        @click="onToggle"
         @keydown.down.prevent
-        @keyup.enter="onOpen"
+        @keyup.enter="onToggle"
         @keyup.down="onOpen"
       >
         <div class="box-content">
@@ -181,6 +216,13 @@ function onSelect(value: T) {
 
   &:hover {
     border-color: var(--input-hover-border-color);
+  }
+
+  /* Keyboard focus shows via the border (the input-family idiom), not the
+     UA's default ring. */
+  &:focus-visible {
+    outline: none;
+    border-color: var(--input-focus-border-color);
   }
 }
 

--- a/lib/support/Dom.ts
+++ b/lib/support/Dom.ts
@@ -72,9 +72,14 @@ function currentPlatform(): string {
  * so it is stopped — with its default prevented — unless it carries the
  * universal submit modifier (Cmd/Ctrl, see {@link isEditorSubmitKeydown}).
  * Shift/Alt+Enter are contained too: the editor's submit predicate would read
- * them off a text-like input as a plain submitting Enter.
+ * them off a text-like input as a plain submitting Enter. The Enter that
+ * commits an IME composition belongs to the IME — swallowing its default would
+ * drop the composed text — so it passes untouched (the editor ignores it).
  */
 export function stopNonSubmitEnterKeydown(event: KeyboardEvent): void {
+  if (event.isComposing) {
+    return
+  }
   if (event.key === 'Enter' && !event.metaKey && !event.ctrlKey) {
     event.stopPropagation()
     event.preventDefault()

--- a/lib/support/Dom.ts
+++ b/lib/support/Dom.ts
@@ -24,7 +24,7 @@ export type EditorSubmitShortcut = 'enter' | 'command-enter' | 'control-enter'
  * Plain Enter is truthful only for simple text-like inputs; other controls need
  * the platform's primary modifier to avoid clashing with their own Enter key
  * behavior. A text input nested inside a dropdown (its search filter, see
- * `SDropdownSectionFilter` / `SInputAsyncDropdown`) keeps bare Enter to itself
+ * `SDropdownSectionFilter` / `SInputAsyncDropdown`) keeps Enter to itself
  * too, so only the modifier gesture reaches the editor from there.
  */
 export function editorSubmitShortcutForTarget(
@@ -64,6 +64,21 @@ function currentPlatform(): string {
   const nav = navigator as Navigator & { userAgentData?: { platform?: string } }
 
   return nav.userAgentData?.platform ?? nav.platform ?? ''
+}
+
+/**
+ * Keydown handler for a text input nested inside a dropdown-like control (a
+ * search filter): Enter operates the control, not an enclosing inline editor,
+ * so it is stopped — with its default prevented — unless it carries the
+ * universal submit modifier (Cmd/Ctrl, see {@link isEditorSubmitKeydown}).
+ * Shift/Alt+Enter are contained too: the editor's submit predicate would read
+ * them off a text-like input as a plain submitting Enter.
+ */
+export function stopNonSubmitEnterKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Enter' && !event.metaKey && !event.ctrlKey) {
+    event.stopPropagation()
+    event.preventDefault()
+  }
 }
 
 /**
@@ -114,8 +129,9 @@ export function isEditorCancelKeydown(event: KeyboardEvent): boolean {
  * throw on `formInputComponent()` (not yet editable). When making one editable,
  * if its input is a composite control with its own nested text input (e.g. a
  * dropdown's search filter), that nested input must keep Enter/Escape from
- * bubbling to this handler — see `SDropdownSectionFilter` — otherwise typing a
- * value and pressing Enter would submit/cancel the whole editor.
+ * bubbling to this handler — {@link stopNonSubmitEnterKeydown} is the Enter
+ * half; see `SDropdownSectionFilter` — otherwise typing a value and pressing
+ * Enter would submit/cancel the whole editor.
  */
 export function dispatchEditorKeydown(
   event: KeyboardEvent,

--- a/lib/support/Dom.ts
+++ b/lib/support/Dom.ts
@@ -23,13 +23,18 @@ export type EditorSubmitShortcut = 'enter' | 'command-enter' | 'control-enter'
  * The user-facing shortcut to show for the currently focused editor control.
  * Plain Enter is truthful only for simple text-like inputs; other controls need
  * the platform's primary modifier to avoid clashing with their own Enter key
- * behavior.
+ * behavior. A text input nested inside a dropdown (its search filter, see
+ * `SDropdownSectionFilter` / `SInputAsyncDropdown`) keeps bare Enter to itself
+ * too, so only the modifier gesture reaches the editor from there.
  */
 export function editorSubmitShortcutForTarget(
   target: EventTarget | null,
   platform = currentPlatform()
 ): EditorSubmitShortcut {
-  if (isTextLikeInput(target)) {
+  if (
+    isTextLikeInput(target)
+    && !(target as HTMLElement).closest('.SDropdown, .SInputAsyncDropdown')
+  ) {
     return 'enter'
   }
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "release": "npm whoami >/dev/null 2>&1 || npm login && release-it"
   },
   "dependencies": {
+    "@iconify-json/lucide": "^1.2.116",
     "@iconify-json/ph": "^1.2.2",
     "@iconify-json/ri": "^1.2.10",
     "@popperjs/core": "^2.11.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@iconify-json/lucide':
+        specifier: ^1.2.116
+        version: 1.2.116
       '@iconify-json/ph':
         specifier: ^1.2.2
         version: 1.2.2
@@ -709,6 +712,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify-json/lucide@1.2.116':
+    resolution: {integrity: sha512-mbwPmiUXaZyLMSeQOxiTqz2fmZikD9qiGnMBiev47UUNY9uGCEgMg9iUYwaJzCtJTDtAIyK4vokfIpqsVorgSw==}
 
   '@iconify-json/ph@1.2.2':
     resolution: {integrity: sha512-PgkEZNtqa8hBGjHXQa4pMwZa93hmfu8FUSjs/nv4oUU6yLsgv+gh9nu28Kqi8Fz9CCVu4hj1MZs9/60J57IzFw==}
@@ -5005,6 +5011,10 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify-json/lucide@1.2.116':
+    dependencies:
+      '@iconify/types': 2.0.0
 
   '@iconify-json/ph@1.2.2':
     dependencies:

--- a/tests/components/SButton.spec.ts
+++ b/tests/components/SButton.spec.ts
@@ -44,6 +44,25 @@ describe('components/SButton', () => {
     expect(wrapper.find('.SButton').element.tagName).toBe('DIV')
   })
 
+  it('renders default slot content as the label', () => {
+    const wrapper = mount(SButton, {
+      props: { label: 'Prop label' },
+      slots: { default: '<span class="x">Slot label</span>' }
+    })
+
+    expect(wrapper.find('.label .x').text()).toBe('Slot label')
+    expect(wrapper.find('.SButton').classes()).toContain('has-label')
+  })
+
+  it('falls back to the `label` prop when the slot renders empty', () => {
+    const wrapper = mount(SButton, {
+      props: { label: 'Prop label' },
+      slots: { default: '' }
+    })
+
+    expect(wrapper.find('.label').text()).toBe('Prop label')
+  })
+
   it('emits click event on click', () => {
     const wrapper = mount(SButton)
 

--- a/tests/support/Dom.spec.ts
+++ b/tests/support/Dom.spec.ts
@@ -37,6 +37,36 @@ describe('support/Dom', () => {
     })
   })
 
+  describe('stopNonSubmitEnterKeydown', () => {
+    function enter(init: KeyboardEventInit = {}): KeyboardEvent {
+      return new KeyboardEvent('keydown', { key: 'Enter', cancelable: true, ...init })
+    }
+
+    it('contains Enter without the submit modifier', () => {
+      for (const event of [enter(), enter({ shiftKey: true }), enter({ altKey: true })]) {
+        const stop = vi.spyOn(event, 'stopPropagation')
+        Dom.stopNonSubmitEnterKeydown(event)
+        expect(stop).toHaveBeenCalled()
+        expect(event.defaultPrevented).toBe(true)
+      }
+    })
+
+    it('lets Cmd/Ctrl+Enter pass through to the editor', () => {
+      for (const event of [enter({ metaKey: true }), enter({ ctrlKey: true })]) {
+        const stop = vi.spyOn(event, 'stopPropagation')
+        Dom.stopNonSubmitEnterKeydown(event)
+        expect(stop).not.toHaveBeenCalled()
+        expect(event.defaultPrevented).toBe(false)
+      }
+    })
+
+    it('ignores non-Enter keys', () => {
+      const event = new KeyboardEvent('keydown', { key: 'a', cancelable: true })
+      Dom.stopNonSubmitEnterKeydown(event)
+      expect(event.defaultPrevented).toBe(false)
+    })
+  })
+
   describe('editorSubmitShortcutForTarget', () => {
     it('shows plain Enter for text-like inputs', () => {
       expect(Dom.editorSubmitShortcutForTarget(input('text'), 'macOS')).toBe('enter')

--- a/tests/support/Dom.spec.ts
+++ b/tests/support/Dom.spec.ts
@@ -65,6 +65,15 @@ describe('support/Dom', () => {
       Dom.stopNonSubmitEnterKeydown(event)
       expect(event.defaultPrevented).toBe(false)
     })
+
+    it('leaves the Enter that commits an IME composition alone', () => {
+      const event = enter()
+      Object.defineProperty(event, 'isComposing', { value: true })
+      const stop = vi.spyOn(event, 'stopPropagation')
+      Dom.stopNonSubmitEnterKeydown(event)
+      expect(stop).not.toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(false)
+    })
   })
 
   describe('editorSubmitShortcutForTarget', () => {


### PR DESCRIPTION
Follow-ups on top of #766, addressing the open review comments plus further keyboard/focus polish.

## Sheet editor

- **One editor open at a time**: fields share a sheet-scoped `LensInlineEdit` context (the same mechanism the table's inline cells use), so opening an editor closes any other. The key is released on unmount, so a closed sheet can't resurrect an editor on reopen.
- **Label a11y**: the editor's visible row label now carries the required `*`, and the input's own label is visually hidden (clip) instead of `display: none`, so it keeps naming the input for screen readers.
- **Hover chrome scoping**: the hover border/shadow is scoped to the data-list row's own cell (`.SDataListItem > .content > .value/.empty`) — display renderers with a nested `.value` (e.g. `SDescPill` pills) no longer grow a second border. The pencil button is borderless (background + shadow only).
- **Apply button**: renders through `SButton` via a new default slot (dropping the hand-copied fill-info chrome). Slot handling uses `useHasSlotContent`, so a slot that renders empty falls back to the `label` prop. The shortcut hint is a keycap-style pill using lucide icons (`command` / `chevron-up` / `corner-down-left`) with no `+` separator, and the shortcut is also exposed to screen readers as visually-hidden text.
- **Click guard**: `SDataListItem`'s interactive-content check is bounded to the cell (`currentTarget`), so an interactive *ancestor* of the list (a tabindexed scroll container, say) can't swallow every cell click.

## Submit-shortcut hint accuracy

- Hidden while nothing inside the form is focused (e.g. a radio-group editor, whose options aren't keyboard-focusable — no shortcut would actually work), and cleared when focus leaves the form.
- A text input nested in a dropdown (the search filters) advertises the modifier gesture rather than bare Enter, since Enter stays inside the dropdown.

## Dropdown inputs (`SInputDropdown` / `SInputAsyncDropdown`)

- **Escape** while the flyout is open closes the flyout (and refocuses the box) without reaching the enclosing editor/sheet; a second Escape then cancels the editor as before. The Escape that cancels an IME composition never operates the flyout.
- **Click / Enter toggles** the flyout; closing returns focus to the box instead of dropping it to `document.body`, so an editor's ⌘/Ctrl+Enter shortcut keeps working after interacting with the dropdown. Bare Enter toggles on **keydown** (`.exact`, ignoring key repeat), so the keyup of a ⌘/Ctrl+Enter submit can't reopen the flyout regardless of key-release order. ArrowDown remains open-only.
- The box shows keyboard focus via the input-family border color (`--input-focus-border-color`) instead of the UA's default ring.
- The search filters keep Enter to themselves via a shared `stopNonSubmitEnterKeydown` helper (`support/Dom`): only ⌘/Ctrl+Enter — the universal submit gesture — passes through to the editor; bare, Shift+ and Alt+Enter all stay contained, and the Enter that commits an IME composition passes untouched so the composed text isn't dropped.
- `SDropdownSectionFilter` gains keyboard parity with the async dropdown: ArrowDown from the search input moves into the first option, ArrowUp from the first option returns to the input. Option rows in both dropdowns now show a `:focus-visible` ring while arrowing (the global reset strips `button:focus` outlines, so they previously had no visible keyboard focus at all).

`@iconify-json/lucide` moves to runtime `dependencies` so consumers resolve the new icons the same way as the existing `ph` / `ri` collections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)