### PR TITLE
fix: ignore webkit.messageHandlers errors from in-app browsers

### DIFF
--- a/lib/composables/Error.ts
+++ b/lib/composables/Error.ts
@@ -141,7 +141,8 @@ const ignoreErrors = [
   /Non-Error (?:exception|promise rejection) captured/,
   /ResizeObserver loop/,
   /Can't find variable: gmo/,
-  /\[Cloudflare Turnstile\] Error: (?:10[2-46]|1106[02]|[36]00)/
+  /\[Cloudflare Turnstile\] Error: (?:10[2-46]|1106[02]|[36]00)/,
+  /window\.webkit\.messageHandlers/
 ]
 
 const stringifiers: readonly ((e: unknown) => string | false)[] = [


### PR DESCRIPTION
## Summary

Adds `/window\.webkit\.messageHandlers/` to the `ignoreErrors` list in `useErrorHandler` so these errors are neither reported to Sentry nor surfaced in the error store.

## Why

iOS in-app browsers (most notably Meta's Facebook/Instagram apps) inject bridge scripts (e.g. `setupIosCallbackHandler`) into every page they load. When `window.webkit.messageHandlers` is unavailable, these injected scripts throw unhandled rejections such as:

```
TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers')
TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers.navigationPerformanceLoggerWithReply.postMessage')
```

These originate entirely from third-party injected code — not from application code — and are pure noise in Sentry. This is a well-known pattern, in line with the existing filters in the list (e.g. `gmo`, Cloudflare Turnstile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)