### PR TITLE
fix: handle scalar vs nested key conflicts in url query sync

### DIFF
--- a/lib/composables/Url.ts
+++ b/lib/composables/Url.ts
@@ -103,10 +103,16 @@ export function useUrlQuerySync(
 
   function normalizeQuery(query: LocationQuery): Record<string, any> {
     const flattenedQuery = flattenObject(query)
+    const keys = Object.keys(flattenedQuery)
     const result: Record<string, any> = {}
 
     for (const key in flattenedQuery) {
-      if (!exclude.includes(key)) {
+      // When a param is shadowed by a nested param with the same prefix
+      // (e.g. `page` and `page.page`), drop the shadowed one: the pair can
+      // never be represented in a single state object, and keeping it here
+      // would make `setQuery` rewrite the URL just to remove it, breaking
+      // recovery of the remaining params on reload.
+      if (!exclude.includes(key) && !keys.some((k) => k.startsWith(`${key}.`))) {
         result[key] = casts[key] ? casts[key](flattenedQuery[key]) : flattenedQuery[key]
       }
     }

--- a/lib/composables/Url.ts
+++ b/lib/composables/Url.ts
@@ -1,4 +1,5 @@
 import isEqual from 'lodash-es/isEqual'
+import isPlainObject from 'lodash-es/isPlainObject'
 import { type MaybeRef, computed, nextTick, unref, watch } from 'vue'
 import { type LocationQuery, useRoute, useRouter } from 'vue-router'
 
@@ -143,7 +144,15 @@ function unflattenObject(obj: Record<string, any>): Record<string, any> {
 
     for (let i = 0; i < keys.length - 1; i++) {
       const k = keys[i]
-      target = target[k] = target[k] || {}
+
+      // When a scalar key conflicts with a nested key (e.g. `page` and
+      // `page.page`), drop the scalar and let the nested key win. Otherwise
+      // assigning a property on the scalar below would throw a `TypeError`.
+      if (!isPlainObject(target[k])) {
+        target[k] = {}
+      }
+
+      target = target[k]
     }
 
     target[keys[keys.length - 1]] = value
@@ -163,7 +172,9 @@ function deepAssign(target: Record<string, any>, source: Record<string, any>) {
         target[key] = value
       }
     } else if (value && typeof value === 'object') {
-      target[key] = deepAssign(target[key] || {}, value)
+      // Same scalar vs. nested conflict handling as `unflattenObject`:
+      // assigning nested values onto an existing scalar would throw.
+      target[key] = deepAssign(isPlainObject(target[key]) ? target[key] : {}, value)
     } else {
       target[key] = value
     }

--- a/lib/composables/Url.ts
+++ b/lib/composables/Url.ts
@@ -103,16 +103,17 @@ export function useUrlQuerySync(
 
   function normalizeQuery(query: LocationQuery): Record<string, any> {
     const flattenedQuery = flattenObject(query)
-    const keys = Object.keys(flattenedQuery)
+    const keys = Object.keys(flattenedQuery).filter((key) => !exclude.includes(key))
     const result: Record<string, any> = {}
 
-    for (const key in flattenedQuery) {
+    for (const key of keys) {
       // When a param is shadowed by a nested param with the same prefix
       // (e.g. `page` and `page.page`), drop the shadowed one: the pair can
       // never be represented in a single state object, and keeping it here
       // would make `setQuery` rewrite the URL just to remove it, breaking
-      // recovery of the remaining params on reload.
-      if (!exclude.includes(key) && !keys.some((k) => k.startsWith(`${key}.`))) {
+      // recovery of the remaining params on reload. Excluded params are
+      // invisible to the sync, so they never shadow anything.
+      if (!keys.some((k) => k.startsWith(`${key}.`))) {
         result[key] = casts[key] ? casts[key](flattenedQuery[key]) : flattenedQuery[key]
       }
     }

--- a/lib/composables/Url.ts
+++ b/lib/composables/Url.ts
@@ -103,12 +103,16 @@ export function useUrlQuerySync(
 
   function normalizeQuery(query: LocationQuery): Record<string, any> {
     const flattenedQuery = flattenObject(query)
-    const keys = Object.keys(flattenedQuery).filter((key) => !exclude.includes(key))
+
+    const keys = Object.keys(flattenedQuery).filter((key) => {
+      return !exclude.includes(key) && fitsDefaultState(key)
+    })
+
     const result: Record<string, any> = {}
 
     for (const key of keys) {
       // When a param is shadowed by a nested param with the same prefix
-      // (e.g. `page` and `page.page`), drop the shadowed one: the pair can
+      // (e.g. `foo` and `foo.bar`), drop the shadowed one: the pair can
       // never be represented in a single state object, and keeping it here
       // would make `setQuery` rewrite the URL just to remove it, breaking
       // recovery of the remaining params on reload. Excluded params are
@@ -119,6 +123,24 @@ export function useUrlQuerySync(
     }
 
     return result
+  }
+
+  // The default state acts as the schema for the sync. A param that does
+  // not fit its shape — a nested param under a scalar or array default
+  // (`page.page` vs `{ page: 1 }`), or a scalar param over a nested
+  // default (`page` vs `{ page: { page: 1 } }`) — cannot be assigned to
+  // the state without corrupting the shape the app expects, so it is
+  // ignored as malformed input, exactly as if the param was absent, and
+  // left in the URL untouched. Params unrelated to any default key are
+  // still synced into the state as is.
+  function fitsDefaultState(key: string): boolean {
+    if (Object.hasOwn(flattenedDefaultState, key)) {
+      return true
+    }
+
+    return !Object.keys(flattenedDefaultState).some((k) => {
+      return k.startsWith(`${key}.`) || key.startsWith(`${k}.`)
+    })
   }
 }
 

--- a/tests/composables/Url.spec.ts
+++ b/tests/composables/Url.spec.ts
@@ -440,5 +440,65 @@ describe('composables/Url', () => {
 
       wrapper.unmount()
     })
+
+    it('handles a scalar query param conflicting with a nested one', async () => {
+      const { wrapper, vm } = setupWithWrapper(() => {
+        const router = useRouter()
+
+        // Old style `?page=5` and new style `?page.page=7` params mixed in
+        // the same URL (e.g. via an outdated bookmark). Unflattening the
+        // nested key on top of the scalar used to throw `TypeError: Cannot
+        // create property 'page' on number '1'`.
+        router.replace({ query: { 'page': '5', 'page.page': '7' } })
+
+        const data = reactive({ page: 1 })
+        useUrlQuerySync(data)
+
+        return { data }
+      })
+
+      // The nested key should win over the scalar prefix.
+      await expect.poll(() => vm.data.page).toEqual({ page: '7' })
+
+      wrapper.unmount()
+    })
+
+    it('keeps the scalar when it comes after the conflicting nested key', async () => {
+      const { wrapper, vm } = setupWithWrapper(() => {
+        const router = useRouter()
+
+        router.replace({ query: { page: '5' } })
+
+        const data = reactive({ page: { page: 1 } })
+        useUrlQuerySync(data)
+
+        return { data }
+      })
+
+      // The nested default state gets flattened to `page.page` before the
+      // scalar `page` query param is merged on top of it, so here the
+      // scalar comes last and wins.
+      await expect.poll(() => vm.data.page).toBe('5')
+
+      wrapper.unmount()
+    })
+
+    it('handles a nested query param conflicting with an array', async () => {
+      const { wrapper, vm } = setupWithWrapper(() => {
+        const router = useRouter()
+
+        router.replace({ query: { 'tags.0': 'z' } })
+
+        const data = reactive({ tags: ['a', 'b'] })
+        useUrlQuerySync(data)
+
+        return { data }
+      })
+
+      // The nested key should win over the array prefix as well.
+      await expect.poll(() => vm.data.tags).toEqual({ 0: 'z' })
+
+      wrapper.unmount()
+    })
   })
 })

--- a/tests/composables/Url.spec.ts
+++ b/tests/composables/Url.spec.ts
@@ -488,6 +488,31 @@ describe('composables/Url', () => {
       wrapper.unmount()
     })
 
+    it('lets a scalar param sync when the shadowing nested param is excluded', async () => {
+      const { wrapper, vm } = setupWithWrapper(() => {
+        const router = useRouter()
+
+        router.replace({ query: { 'page': '2', 'page.page': 'debug' } })
+
+        const data = reactive({ page: 1 })
+        useUrlQuerySync(data, {
+          exclude: ['page.page']
+        })
+
+        const route = useRoute()
+        return { data, route }
+      })
+
+      // The excluded nested param is invisible to the sync, so it should
+      // not shadow the scalar param.
+      await expect.poll(() => vm.data.page).toBe('2')
+
+      // The excluded param itself should stay in the URL untouched.
+      expect(vm.route.query).toEqual({ 'page': '2', 'page.page': 'debug' })
+
+      wrapper.unmount()
+    })
+
     it('handles a nested query param conflicting with an array', async () => {
       const { wrapper, vm } = setupWithWrapper(() => {
         const router = useRouter()

--- a/tests/composables/Url.spec.ts
+++ b/tests/composables/Url.spec.ts
@@ -458,17 +458,18 @@ describe('composables/Url', () => {
         return { data, route }
       })
 
-      // The nested key should win over the scalar prefix.
-      await expect.poll(() => vm.data.page).toEqual({ page: '7' })
+      // The default state is scalar, so the nested param does not fit its
+      // shape and is ignored as malformed input, while the scalar applies.
+      await expect.poll(() => vm.data.page).toBe('5')
 
-      // The conflicting params should be left in the URL untouched so that
-      // reloading the page recovers the same state again.
+      // The params should be left in the URL untouched so that reloading
+      // the page recovers the same state again.
       expect(vm.route.query).toEqual({ 'page': '5', 'page.page': '7' })
 
       wrapper.unmount()
     })
 
-    it('keeps the scalar when it comes after the conflicting nested key', async () => {
+    it('ignores a scalar param that conflicts with a nested default', async () => {
       const { wrapper, vm } = setupWithWrapper(() => {
         const router = useRouter()
 
@@ -477,13 +478,16 @@ describe('composables/Url', () => {
         const data = reactive({ page: { page: 1 } })
         useUrlQuerySync(data)
 
-        return { data }
+        const route = useRoute()
+        return { data, route }
       })
 
-      // The nested default state gets flattened to `page.page` before the
-      // scalar `page` query param is merged on top of it, so here the
-      // scalar comes last and wins.
-      await expect.poll(() => vm.data.page).toBe('5')
+      // The scalar param cannot be assigned over the nested default
+      // without corrupting the state shape, so it is ignored and the URL
+      // is left untouched.
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      expect(vm.data.page).toEqual({ page: 1 })
+      expect(vm.route.query).toEqual({ page: '5' })
 
       wrapper.unmount()
     })
@@ -513,7 +517,7 @@ describe('composables/Url', () => {
       wrapper.unmount()
     })
 
-    it('handles a nested query param conflicting with an array', async () => {
+    it('ignores a nested param that conflicts with an array default', async () => {
       const { wrapper, vm } = setupWithWrapper(() => {
         const router = useRouter()
 
@@ -522,11 +526,37 @@ describe('composables/Url', () => {
         const data = reactive({ tags: ['a', 'b'] })
         useUrlQuerySync(data)
 
-        return { data }
+        const route = useRoute()
+        return { data, route }
       })
 
-      // The nested key should win over the array prefix as well.
-      await expect.poll(() => vm.data.tags).toEqual({ 0: 'z' })
+      // Arrays sync as whole values, so a nested param under an array
+      // default does not fit the state shape and is ignored.
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      expect(vm.data.tags).toEqual(['a', 'b'])
+      expect(vm.route.query).toEqual({ 'tags.0': 'z' })
+
+      wrapper.unmount()
+    })
+
+    it('handles conflicting params that are unrelated to the state', async () => {
+      const { wrapper, vm } = setupWithWrapper(() => {
+        const router = useRouter()
+
+        router.replace({ query: { 'foo': '1', 'foo.bar': '2' } })
+
+        const data = reactive<Record<string, any>>({ search: '' })
+        useUrlQuerySync(data)
+
+        const route = useRoute()
+        return { data, route }
+      })
+
+      // Params unrelated to any default key are synced into the state as
+      // is. The nested param wins over the shadowed scalar prefix, and
+      // unflattening it must not throw.
+      await expect.poll(() => vm.data.foo).toEqual({ bar: '2' })
+      expect(vm.route.query).toEqual({ 'foo': '1', 'foo.bar': '2' })
 
       wrapper.unmount()
     })

--- a/tests/composables/Url.spec.ts
+++ b/tests/composables/Url.spec.ts
@@ -454,11 +454,16 @@ describe('composables/Url', () => {
         const data = reactive({ page: 1 })
         useUrlQuerySync(data)
 
-        return { data }
+        const route = useRoute()
+        return { data, route }
       })
 
       // The nested key should win over the scalar prefix.
       await expect.poll(() => vm.data.page).toEqual({ page: '7' })
+
+      // The conflicting params should be left in the URL untouched so that
+      // reloading the page recovers the same state again.
+      expect(vm.route.query).toEqual({ 'page': '5', 'page.page': '7' })
 
       wrapper.unmount()
     })


### PR DESCRIPTION
## Summary

Fixes a crash in `useUrlQuerySync`: `TypeError: Cannot create property 'page' on number '1'`, thrown when a URL mixes an old-style scalar query param with a new-style nested param for the same key (e.g. `?page=1&page.page=1`, reachable via outdated bookmarks). Ref: Sentry issue 7614687987.

## Root cause

In `unflattenObject`, the intermediate key resolution `target[k] = target[k] || {}` passes truthy scalars through untouched, so the subsequent property assignment throws when a flattened key set contains both `page` (scalar) and `page.page` (nested).

## Changes

- `normalizeQuery` now treats the default state as the schema for the sync (evolved over review, see the thread): a param that does not fit the default shape — a nested param under a scalar or array default (`page.page` vs `{ page: 1 }`), or a scalar param over a nested default (`page` vs `{ page: { page: 1 } }`) — can only corrupt the shape the app expects, so it is ignored as malformed input, exactly as if the param was absent, and left in the URL untouched (so reloads recover the same state, and the URL is never rewritten just to drop it). This matches the semantics `useCatalogUrlQuerySync` already documents ("anything malformed falls back to the state's initial value"). Params unrelated to any default key still sync into the state as before, with a nested param shadowing its scalar prefix (`?foo=1&foo.bar=2` → `{ foo: { bar: '2' } }`). Excluded keys are filtered out before all of this, so an excluded param never shadows an included one.
- `unflattenObject` / `deepAssign`: when an intermediate key holds anything other than a plain object, replace it with `{}` instead of throwing. With the schema filtering above this is defense in depth — it keeps the state-unrelated conflict path (and any future caller) crash-free.

## Tests

All added tests go through the public `useUrlQuerySync` API (`unflattenObject` stays private):

- **Crash repro**: `?page=5&page.page=7` with `reactive({ page: 1 })` — no exception, the scalar applies (`'5'`), the misfit nested param is ignored, and the URL keeps the original params untouched so a reload recovers the same state. Fails on `main` (verified: same `TypeError` as production).
- **Scalar param vs nested default**: `?page=5` with `reactive({ page: { page: 1 } })` — ignored, state keeps its shape, URL untouched. (Previously the scalar overwrote the nested state with a string.)
- **Nested param vs array default**: `?tags.0=z` with `reactive({ tags: ['a', 'b'] })` — ignored, array preserved, URL untouched.
- **State-unrelated conflict**: `?foo=1&foo.bar=2` with state not containing `foo` — syncs in as `{ foo: { bar: '2' } }` without throwing (exercises the `unflattenObject`/`deepAssign` guards).
- **Excluded shadow** (`exclude: ['page.page']` with `?page=2&page.page=debug`): the scalar `page` still syncs and the excluded param stays in the URL untouched.

`pnpm run check:fail` (type, lint, tests — 1276 passed) is green.

## Known pre-existing limitation (not addressed here)

`setQuery` writes nested state back via `router.replace({ query: unflattenObject(...) })`. That shape appears intentional for routers configured with a nesting-aware `parseQuery`/`stringifyQuery` (where nested query objects round-trip properly), but under vue-router's default config any nested, non-serializer-based state value that changes still ends up as `?key=%5Bobject%20Object%5D`. With the schema filtering in this PR the state now survives that malformed param on the next sync (it is ignored instead of assigned), but the URL param itself is lost. Flattening the write-back to dotted keys would fix the default config and still round-trip on custom configs, but changes the emitted URL format for those setups — left as a separate design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
