### PR TITLE
fix(lens): show catalog table loading state

### DIFF
--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -78,12 +78,17 @@ const columnKeys = computed(() => {
   return visible.map((k) => (k === '__empty__' ? `__empty__::${emptyIndex++}` : k))
 })
 
-const columns = computedAsync(async () => {
+interface ColumnBuild {
+  result?: LensResult
+  columns: TableColumns<any, any, any>
+}
+
+const columnBuild = computedAsync<ColumnBuild>(async () => {
   const r = props.result
   const columns = createBaseColumns()
 
   if (!r) {
-    return columns
+    return { result: r, columns }
   }
 
   // Snapshot the column keys at the start of the run. `columnKeys` is a
@@ -218,8 +223,11 @@ const columns = computedAsync(async () => {
     }
   }
 
-  return columns
-}, createBaseColumns())
+  return { result: r, columns }
+}, { result: undefined, columns: createBaseColumns() })
+
+const columns = computed(() => columnBuild.value.columns)
+const columnsLoading = computed(() => columnBuild.value.result !== props.result)
 
 // Render a column only once its definition exists. `columns` resolves
 // asynchronously (computedAsync), so when a column is toggled back on its key
@@ -243,7 +251,7 @@ const table = useTable({
   // settling re-keys it. STable reads this inside a computed, so the getter
   // establishes the dependency and selection re-keys correctly.
   get indexField() { return props.indexField },
-  get loading() { return props.loading },
+  get loading() { return props.loading || columnsLoading.value },
   borderless: true
 })
 

--- a/lib/blocks/lens/components/LensTable.vue
+++ b/lib/blocks/lens/components/LensTable.vue
@@ -49,6 +49,14 @@ const avatarCellComponent = markRaw(LensTableAvatarCell)
 
 const records = computed(() => props.result?.data ?? [])
 
+function createBaseColumns(): TableColumns<any, any, any> {
+  return {
+    __last_empty__: {
+      cell: { type: 'empty' }
+    }
+  }
+}
+
 // Resolve the list of columns to render. We intersect the caller's
 // requested `select` with what the latest response actually fetched so
 // that toggling a column on through "Manage table view" doesn't surface
@@ -72,9 +80,10 @@ const columnKeys = computed(() => {
 
 const columns = computedAsync(async () => {
   const r = props.result
+  const columns = createBaseColumns()
 
   if (!r) {
-    return {}
+    return columns
   }
 
   // Snapshot the column keys at the start of the run. `columnKeys` is a
@@ -84,13 +93,6 @@ const columns = computedAsync(async () => {
   // produce `undefined` for indices past the new length — crashing
   // `Object.assign(_fieldData, ...)` below.
   const keys = [...columnKeys.value]
-
-  // Prepare base columns that has `__last_empty__` to fill the end space.
-  const columns: TableColumns<any, any, any> = {
-    __last_empty__: {
-      cell: { type: 'empty' }
-    }
-  }
 
   // Build the list of columns based on the resolved column key list.
   for (const key of keys) {
@@ -217,7 +219,7 @@ const columns = computedAsync(async () => {
   }
 
   return columns
-}, {})
+}, createBaseColumns())
 
 // Render a column only once its definition exists. `columns` resolves
 // asynchronously (computedAsync), so when a column is toggled back on its key
@@ -241,6 +243,7 @@ const table = useTable({
   // settling re-keys it. STable reads this inside a computed, so the getter
   // establishes the dependency and selection re-keys correctly.
   get indexField() { return props.indexField },
+  get loading() { return props.loading },
   borderless: true
 })
 
@@ -299,7 +302,6 @@ function makeEditableField(r: LensResult, key?: string | null): Field<FieldData>
     :class="{ 'is-loading': loading, 'is-empty': (result?.data.length ?? 0) === 0 }"
   >
     <STable
-      v-if="Object.keys(columns).length > 0"
       class="table"
       :options="table"
       :selected

--- a/tests/blocks/lens/components/LensTable.spec.ts
+++ b/tests/blocks/lens/components/LensTable.spec.ts
@@ -1,0 +1,31 @@
+import { mount } from '@vue/test-utils'
+import LensTable from 'sefirot/blocks/lens/components/LensTable.vue'
+import { FieldRegistryKey } from 'sefirot/blocks/lens/composables/FieldRegistry'
+
+vi.stubGlobal('IntersectionObserver', vi.fn(() => ({
+  disconnect: vi.fn(),
+  observe: vi.fn()
+})))
+
+describe('blocks/lens/components/LensTable', () => {
+  it('renders the table during initial loading and forwards loading updates', async () => {
+    const wrapper = mount(LensTable, {
+      props: {
+        loading: true
+      },
+      global: {
+        provide: {
+          [FieldRegistryKey as symbol]: {
+            resolve: vi.fn()
+          }
+        }
+      }
+    })
+
+    expect(wrapper.find('.STable .loading').exists()).toBe(true)
+
+    await wrapper.setProps({ loading: false })
+
+    expect(wrapper.find('.STable .loading').exists()).toBe(false)
+  })
+})

--- a/tests/blocks/lens/components/LensTable.spec.ts
+++ b/tests/blocks/lens/components/LensTable.spec.ts
@@ -1,4 +1,5 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
+import { type LensResult } from 'sefirot/blocks/lens/LensResult'
 import LensTable from 'sefirot/blocks/lens/components/LensTable.vue'
 import { FieldRegistryKey } from 'sefirot/blocks/lens/composables/FieldRegistry'
 
@@ -27,5 +28,54 @@ describe('blocks/lens/components/LensTable', () => {
     await wrapper.setProps({ loading: false })
 
     expect(wrapper.find('.STable .loading').exists()).toBe(false)
+  })
+
+  it('keeps loading visible until async columns finish building', async () => {
+    let resolveFilterMenu!: (value: null) => void
+    const filterMenu = new Promise<null>((resolve) => {
+      resolveFilterMenu = resolve
+    })
+    const field = {
+      tableColumn: vi.fn(() => ({ cell: { type: 'text' } })),
+      tableSortMenu: vi.fn(() => null),
+      tableFilterMenu: vi.fn(() => filterMenu)
+    }
+    const result = {
+      query: {
+        entity: 'users',
+        select: ['name'],
+        filters: [],
+        sort: [],
+        page: 1,
+        perPage: 100
+      },
+      fields: {
+        name: { key: 'name', type: 'text' }
+      },
+      data: [{ name: 'Alice' }],
+      pagination: { total: 1, page: 1, perPage: 100 }
+    } as unknown as LensResult
+    const wrapper = mount(LensTable, {
+      props: {
+        loading: true
+      },
+      global: {
+        provide: {
+          [FieldRegistryKey as symbol]: {
+            resolve: vi.fn(() => () => field)
+          }
+        }
+      }
+    })
+
+    await wrapper.setProps({ loading: false, result })
+
+    expect(wrapper.find('.STable .loading').exists()).toBe(true)
+
+    resolveFilterMenu(null)
+    await flushPromises()
+
+    expect(wrapper.find('.STable .loading').exists()).toBe(false)
+    expect(wrapper.find('.STableCellText').text()).toBe('Alice')
   })
 })


### PR DESCRIPTION
## Summary

- keep the underlying table mounted with a minimal placeholder column definition during the initial request
- forward LensCatalog's reactive loading state to STable so its skeleton appears for initial loads, filtering, and pagination
- add a regression test covering the loading skeleton lifecycle

## Root cause

LensTable accepted the `loading` prop, but only used it for a CSS class and did not pass it into STable's options. It also hid STable until asynchronous column definitions were available, preventing the initial loading skeleton from rendering at all.

## Impact

Catalog users now get the standard table loading feedback while data is being fetched, including on the first load and subsequent filter or page changes.

## Testing

Tested locally:

- `CI=true pnpm test:fail` (122 test files, 1,270 tests passed)
- `CI=true pnpm type`
- `CI=true pnpm exec eslint lib/blocks/lens/components/LensTable.vue tests/blocks/lens/components/LensTable.spec.ts --max-warnings 0`