### PR TITLE
feat(lens): support content after sheet title

### DIFF
--- a/histoire.config.ts
+++ b/histoire.config.ts
@@ -12,6 +12,7 @@ function getDocsHost(): string {
 export default defineConfig({
   plugins: [hstVue()],
   setupFile: 'stories/histoire.setup.ts',
+  storyIgnored: ['**/node_modules/**', '**/dist/**', '**/.git/**'],
   defaultStoryProps: { autoPropsDisabled: true },
 
   theme: { title: 'Sefirot', colors: { primary: defaultColors.neutral } },

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -1768,6 +1768,9 @@ defineExpose({
       :width="sheetWidth"
       @close="sheet.off"
     >
+      <template v-if="$slots['sheet-title-after']" #title-after="s">
+        <slot name="sheet-title-after" v-bind="s" />
+      </template>
       <template v-if="$slots['sheet-before']" #before="s">
         <slot name="sheet-before" v-bind="s" />
       </template>

--- a/lib/blocks/lens/components/LensSheet.vue
+++ b/lib/blocks/lens/components/LensSheet.vue
@@ -301,15 +301,15 @@ function requestClose() {
 
 // --- Slot context -----------------------------------------------------------
 //
-// Content passed to the `#before` / `#after` slots is declared in the page
+// Content passed to the `#title-after` / `#before` / `#after` slots is declared in the page
 // that hosts the catalog, so it cannot `inject` the edit context (which is
 // provided inside `LensCatalog`, a child of that page). Expose the pieces a
-// slot needs as slot props instead: the resolved record id, a record-bound
-// partial `save`, the entity key, the sheet `mode` (so a slot can render
-// different content for create vs view), and `registerCreateExtension` (so a
-// create-mode slot can contribute extra keys to the create payload). This keeps
-// the generic sheet free of one-off concerns (avatar upload, social links,
-// linked records) while still letting a page implement them.
+// slot needs as slot props instead: the rendered title, resolved record id, a
+// record-bound partial `save`, the entity key, the sheet `mode` (so a slot can
+// render different content for create vs view), and `registerCreateExtension`
+// (so a create-mode slot can contribute extra keys to the create payload). This
+// keeps the generic sheet free of one-off concerns (badges, avatar upload,
+// social links, linked records) while still letting a page implement them.
 
 const resolvedId = computed(() => (props.record && edit ? edit.resolveId(props.record) : null))
 
@@ -331,6 +331,7 @@ function saveRecord(values: Record<string, any>): Promise<void> {
 }
 
 const slotProps = computed(() => ({
+  title: title.value,
   record: props.record ?? null,
   id: resolvedId.value,
   entity: props.entity,
@@ -357,7 +358,12 @@ const slotProps = computed(() => ({
   <SSheet :open :closable="!saving" :width="width ?? '480px'" @close="requestClose">
     <div class="LensSheet">
       <div class="header">
-        <div class="title">{{ title }}</div>
+        <div class="heading">
+          <div class="title">{{ title }}</div>
+          <div v-if="$slots['title-after']" class="title-after">
+            <slot name="title-after" v-bind="slotProps" />
+          </div>
+        </div>
         <button
           class="close"
           type="button"
@@ -462,6 +468,15 @@ const slotProps = computed(() => ({
   border-bottom: 1px solid var(--c-divider);
 }
 
+.heading {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  flex: 1;
+  gap: 8px;
+  min-width: 0;
+}
+
 .title {
   font-size: 16px;
   font-weight: 500;
@@ -469,10 +484,17 @@ const slotProps = computed(() => ({
   color: var(--c-text-1);
 }
 
+.title-after {
+  display: flex;
+  align-items: center;
+  flex: none;
+}
+
 .close {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: none;
   width: 32px;
   height: 32px;
   border-radius: 6px;

--- a/stories/blocks/LensSheet.01_Title_Addon.story.Fixture.vue
+++ b/stories/blocks/LensSheet.01_Title_Addon.story.Fixture.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { type FieldData, type TextFieldData } from 'sefirot/blocks/lens/FieldData'
+import LensSheet from 'sefirot/blocks/lens/components/LensSheet.vue'
+import { useSetupLens } from 'sefirot/blocks/lens/composables/SetupLens'
+import SButton from 'sefirot/components/SButton.vue'
+import SPill from 'sefirot/components/SPill.vue'
+import { ref } from 'vue'
+
+const open = ref(true)
+
+useSetupLens()
+
+function textField(key: string, label: string): TextFieldData {
+  return {
+    type: 'text',
+    key,
+    labelEn: label,
+    labelJa: label,
+    filterKey: key,
+    sortable: false,
+    freeze: false,
+    width: 160,
+    required: false,
+    rules: [],
+    showOnDetail: true,
+    placeholderEn: null,
+    placeholderJa: null,
+    helpEn: null,
+    helpJa: null,
+    unitBefore: null,
+    unitAfter: null
+  }
+}
+
+const fields: Record<string, FieldData> = {
+  category: textField('category', 'Category'),
+  maintainer: textField('maintainer', 'Maintainer'),
+  summary: textField('summary', 'Summary'),
+  updatedAt: textField('updatedAt', 'Last updated')
+}
+
+const record = {
+  id: { value: 42, display: 'Designing resilient interfaces' },
+  category: 'Design systems',
+  maintainer: 'Documentation team',
+  summary: 'A practical guide to building flexible, accessible components for evolving products.',
+  updatedAt: 'July 18, 2026'
+}
+</script>
+
+<template>
+  <SButton label="Open sheet" @click="open = true" />
+
+  <LensSheet
+    :open
+    entity="documents"
+    :record
+    :fields
+    width="760px"
+    @close="open = false"
+  >
+    <template #title-after>
+      <SPill size="mini" label="Featured" />
+    </template>
+  </LensSheet>
+</template>

--- a/stories/blocks/LensSheet.01_Title_Addon.story.vue
+++ b/stories/blocks/LensSheet.01_Title_Addon.story.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+// Histoire renders story content in a separate Vue sub-app, so Lens providers
+// registered in the story component are unavailable to LensSheet. The fixture
+// registers them in the same component tree as LensSheet.
+import HFixture from './LensSheet.01_Title_Addon.story.Fixture.vue'
+
+const title = 'Blocks / LensSheet / 01. Title Addon'
+</script>
+
+<template>
+  <Story :title source="Not available" auto-props-disabled>
+    <Board :title>
+      <HFixture />
+    </Board>
+  </Story>
+</template>

--- a/tests/blocks/lens/components/LensSheet.spec.ts
+++ b/tests/blocks/lens/components/LensSheet.spec.ts
@@ -1,0 +1,119 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import LensCatalog from 'sefirot/blocks/lens/components/LensCatalog.vue'
+import LensSheet from 'sefirot/blocks/lens/components/LensSheet.vue'
+import { FieldRegistryKey } from 'sefirot/blocks/lens/composables/FieldRegistry'
+import { type LensEditContext, provideLensEdit } from 'sefirot/blocks/lens/composables/LensEdit'
+import { Http } from 'sefirot/http/Http'
+import { defineComponent, h, nextTick } from 'vue'
+
+describe('blocks/lens/components/LensSheet', () => {
+  it('renders record-aware content after the sheet title', () => {
+    const record = {
+      id: { value: 'DOC-042', display: 'Interface design notes' }
+    }
+    const edit = {
+      editable: false,
+      viewable: true,
+      creatable: false,
+      canEdit: () => false,
+      canDelete: () => false,
+      entity: 'documents',
+      indexField: 'id',
+      resolveId: (value) => value.id.value,
+      save: vi.fn(),
+      saveBlocking: vi.fn(),
+      create: vi.fn(),
+      remove: vi.fn(),
+      openSheet: vi.fn(),
+      openCreate: vi.fn(),
+      refresh: vi.fn()
+    } satisfies LensEditContext
+
+    const Host = defineComponent({
+      setup() {
+        provideLensEdit(edit)
+
+        return () => h(LensSheet, {
+          open: true,
+          entity: 'documents',
+          record,
+          fields: {}
+        }, {
+          'title-after': ({ title, id, entity, mode, record: slotRecord }: any) => h(
+            'span',
+            { class: 'title-context' },
+            `${title}|${id}|${entity}|${mode}|${slotRecord === record}`
+          )
+        })
+      }
+    })
+
+    mount(Host, {
+      global: {
+        provide: {
+          [FieldRegistryKey as symbol]: {
+            resolve: vi.fn()
+          }
+        }
+      }
+    })
+
+    expect(document.querySelector('.LensSheet .title')?.textContent)
+      .toBe('Interface design notes')
+    expect(document.querySelector('.LensSheet .title-after .title-context')?.textContent)
+      .toBe('Interface design notes|DOC-042|documents|view|true')
+  })
+
+  it('forwards the public catalog sheet-title-after slot', async () => {
+    vi.spyOn(Http.prototype, 'post').mockResolvedValue({
+      query: {
+        entity: 'documents',
+        select: [],
+        filters: [],
+        sort: [],
+        page: 1,
+        perPage: 100
+      },
+      fields: {},
+      data: [{ id: 'DOC-042' }],
+      pagination: { total: 1, page: 1, perPage: 100 }
+    })
+
+    const wrapper = mount(LensCatalog, {
+      props: {
+        endpoint: '/api/documents/search',
+        entity: 'documents',
+        editable: true
+      },
+      slots: {
+        'sheet-title-after': ({ title, entity, mode }: any) => h(
+          'span',
+          { class: 'catalog-title-context' },
+          `${title}|${entity}|${mode}`
+        )
+      },
+      global: {
+        provide: {
+          [FieldRegistryKey as symbol]: {
+            resolve: vi.fn()
+          }
+        },
+        stubs: {
+          LensCatalogControl: true,
+          LensCatalogFooter: true,
+          LensFormFilter: true,
+          LensFormView: true,
+          LensTable: true,
+          SModal: true
+        }
+      }
+    })
+
+    await flushPromises()
+    wrapper.vm.openCreate()
+    await nextTick()
+
+    expect(document.querySelector('.LensSheet .title-after .catalog-title-context')?.textContent)
+      .toBe('New record|documents|create')
+  })
+})


### PR DESCRIPTION
Supports design like this, through a `sheet-title-after` slot in `<LensCatalog />`:

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/3373e614-c9b0-4184-817e-11e851be9e1f" />

Useful for displaying the ID of an item in a Lens Table.

---

Also added tests and story. Worked around a histoire issue where it incorrectly watches the content in `.git` directory.