### PR TITLE
feat(http): support Sanctum authentication recovery

### DIFF
--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -51,7 +51,8 @@ interface HttpOptions {
   /**
    * Attempts to recover the application's server session after a `401`.
    * Return `true` to rebuild and retry the request. Return `false` when
-   * the session cannot be recovered.
+   * the session cannot be recovered. Set to `false` to disable a
+   * previously configured callback.
    *
    * @default undefined
    */
@@ -111,9 +112,17 @@ type HttpRequestOptions = FetchOptions & {
 }
 ```
 
-The recovery callback is authentication-provider agnostic. Applications can
-recover their Laravel session through any identity provider. It is configured
-once and applies to all requests by default:
+### Authentication recovery
+
+`Http` has two automatic recovery paths:
+
+- After a `419`, it refreshes the Sanctum CSRF token and retries the request.
+- After a `401`, it calls `recoverSession` and retries the request if the
+  callback returns `true`.
+
+Configure `recoverSession` once to apply it to all application requests by
+default. The callback can restore the Laravel session through any identity
+provider:
 
 ```ts
 httpConfig.apply({
@@ -121,9 +130,9 @@ httpConfig.apply({
 })
 ```
 
-Set `recoverSession` to `false` to disable a previously configured callback
-globally. Omitting it or passing `undefined` leaves the current configuration
-unchanged.
+Returning `false` leaves the original `401` unchanged. If the callback throws,
+its error is propagated. Set `recoverSession` to `false` to remove a previously
+configured callback.
 
 Requests used by the recovery flow itself should opt out:
 
@@ -133,26 +142,13 @@ await http.post('/api/auth/exchange', body, {
 })
 ```
 
-A `419` and a `401` are recovered independently. Sefirot can refresh CSRF after
-a `419`, then recover the session if the retried request returns a `401`. Each
-recovery stage runs at most once. Concurrent requests share the same in-progress
-recovery, and delayed `401` responses reuse a successful recovery completed
-after their request began. Returning `false` from `recoverSession` leaves the
-original `401` error observable to the caller. If the callback throws, its error
-remains observable instead.
+`sessionRecovery: false` disables `401` recovery for that request without
+disabling CSRF recovery.
 
-Sanctum behavior applies only when the effective request URL matches the
-configured `baseUrl` origin. A per-request `baseURL` override is applied before
-this comparison. When the configured `baseUrl` is unset, requests must resolve
-to the current page origin. Other origins receive neither the XSRF token nor
-automatic `401` or `419` recovery. During SSR, if no origin is available,
-relative base and request URLs are treated as application-local, while absolute
-request URLs are not.
-
-Automatic recovery retries only bodies Sefirot can identify as replayable, such
-as JSON values and standard reusable `BodyInit` values. Streams, iterators, and
-unknown object bodies are not retried because they may be consumed by the first
-send. The original `401` or `419` remains observable.
+Each recovery path retries at most once. Automatic recovery applies only to
+requests sent to the application origin (`baseUrl`, or the current page origin
+when unset). Concurrent `401` responses share one recovery attempt. Requests
+whose bodies cannot be safely sent again, such as streams, are not retried.
 
 ### `get`
 

--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -55,7 +55,7 @@ interface HttpOptions {
    *
    * @default undefined
    */
-  recoverSession?: () => boolean | PromiseLike<boolean>
+  recoverSession?: false | (() => boolean | PromiseLike<boolean>)
   /**
    * Returns additional headers for each request.
    *
@@ -121,6 +121,10 @@ httpConfig.apply({
 })
 ```
 
+Set `recoverSession` to `false` to disable a previously configured callback
+globally. Omitting it or passing `undefined` leaves the current configuration
+unchanged.
+
 Requests used by the recovery flow itself should opt out:
 
 ```ts
@@ -145,9 +149,10 @@ automatic `401` or `419` recovery. During SSR, if no origin is available,
 relative base and request URLs are treated as application-local, while absolute
 request URLs are not.
 
-Requests with a Web stream, Node stream, async iterable, or one-shot iterator
-body are not retried because their body may be consumed by the first send. The
-original `401` or `419` remains observable.
+Automatic recovery retries only bodies Sefirot can identify as replayable, such
+as JSON values and standard reusable `BodyInit` values. Streams, iterators, and
+unknown object bodies are not retried because they may be consumed by the first
+send. The original `401` or `419` remains observable.
 
 ### `get`
 

--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -131,9 +131,19 @@ await http.post('/api/auth/exchange', body, {
 
 A `419` and a `401` are recovered independently. Sefirot can refresh CSRF after
 a `419`, then recover the session if the retried request returns a `401`. Each
-recovery stage runs at most once, and concurrent requests share the same
-in-progress recovery. Returning `false` from `recoverSession` leaves the
+recovery stage runs at most once. Concurrent requests share the same in-progress
+recovery, and delayed `401` responses reuse a successful recovery completed
+after their request began. Returning `false` from `recoverSession` leaves the
 original `401` error observable to the caller.
+
+Sanctum behavior applies only when the effective request URL matches the
+configured `baseUrl` origin. A per-request `baseURL` override is applied before
+this comparison. When the configured `baseUrl` is unset, requests must resolve
+to the current page origin. Other origins receive neither the XSRF token nor
+automatic `401` or `419` recovery.
+
+Requests with a `ReadableStream` body are not retried because their body cannot
+be sent a second time. The original `401` or `419` remains observable.
 
 ### `get`
 

--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -140,7 +140,9 @@ Sanctum behavior applies only when the effective request URL matches the
 configured `baseUrl` origin. A per-request `baseURL` override is applied before
 this comparison. When the configured `baseUrl` is unset, requests must resolve
 to the current page origin. Other origins receive neither the XSRF token nor
-automatic `401` or `419` recovery.
+automatic `401` or `419` recovery. During SSR, if no origin is available,
+relative base and request URLs are treated as application-local, while absolute
+request URLs are not.
 
 Requests with a `ReadableStream` body are not retried because their body cannot
 be sent a second time. The original `401` or `419` remains observable.

--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -134,7 +134,8 @@ a `419`, then recover the session if the retried request returns a `401`. Each
 recovery stage runs at most once. Concurrent requests share the same in-progress
 recovery, and delayed `401` responses reuse a successful recovery completed
 after their request began. Returning `false` from `recoverSession` leaves the
-original `401` error observable to the caller.
+original `401` error observable to the caller. If the callback throws, its error
+remains observable instead.
 
 Sanctum behavior applies only when the effective request URL matches the
 configured `baseUrl` origin. A per-request `baseURL` override is applied before
@@ -144,8 +145,9 @@ automatic `401` or `419` recovery. During SSR, if no origin is available,
 relative base and request URLs are treated as application-local, while absolute
 request URLs are not.
 
-Requests with a `ReadableStream` body are not retried because their body cannot
-be sent a second time. The original `401` or `419` remains observable.
+Requests with a Web stream, Node stream, async iterable, or one-shot iterator
+body are not retried because their body may be consumed by the first send. The
+original `401` or `419` remains observable.
 
 ### `get`
 

--- a/docs/network-requests/http.md
+++ b/docs/network-requests/http.md
@@ -6,31 +6,31 @@
 
 The `Http` class. It uses [ofetch](https://github.com/unjs/ofetch) under the hood so that it can be smoothly used together with Nuxt.
 
-This class deeply integrates with [Laravel Sanctum](https://laravel.com/docs/sanctum), which is the authentication system used by Laravel. When instantiating the class, it will automatically checks for cookies and set the `X-XSRF-TOKEN` header. When cookies are missing, it will automatically make a request to the Laravel Sanctum endpoint to obtain it.
+This class deeply integrates with [Laravel Sanctum](https://laravel.com/docs/sanctum), which is the authentication system used by Laravel. Before an unsafe request, it checks for the `XSRF-TOKEN` cookie and sets the `X-XSRF-TOKEN` header. When the cookie is missing, it automatically requests one from the Laravel Sanctum endpoint. If Laravel rejects a stale token with a `419`, it refreshes the token and retries the request once.
 
 ```ts
 import { Http } from '@globalbrain/sefirot/lib/http/Http'
+import { useHttpConfig } from '@globalbrain/sefirot/lib/stores/HttpConfig'
 
-const http = new Http()
+const http = new Http(useHttpConfig())
 
 const res = http.get('https://example.com')
 ```
 
-### `static config`
+### Configuration
 
-Sets the default configuration for all requests.
+Use `useHttpConfig()` to set the default configuration for all requests.
 
 ```ts
-import { type FetchOptions } from 'ofetch'
+import { useHttpConfig } from '@globalbrain/sefirot/lib/stores/HttpConfig'
 
-class Http {
-  static config(options: HttpOptions): void
-}
+const httpConfig = useHttpConfig()
+httpConfig.apply(options)
 
 interface HttpOptions {
   /**
    * The base URL for all requests.
-   * @default '/'
+   * @default undefined
    */
   baseUrl?: string
   /**
@@ -49,14 +49,30 @@ interface HttpOptions {
    */
   client?: HttpClient
   /**
+   * Attempts to recover the application's server session after a `401`.
+   * Return `true` to rebuild and retry the request. Return `false` when
+   * the session cannot be recovered.
+   *
+   * @default undefined
+   */
+  recoverSession?: () => boolean | PromiseLike<boolean>
+  /**
+   * Returns additional headers for each request.
+   *
+   * @default () => ({})
+   */
+  headers?: () =>
+    | Record<string, string>
+    | PromiseLike<Record<string, string>>
+  /**
    * The language to use for Accept-Language header.
    * 
    * @default undefined
    */
   lang?: 'en' | 'ja'
   /**
-   * If you call `http.post` with a file, it will be send as `multipart/form-data`.
-   * The rest of the body will be send as JSON string. This option allows you to
+   * If you call `http.post` with a file, it will be sent as `multipart/form-data`.
+   * The rest of the body will be sent as a JSON string. This option allows you to
    * specify the key for the JSON part. This key should match the key in backend
    * middleware which parses the JSON part. Don't set this option to some common
    * key to avoid conflicts with other parts of the body. (Sending JSON part as
@@ -74,20 +90,60 @@ interface HttpOptions {
 }
 
 interface HttpClient {
-  <T = any>(request: FetchRequest, options?: FetchOptions): Promise<T>
-  raw<T = any>(request: FetchRequest, options?: FetchOptions): Promise<FetchResponse<T>>
+  (
+    request: FetchRequest,
+    options?: Omit<FetchOptions, 'method'>
+  ): Promise<any>
+  raw?(
+    request: FetchRequest,
+    options?: Omit<FetchOptions, 'method'>
+  ): Promise<FetchResponse<any>>
+}
+
+type HttpRequestOptions = FetchOptions & {
+  /**
+   * Authentication bootstrap requests should disable session recovery
+   * to prevent recursion.
+   *
+   * @default true
+   */
+  sessionRecovery?: false
 }
 ```
+
+The recovery callback is authentication-provider agnostic. Applications can
+recover their Laravel session through any identity provider. It is configured
+once and applies to all requests by default:
+
+```ts
+httpConfig.apply({
+  recoverSession: async () => Boolean(await authenticate())
+})
+```
+
+Requests used by the recovery flow itself should opt out:
+
+```ts
+await http.post('/api/auth/exchange', body, {
+  sessionRecovery: false
+})
+```
+
+A `419` and a `401` are recovered independently. Sefirot can refresh CSRF after
+a `419`, then recover the session if the retried request returns a `401`. Each
+recovery stage runs at most once, and concurrent requests share the same
+in-progress recovery. Returning `false` from `recoverSession` leaves the
+original `401` error observable to the caller.
 
 ### `get`
 
 Performs a `GET` request.
 
 ```ts
-import { type FetchOptions } from 'ofetch'
+import { type HttpRequestOptions } from '@globalbrain/sefirot/lib/http/Http'
 
 class Http {
-  get<T = any>(url: string, options?: FetchOptions): Promise<T>
+  get<T = any>(url: string, options?: HttpRequestOptions): Promise<T>
 }
 ```
 
@@ -96,10 +152,10 @@ class Http {
 Performs a `HEAD` request.
 
 ```ts
-import { type FetchOptions } from 'ofetch'
+import { type HttpRequestOptions } from '@globalbrain/sefirot/lib/http/Http'
 
 class Http {
-  head<T = any>(url: string, options?: FetchOptions): Promise<T>
+  head<T = any>(url: string, options?: HttpRequestOptions): Promise<T>
 }
 ```
 
@@ -108,10 +164,10 @@ class Http {
 Performs a `POST` request.
 
 ```ts
-import { type FetchOptions } from 'ofetch'
+import { type HttpRequestOptions } from '@globalbrain/sefirot/lib/http/Http'
 
 class Http {
-  post<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
+  post<T = any>(url: string, body?: any, options?: HttpRequestOptions): Promise<T>
 }
 ```
 
@@ -120,10 +176,10 @@ class Http {
 Performs a `PUT` request.
 
 ```ts
-import { type FetchOptions } from 'ofetch'
+import { type HttpRequestOptions } from '@globalbrain/sefirot/lib/http/Http'
 
 class Http {
-  put<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
+  put<T = any>(url: string, body?: any, options?: HttpRequestOptions): Promise<T>
 }
 ```
 
@@ -132,10 +188,10 @@ class Http {
 Performs a `PATCH` request.
 
 ```ts
-import { type FetchOptions } from 'ofetch'
+import { type HttpRequestOptions } from '@globalbrain/sefirot/lib/http/Http'
 
 class Http {
-  patch<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
+  patch<T = any>(url: string, body?: any, options?: HttpRequestOptions): Promise<T>
 }
 ```
 
@@ -144,10 +200,10 @@ class Http {
 Performs a `DELETE` request.
 
 ```ts
-import { type FetchOptions } from 'ofetch'
+import { type HttpRequestOptions } from '@globalbrain/sefirot/lib/http/Http'
 
 class Http {
-  delete<T = any>(url: string, options?: FetchOptions): Promise<T>
+  delete<T = any>(url: string, options?: HttpRequestOptions): Promise<T>
 }
 ```
 
@@ -156,10 +212,10 @@ class Http {
 Performs a `POST` request with `multipart/form-data` content type. Useful for uploading files. It also handles nested body structures as well.
 
 ```ts
-import { type FetchOptions } from 'ofetch'
+import { type HttpRequestOptions } from '@globalbrain/sefirot/lib/http/Http'
 
 class Http {
-  upload<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T>
+  upload<T = any>(url: string, body?: any, options?: HttpRequestOptions): Promise<T>
 }
 ```
 
@@ -168,9 +224,9 @@ class Http {
 Download a file from the response. Use this method when you want browser to save a file to local disk.
 
 ```ts
-import { type FetchOptions } from 'ofetch'
+import { type HttpRequestOptions } from '@globalbrain/sefirot/lib/http/Http'
 
 class Http {
-  download<T = any>(url: string, options?: FetchOptions): Promise<T>
+  download(url: string, options?: HttpRequestOptions): Promise<void>
 }
 ```

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -3,9 +3,43 @@ import { parse as parseCookie } from '@tinyhttp/cookie'
 import { FetchError, type FetchOptions, type FetchResponse } from 'ofetch'
 import { stringify } from 'qs'
 import { saveAs } from '../support/File'
-import { objectToFormData } from '../support/Http'
+import { getHttpStatusCode, objectToFormData } from '../support/Http'
 
 type Config = ReturnType<typeof import('../stores/HttpConfig').useHttpConfig>
+type BuiltRequest = [url: string, options: FetchOptions]
+
+export type HttpRequestOptions = FetchOptions & {
+  /**
+   * Prevent this request from recursively recovering the application session.
+   * Authentication bootstrap requests should disable session recovery.
+   */
+  sessionRecovery?: false
+}
+
+const xsrfRefreshes = new WeakMap<Config, Promise<void>>()
+const sessionRecoveries = new WeakMap<Config, Promise<boolean>>()
+
+async function runSingleFlight<T>(
+  activeRequests: WeakMap<Config, Promise<T>>,
+  config: Config,
+  request: () => Promise<T>
+): Promise<T> {
+  const activeRequest = activeRequests.get(config)
+  if (activeRequest) {
+    return activeRequest
+  }
+
+  const nextRequest = Promise.resolve().then(request)
+  activeRequests.set(config, nextRequest)
+
+  try {
+    return await nextRequest
+  } finally {
+    if (activeRequests.get(config) === nextRequest) {
+      activeRequests.delete(config)
+    }
+  }
+}
 
 export class Http {
   private config: Config
@@ -22,15 +56,42 @@ export class Http {
     let xsrfToken = parseCookie(document.cookie)['XSRF-TOKEN']
 
     if (!xsrfToken) {
-      await this.head(this.config.xsrfUrl)
+      await this.refreshXsrfToken()
       xsrfToken = parseCookie(document.cookie)['XSRF-TOKEN']
     }
 
     return xsrfToken
   }
 
-  private async buildRequest(url: string, _options: FetchOptions = {}): Promise<[string, FetchOptions]> {
+  private async refreshXsrfToken(): Promise<void> {
+    const xsrfUrl = this.config.xsrfUrl
+    if (!xsrfUrl) {
+      return
+    }
+
+    return runSingleFlight(xsrfRefreshes, this.config, async () => {
+      await this.config.client(...(await this.buildRequest(
+        xsrfUrl,
+        { method: 'HEAD' }
+      )))
+    })
+  }
+
+  private async recoverSession(): Promise<boolean> {
+    const recoverSession = this.config.recoverSession
+    if (!recoverSession) {
+      return false
+    }
+
+    return runSingleFlight(sessionRecoveries, this.config, async () => {
+      return recoverSession()
+    })
+  }
+
+  private async buildRequest(url: string, _options: HttpRequestOptions = {}): Promise<BuiltRequest> {
     const { method, params, query, ...options } = _options
+    delete options.sessionRecovery
+
     const xsrfToken = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '')
       && (await this.ensureXsrfToken())
 
@@ -57,25 +118,73 @@ export class Http {
     ]
   }
 
-  private async performRequest<T>(url: string, options: FetchOptions = {}): Promise<T> {
-    return this.config.client(...(await this.buildRequest(url, options)))
+  private async execute<T>(
+    url: string,
+    options: HttpRequestOptions,
+    send: (request: BuiltRequest) => Promise<T>
+  ): Promise<T> {
+    const attempt = async (
+      xsrfRecovered = false,
+      sessionRecovered = false
+    ): Promise<T> => {
+      try {
+        return await send(await this.buildRequest(url, options))
+      } catch (error) {
+        const status = getHttpStatusCode(error)
+
+        if (status === 419 && this.config.xsrfUrl && !xsrfRecovered) {
+          await this.refreshXsrfToken()
+          return attempt(true, sessionRecovered)
+        }
+
+        const canRecoverSession =
+          options.sessionRecovery !== false
+          && this.config.recoverSession != null
+          && !sessionRecovered
+
+        if (status === 401 && canRecoverSession) {
+          if (await this.recoverSession()) {
+            return attempt(xsrfRecovered, true)
+          }
+        }
+
+        throw error
+      }
+    }
+
+    return attempt()
   }
 
-  private async performRequestRaw<T>(url: string, options: FetchOptions = {}): Promise<FetchResponse<T>> {
+  private async performRequest<T>(url: string, options: HttpRequestOptions = {}): Promise<T> {
+    return this.execute(
+      url,
+      options,
+      (request) => this.config.client(...request)
+    )
+  }
+
+  private async performRequestRaw<T>(
+    url: string,
+    options: HttpRequestOptions = {}
+  ): Promise<FetchResponse<T>> {
     // 'raw' is unavailable in useRequestFetch() during SSR, but performRequestRaw is only
     // called by download, which runs client-side, so asserting raw's existence is safe
-    return this.config.client.raw!(...(await this.buildRequest(url, options)))
+    return this.execute(
+      url,
+      options,
+      (request) => this.config.client.raw!(...request)
+    )
   }
 
-  async get<T = any>(url: string, options?: FetchOptions): Promise<T> {
+  async get<T = any>(url: string, options?: HttpRequestOptions): Promise<T> {
     return this.performRequest<T>(url, { method: 'GET', ...options })
   }
 
-  async head<T = any>(url: string, options?: FetchOptions): Promise<T> {
+  async head<T = any>(url: string, options?: HttpRequestOptions): Promise<T> {
     return this.performRequest<T>(url, { method: 'HEAD', ...options })
   }
 
-  async post<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T> {
+  async post<T = any>(url: string, body?: any, options?: HttpRequestOptions): Promise<T> {
     if (body && !(body instanceof FormData)) {
       let hasFile = false
 
@@ -99,23 +208,23 @@ export class Http {
     return this.performRequest<T>(url, { method: 'POST', body, ...options })
   }
 
-  async put<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T> {
+  async put<T = any>(url: string, body?: any, options?: HttpRequestOptions): Promise<T> {
     return this.performRequest<T>(url, { method: 'PUT', body, ...options })
   }
 
-  async patch<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T> {
+  async patch<T = any>(url: string, body?: any, options?: HttpRequestOptions): Promise<T> {
     return this.performRequest<T>(url, { method: 'PATCH', body, ...options })
   }
 
-  async delete<T = any>(url: string, options?: FetchOptions): Promise<T> {
+  async delete<T = any>(url: string, options?: HttpRequestOptions): Promise<T> {
     return this.performRequest<T>(url, { method: 'DELETE', ...options })
   }
 
-  async upload<T = any>(url: string, body?: any, options?: FetchOptions): Promise<T> {
+  async upload<T = any>(url: string, body?: any, options?: HttpRequestOptions): Promise<T> {
     return this.post<T>(url, objectToFormData(body), options)
   }
 
-  async download(url: string, options?: FetchOptions): Promise<void> {
+  async download(url: string, options?: HttpRequestOptions): Promise<void> {
     const { _data: blob, headers } =
       await this.performRequestRaw<Blob>(url, { method: 'GET', responseType: 'blob', ...options })
 

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -40,21 +40,47 @@ function isLocalUrlReference(url: string): boolean {
 }
 
 function isReplayableBody(body: unknown): boolean {
-  if (!body || typeof body !== 'object') {
+  if (body == null) {
+    return true
+  }
+
+  if (typeof body !== 'object') {
+    return ['string', 'number', 'boolean'].includes(typeof body)
+  }
+
+  if (
+    Array.isArray(body)
+    || body instanceof Blob
+    || body instanceof FormData
+    || body instanceof URLSearchParams
+    || body instanceof ArrayBuffer
+    || ArrayBuffer.isView(body)
+  ) {
     return true
   }
 
   const source = body as {
+    constructor?: { name?: string }
     pipeTo?: unknown
     pipe?: unknown
     next?: unknown
+    toJSON?: unknown
+    [Symbol.iterator]?: unknown
     [Symbol.asyncIterator]?: unknown
   }
 
-  return typeof source.pipeTo !== 'function'
-    && typeof source.pipe !== 'function'
-    && typeof source.next !== 'function'
-    && typeof source[Symbol.asyncIterator] !== 'function'
+  if (
+    typeof source.pipeTo === 'function'
+    || typeof source.pipe === 'function'
+    || typeof source.next === 'function'
+    || typeof source[Symbol.iterator] === 'function'
+    || typeof source[Symbol.asyncIterator] === 'function'
+  ) {
+    return false
+  }
+
+  return source.constructor?.name === 'Object'
+    || typeof source.toJSON === 'function'
 }
 
 async function runSingleFlight<T>(

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -19,13 +19,24 @@ export type HttpRequestOptions = FetchOptions & {
 const xsrfRefreshes = new WeakMap<Config, Promise<void>>()
 const sessionRecoveries = new WeakMap<Config, Promise<boolean>>()
 const sessionRecoveryGenerations = new WeakMap<Config, number>()
+const relativeUrlBases = [
+  new URL('http://a.sefirot.invalid'),
+  new URL('http://b.sefirot.invalid')
+]
 
 function getSessionRecoveryGeneration(config: Config): number {
   return sessionRecoveryGenerations.get(config) ?? 0
 }
 
-function isAbsoluteUrl(url: string): boolean {
-  return /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i.test(url.trimStart())
+function isLocalUrlReference(url: string): boolean {
+  if (URL.canParse(url)) {
+    return false
+  }
+
+  return relativeUrlBases.every(
+    (base) => URL.canParse(url, base)
+      && new URL(url, base).origin === base.origin
+  )
 }
 
 function isReplayableBody(body: unknown): boolean {
@@ -33,21 +44,17 @@ function isReplayableBody(body: unknown): boolean {
     return true
   }
 
-  const stream = body as {
-    constructor?: { name?: string }
+  const source = body as {
     pipeTo?: unknown
     pipe?: unknown
-    toJSON?: unknown
-  }
-  if (
-    Array.isArray(body)
-    || stream.constructor?.name === 'Object'
-    || typeof stream.toJSON === 'function'
-  ) {
-    return true
+    next?: unknown
+    [Symbol.asyncIterator]?: unknown
   }
 
-  return typeof stream.pipeTo !== 'function' && typeof stream.pipe !== 'function'
+  return typeof source.pipeTo !== 'function'
+    && typeof source.pipe !== 'function'
+    && typeof source.next !== 'function'
+    && typeof source[Symbol.asyncIterator] !== 'function'
 }
 
 async function runSingleFlight<T>(
@@ -96,24 +103,25 @@ export class Http {
 
   private isApplicationRequest(url: string, options: HttpRequestOptions = {}): boolean {
     const pageUrl = typeof location === 'undefined' ? undefined : location.href
-    const applicationBaseUrl = this.config.baseUrl ?? pageUrl
-    if (!applicationBaseUrl) {
-      return !isAbsoluteUrl(url)
-        && (options.baseURL == null || !isAbsoluteUrl(options.baseURL))
-    }
-
-    if (!pageUrl && !isAbsoluteUrl(applicationBaseUrl)) {
-      return !isAbsoluteUrl(url)
-        && (options.baseURL == null || !isAbsoluteUrl(options.baseURL))
+    const applicationBaseUrl = this.config.baseUrl || pageUrl
+    const requestBaseUrl = Object.hasOwn(options, 'baseURL')
+      ? options.baseURL
+      : this.config.baseUrl
+    if (
+      !applicationBaseUrl
+      || (!pageUrl && isLocalUrlReference(applicationBaseUrl))
+    ) {
+      return isLocalUrlReference(url)
+        && (requestBaseUrl == null || isLocalUrlReference(requestBaseUrl))
     }
 
     try {
       const applicationUrl = new URL(applicationBaseUrl, pageUrl)
-      const requestBaseUrl = options.baseURL == null
-        ? applicationUrl
-        : new URL(options.baseURL, pageUrl)
+      const resolvedRequestBaseUrl = requestBaseUrl
+        ? new URL(requestBaseUrl, pageUrl)
+        : pageUrl
 
-      return new URL(url, requestBaseUrl).origin === applicationUrl.origin
+      return new URL(url, resolvedRequestBaseUrl).origin === applicationUrl.origin
     } catch {
       return false
     }

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -24,6 +24,10 @@ function getSessionRecoveryGeneration(config: Config): number {
   return sessionRecoveryGenerations.get(config) ?? 0
 }
 
+function isAbsoluteUrl(url: string): boolean {
+  return /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i.test(url)
+}
+
 function isReplayableBody(body: unknown): boolean {
   if (!body || typeof body !== 'object') {
     return true
@@ -94,8 +98,13 @@ export class Http {
     const pageUrl = typeof location === 'undefined' ? undefined : location.href
     const applicationBaseUrl = this.config.baseUrl ?? pageUrl
     if (!applicationBaseUrl) {
-      return options.baseURL == null
-        && !/^(?:[a-z][a-z\d+\-.]*:)?\/\//i.test(url)
+      return !isAbsoluteUrl(url)
+        && (options.baseURL == null || !isAbsoluteUrl(options.baseURL))
+    }
+
+    if (!pageUrl && !isAbsoluteUrl(applicationBaseUrl)) {
+      return !isAbsoluteUrl(url)
+        && (options.baseURL == null || !isAbsoluteUrl(options.baseURL))
     }
 
     try {

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -25,7 +25,7 @@ function getSessionRecoveryGeneration(config: Config): number {
 }
 
 function isAbsoluteUrl(url: string): boolean {
-  return /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i.test(url)
+  return /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i.test(url.trimStart())
 }
 
 function isReplayableBody(body: unknown): boolean {
@@ -194,10 +194,11 @@ export class Http {
       xsrfRecovered = false,
       sessionRecovered = false
     ): Promise<T> => {
+      const request = await this.buildRequest(url, options)
       const sessionRecoveryGeneration = getSessionRecoveryGeneration(this.config)
 
       try {
-        return await send(await this.buildRequest(url, options))
+        return await send(request)
       } catch (error) {
         const status = getHttpStatusCode(error)
 

--- a/lib/http/Http.ts
+++ b/lib/http/Http.ts
@@ -18,6 +18,33 @@ export type HttpRequestOptions = FetchOptions & {
 
 const xsrfRefreshes = new WeakMap<Config, Promise<void>>()
 const sessionRecoveries = new WeakMap<Config, Promise<boolean>>()
+const sessionRecoveryGenerations = new WeakMap<Config, number>()
+
+function getSessionRecoveryGeneration(config: Config): number {
+  return sessionRecoveryGenerations.get(config) ?? 0
+}
+
+function isReplayableBody(body: unknown): boolean {
+  if (!body || typeof body !== 'object') {
+    return true
+  }
+
+  const stream = body as {
+    constructor?: { name?: string }
+    pipeTo?: unknown
+    pipe?: unknown
+    toJSON?: unknown
+  }
+  if (
+    Array.isArray(body)
+    || stream.constructor?.name === 'Object'
+    || typeof stream.toJSON === 'function'
+  ) {
+    return true
+  }
+
+  return typeof stream.pipeTo !== 'function' && typeof stream.pipe !== 'function'
+}
 
 async function runSingleFlight<T>(
   activeRequests: WeakMap<Config, Promise<T>>,
@@ -63,6 +90,26 @@ export class Http {
     return xsrfToken
   }
 
+  private isApplicationRequest(url: string, options: HttpRequestOptions = {}): boolean {
+    const pageUrl = typeof location === 'undefined' ? undefined : location.href
+    const applicationBaseUrl = this.config.baseUrl ?? pageUrl
+    if (!applicationBaseUrl) {
+      return options.baseURL == null
+        && !/^(?:[a-z][a-z\d+\-.]*:)?\/\//i.test(url)
+    }
+
+    try {
+      const applicationUrl = new URL(applicationBaseUrl, pageUrl)
+      const requestBaseUrl = options.baseURL == null
+        ? applicationUrl
+        : new URL(options.baseURL, pageUrl)
+
+      return new URL(url, requestBaseUrl).origin === applicationUrl.origin
+    } catch {
+      return false
+    }
+  }
+
   private async refreshXsrfToken(): Promise<void> {
     const xsrfUrl = this.config.xsrfUrl
     if (!xsrfUrl) {
@@ -84,7 +131,14 @@ export class Http {
     }
 
     return runSingleFlight(sessionRecoveries, this.config, async () => {
-      return recoverSession()
+      const recovered = await recoverSession()
+      if (recovered) {
+        sessionRecoveryGenerations.set(
+          this.config,
+          getSessionRecoveryGeneration(this.config) + 1
+        )
+      }
+      return recovered
     })
   }
 
@@ -92,7 +146,8 @@ export class Http {
     const { method, params, query, ...options } = _options
     delete options.sessionRecovery
 
-    const xsrfToken = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '')
+    const xsrfToken = this.isApplicationRequest(url, _options)
+      && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method || '')
       && (await this.ensureXsrfToken())
 
     const queryString = stringify(
@@ -123,27 +178,43 @@ export class Http {
     options: HttpRequestOptions,
     send: (request: BuiltRequest) => Promise<T>
   ): Promise<T> {
+    const applicationRequest = this.isApplicationRequest(url, options)
+    const replayable = isReplayableBody(options.body)
+
     const attempt = async (
       xsrfRecovered = false,
       sessionRecovered = false
     ): Promise<T> => {
+      const sessionRecoveryGeneration = getSessionRecoveryGeneration(this.config)
+
       try {
         return await send(await this.buildRequest(url, options))
       } catch (error) {
         const status = getHttpStatusCode(error)
 
-        if (status === 419 && this.config.xsrfUrl && !xsrfRecovered) {
+        if (
+          status === 419
+          && applicationRequest
+          && replayable
+          && this.config.xsrfUrl
+          && !xsrfRecovered
+        ) {
           await this.refreshXsrfToken()
           return attempt(true, sessionRecovered)
         }
 
         const canRecoverSession =
-          options.sessionRecovery !== false
+          applicationRequest
+          && replayable
+          && options.sessionRecovery !== false
           && this.config.recoverSession != null
           && !sessionRecovered
 
         if (status === 401 && canRecoverSession) {
-          if (await this.recoverSession()) {
+          const alreadyRecovered =
+            sessionRecoveryGeneration !== getSessionRecoveryGeneration(this.config)
+
+          if (alreadyRecovered || await this.recoverSession()) {
             return attempt(xsrfRecovered, true)
           }
         }

--- a/lib/stores/HttpConfig.ts
+++ b/lib/stores/HttpConfig.ts
@@ -15,6 +15,7 @@ export interface HttpOptions {
   baseUrl?: string
   xsrfUrl?: string | false
   client?: HttpClient
+  recoverSession?: () => Awaitable<boolean>
   lang?: Lang
   payloadKey?: string
   headers?: () => Awaitable<Record<string, string>>
@@ -25,6 +26,7 @@ export const useHttpConfig = defineStore('sefirot-http-config', () => {
   const baseUrl = ref<string | undefined>(undefined)
   const xsrfUrl = ref<string | false>('/api/csrf-cookie')
   const client = ref<HttpClient>(ofetch)
+  const recoverSession = ref<(() => Awaitable<boolean>) | undefined>(undefined)
   const lang = ref<Lang | undefined>(undefined)
   const payloadKey = ref<string>('__payload__')
   const headers = ref<() => Awaitable<Record<string, string>>>(async () => ({}))
@@ -34,6 +36,7 @@ export const useHttpConfig = defineStore('sefirot-http-config', () => {
     if (options.baseUrl != null) { baseUrl.value = options.baseUrl }
     if (options.xsrfUrl != null) { xsrfUrl.value = options.xsrfUrl }
     if (options.client != null) { client.value = options.client }
+    if (options.recoverSession != null) { recoverSession.value = options.recoverSession }
     if (options.lang != null) { lang.value = options.lang }
     if (options.payloadKey != null) { payloadKey.value = options.payloadKey }
     if (options.headers != null) { headers.value = options.headers }
@@ -44,6 +47,7 @@ export const useHttpConfig = defineStore('sefirot-http-config', () => {
     baseUrl: computed(() => baseUrl.value),
     xsrfUrl: computed(() => xsrfUrl.value),
     client: computed(() => client.value),
+    recoverSession: computed(() => recoverSession.value),
     lang: computed(() => lang.value),
     payloadKey: computed(() => payloadKey.value),
     headers: computed(() => headers.value),

--- a/lib/stores/HttpConfig.ts
+++ b/lib/stores/HttpConfig.ts
@@ -15,7 +15,7 @@ export interface HttpOptions {
   baseUrl?: string
   xsrfUrl?: string | false
   client?: HttpClient
-  recoverSession?: () => Awaitable<boolean>
+  recoverSession?: false | (() => Awaitable<boolean>)
   lang?: Lang
   payloadKey?: string
   headers?: () => Awaitable<Record<string, string>>
@@ -36,7 +36,9 @@ export const useHttpConfig = defineStore('sefirot-http-config', () => {
     if (options.baseUrl != null) { baseUrl.value = options.baseUrl }
     if (options.xsrfUrl != null) { xsrfUrl.value = options.xsrfUrl }
     if (options.client != null) { client.value = options.client }
-    if (options.recoverSession != null) { recoverSession.value = options.recoverSession }
+    if (options.recoverSession != null) {
+      recoverSession.value = options.recoverSession || undefined
+    }
     if (options.lang != null) { lang.value = options.lang }
     if (options.payloadKey != null) { payloadKey.value = options.payloadKey }
     if (options.headers != null) { headers.value = options.headers }

--- a/tests/http/Http.spec.ts
+++ b/tests/http/Http.spec.ts
@@ -391,6 +391,7 @@ describe('http/Http', () => {
   })
 
   it.each([401, 419])('does not retry a %i response with a one-shot body', async (status) => {
+    document.cookie = 'XSRF-TOKEN=valid; Path=/'
     const error = httpError(status)
     const recoverSession = vi.fn(async () => true)
     const client = vi.fn(async () => {
@@ -407,6 +408,7 @@ describe('http/Http', () => {
   })
 
   it('does not retry a response with a Node stream body', async () => {
+    document.cookie = 'XSRF-TOKEN=valid; Path=/'
     const error = httpError(401)
     const recoverSession = vi.fn(async () => true)
     const client = vi.fn(async () => {
@@ -416,6 +418,84 @@ describe('http/Http', () => {
 
     await expect(
       http.put('/api/items', Readable.from('content'))
+    ).rejects.toBe(error)
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('does not retry a response with an async iterable body', async () => {
+    document.cookie = 'XSRF-TOKEN=valid; Path=/'
+
+    async function* body(): AsyncGenerator<string> {
+      yield 'content'
+    }
+
+    const error = httpError(401)
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async (_request, options) => {
+      for await (const chunk of options?.body as AsyncIterable<string>) {
+        expect(chunk).toBe('content')
+      }
+      throw error
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(
+      http.put('/api/items', body())
+    ).rejects.toBe(error)
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('does not retry a response with a one-shot sync iterator body', async () => {
+    document.cookie = 'XSRF-TOKEN=valid; Path=/'
+
+    function* body(): Generator<string> {
+      yield 'content'
+    }
+
+    const error = httpError(401)
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async (_request, options) => {
+      for (const chunk of options?.body as Iterable<string>) {
+        expect(chunk).toBe('content')
+      }
+      throw error
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(
+      http.put('/api/items', body())
+    ).rejects.toBe(error)
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('does not retry a response with a bare one-shot iterator body', async () => {
+    document.cookie = 'XSRF-TOKEN=valid; Path=/'
+
+    const values = ['content']
+    const body = {
+      next: (): IteratorResult<string> => values.length
+        ? { done: false, value: values.shift()! }
+        : { done: true, value: undefined }
+    }
+    const error = httpError(401)
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async (_request, options) => {
+      const iterator = options?.body as Iterator<string>
+      while (!iterator.next().done) {
+        // Consume the one-shot body before returning the response.
+      }
+      throw error
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(
+      http.put('/api/items', body)
     ).rejects.toBe(error)
 
     expect(recoverSession).not.toHaveBeenCalled()
@@ -448,6 +528,31 @@ describe('http/Http', () => {
     expect(client).toHaveBeenCalledOnce()
   })
 
+  it('matches request scoping when baseURL is explicitly undefined', async () => {
+    document.cookie = 'XSRF-TOKEN=secret; Path=/'
+    const error = httpError(401)
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async (_request, options) => {
+      expect(options?.baseURL).toBeUndefined()
+      expect(xsrfHeader(options)).toBeNull()
+      throw error
+    })
+    const config = useHttpConfig()
+    config.apply({
+      baseUrl: 'https://app.example.com',
+      client,
+      recoverSession
+    })
+    const http = new Http(config)
+
+    await expect(
+      http.post('/items', undefined, { baseURL: undefined })
+    ).rejects.toBe(error)
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
   it('recovers absolute URLs on the configured application origin', async () => {
     let requestCount = 0
     const recoverSession = vi.fn(async () => true)
@@ -468,6 +573,32 @@ describe('http/Http', () => {
 
     await expect(
       http.get('https://app.example.com/items')
+    ).resolves.toBe('ok')
+
+    expect(recoverSession).toHaveBeenCalledOnce()
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the page origin when the configured base URL is empty', async () => {
+    let requestCount = 0
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async () => {
+      requestCount++
+      if (requestCount === 1) {
+        throw httpError(401)
+      }
+      return 'ok'
+    })
+    const config = useHttpConfig()
+    config.apply({
+      baseUrl: '',
+      client,
+      recoverSession
+    })
+    const http = new Http(config)
+
+    await expect(
+      http.get(new URL('/items', location.href).href)
     ).resolves.toBe('ok')
 
     expect(recoverSession).toHaveBeenCalledOnce()
@@ -522,7 +653,11 @@ describe('http/Http', () => {
     expect(client).toHaveBeenCalledOnce()
   })
 
-  it('does not recover whitespace-prefixed absolute URLs during SSR', async () => {
+  it.each([
+    ' https://example.com/items',
+    '\0https://example.com/items',
+    '//sefirot.invalid/items'
+  ])('does not recover externally resolving URL %j during SSR', async (url) => {
     vi.stubGlobal('location', undefined)
     document.cookie = 'XSRF-TOKEN=secret; Path=/'
     const error = httpError(401)
@@ -540,7 +675,7 @@ describe('http/Http', () => {
     const http = new Http(config)
 
     await expect(
-      http.post(' https://example.com/items')
+      http.post(url)
     ).rejects.toBe(error)
 
     expect(recoverSession).not.toHaveBeenCalled()

--- a/tests/http/Http.spec.ts
+++ b/tests/http/Http.spec.ts
@@ -11,6 +11,10 @@ describe('http/Http', () => {
     document.cookie = 'XSRF-TOKEN=; Max-Age=0; Path=/'
   })
 
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('refreshes a stale Sanctum CSRF token and retries once after a 419', async () => {
     document.cookie = 'XSRF-TOKEN=stale; Path=/'
     let requestCount = 0
@@ -400,6 +404,54 @@ describe('http/Http', () => {
 
     expect(recoverSession).toHaveBeenCalledOnce()
     expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('recovers relative application URLs with a relative base URL during SSR', async () => {
+    vi.stubGlobal('location', undefined)
+    let requestCount = 0
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async () => {
+      requestCount++
+      if (requestCount === 1) {
+        throw httpError(401)
+      }
+      return 'ok'
+    })
+    const config = useHttpConfig()
+    config.apply({
+      baseUrl: '/api',
+      client,
+      recoverSession
+    })
+    const http = new Http(config)
+
+    await expect(http.get('/items')).resolves.toBe('ok')
+
+    expect(recoverSession).toHaveBeenCalledOnce()
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not recover absolute URLs when the application origin is unavailable during SSR', async () => {
+    vi.stubGlobal('location', undefined)
+    const error = httpError(401)
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async () => {
+      throw error
+    })
+    const config = useHttpConfig()
+    config.apply({
+      baseUrl: '/api',
+      client,
+      recoverSession
+    })
+    const http = new Http(config)
+
+    await expect(
+      http.get('https://example.com/items')
+    ).rejects.toBe(error)
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
   })
 
   it('leaves callback errors observable', async () => {

--- a/tests/http/Http.spec.ts
+++ b/tests/http/Http.spec.ts
@@ -1,0 +1,392 @@
+import { type FetchOptions, type FetchResponse, Http } from 'sefirot/http/Http'
+import { type HttpClient, useHttpConfig } from 'sefirot/stores/HttpConfig'
+
+vi.mock('sefirot/support/File', () => ({
+  saveAs: vi.fn()
+}))
+
+describe('http/Http', () => {
+  beforeEach(() => {
+    document.cookie = 'XSRF-TOKEN=; Max-Age=0; Path=/'
+  })
+
+  it('refreshes a stale Sanctum CSRF token and retries once after a 419', async () => {
+    document.cookie = 'XSRF-TOKEN=stale; Path=/'
+    let requestCount = 0
+    const recoverSession = vi.fn(async () => true)
+
+    const client = vi.fn(async (request, options) => {
+      if (request === '/api/csrf-cookie') {
+        document.cookie = 'XSRF-TOKEN=fresh; Path=/'
+        return
+      }
+
+      requestCount++
+
+      if (requestCount === 1) {
+        expect(xsrfHeader(options)).toBe('stale')
+        throw httpError(419)
+      }
+
+      expect(xsrfHeader(options)).toBe('fresh')
+      return 'ok'
+    })
+
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(http.post('/api/items', { name: 'item' })).resolves.toBe('ok')
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client.mock.calls.map(([request]) => request)).toEqual([
+      '/api/items',
+      '/api/csrf-cookie',
+      '/api/items'
+    ])
+  })
+
+  it('shares a CSRF refresh across concurrent 419 responses', async () => {
+    document.cookie = 'XSRF-TOKEN=stale; Path=/'
+    const attempts = new Map<string, number>()
+    let releaseRefresh: () => void
+    const refresh = new Promise<void>((resolve) => {
+      releaseRefresh = resolve
+    })
+
+    const client = vi.fn(async (request) => {
+      if (request === '/api/csrf-cookie') {
+        await refresh
+        document.cookie = 'XSRF-TOKEN=fresh; Path=/'
+        return
+      }
+
+      const url = String(request)
+      const attempt = (attempts.get(url) ?? 0) + 1
+      attempts.set(url, attempt)
+
+      if (attempt === 1) {
+        throw httpError(419)
+      }
+
+      return url
+    })
+
+    const config = useHttpConfig()
+    config.apply({ client })
+    const requests = Promise.all([
+      new Http(config).post('/api/one'),
+      new Http(config).post('/api/two')
+    ])
+
+    await vi.waitFor(() => {
+      expect(client.mock.calls.filter(([request]) => request === '/api/csrf-cookie')).toHaveLength(1)
+    })
+
+    releaseRefresh!()
+
+    await expect(requests).resolves.toEqual(['/api/one', '/api/two'])
+  })
+
+  it('does not retry a second 419 response', async () => {
+    document.cookie = 'XSRF-TOKEN=stale; Path=/'
+
+    const client = vi.fn(async (request) => {
+      if (request === '/api/csrf-cookie') {
+        document.cookie = 'XSRF-TOKEN=fresh; Path=/'
+        return
+      }
+
+      throw httpError(419)
+    })
+
+    const http = setupHttp(client)
+
+    await expect(http.post('/api/items')).rejects.toMatchObject({ status: 419 })
+    expect(client.mock.calls.map(([request]) => request)).toEqual([
+      '/api/items',
+      '/api/csrf-cookie',
+      '/api/items'
+    ])
+  })
+
+  it('can recover the session after repairing a 419', async () => {
+    document.cookie = 'XSRF-TOKEN=stale; Path=/'
+    let requestCount = 0
+    const recoverSession = vi.fn(async () => true)
+
+    const client = vi.fn(async (request) => {
+      if (request === '/api/csrf-cookie') {
+        document.cookie = 'XSRF-TOKEN=fresh; Path=/'
+        return
+      }
+
+      requestCount++
+      if (requestCount === 1) {
+        throw httpError(419)
+      }
+      if (requestCount === 2) {
+        throw httpError(401)
+      }
+
+      return 'ok'
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(http.post('/api/items')).resolves.toBe('ok')
+    expect(recoverSession).toHaveBeenCalledOnce()
+    expect(client.mock.calls.map(([request]) => request)).toEqual([
+      '/api/items',
+      '/api/csrf-cookie',
+      '/api/items',
+      '/api/items'
+    ])
+  })
+
+  it('recovers the application session and rebuilds the request after a 401', async () => {
+    document.cookie = 'XSRF-TOKEN=valid; Path=/'
+    let requestCount = 0
+    const recoverSession = vi.fn(async () => true)
+
+    const client = vi.fn(async (request, options) => {
+      requestCount++
+
+      if (requestCount === 1) {
+        expect(xsrfHeader(options)).toBe('valid')
+        throw httpError(401)
+      }
+
+      expect(xsrfHeader(options)).toBe('valid')
+      return 'ok'
+    })
+
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(http.post('/api/items')).resolves.toBe('ok')
+    expect(recoverSession).toHaveBeenCalledOnce()
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry a 401 when the application session cannot be restored', async () => {
+    const recoverSession = vi.fn(async () => false)
+    const error = httpError(401)
+    const client = vi.fn(async (request) => {
+      if (request === '/api/csrf-cookie') {
+        return
+      }
+
+      throw error
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(http.get('/api/items')).rejects.toBe(error)
+    expect(recoverSession).toHaveBeenCalledOnce()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('does not recover a second 401 response', async () => {
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async () => {
+      throw httpError(401)
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(http.get('/api/items')).rejects.toMatchObject({ status: 401 })
+    expect(recoverSession).toHaveBeenCalledOnce()
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('can opt an authentication bootstrap request out of session recovery', async () => {
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async (request) => {
+      if (request === '/api/csrf-cookie') {
+        return
+      }
+
+      throw httpError(401)
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(
+      http.get('/api/auth/check', { sessionRecovery: false })
+    ).rejects.toMatchObject({ status: 401 })
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('still repairs a bootstrap request after a 419 without recovering the session', async () => {
+    document.cookie = 'XSRF-TOKEN=stale; Path=/'
+    const recoverSession = vi.fn(async () => true)
+    let requestCount = 0
+
+    const client = vi.fn(async (request) => {
+      if (request === '/api/csrf-cookie') {
+        document.cookie = 'XSRF-TOKEN=fresh; Path=/'
+        return
+      }
+
+      requestCount++
+      if (requestCount === 1) {
+        throw httpError(419)
+      }
+
+      return 'ok'
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(
+      http.post('/api/auth/exchange', undefined, { sessionRecovery: false })
+    ).resolves.toBe('ok')
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledTimes(3)
+  })
+
+  it('shares session recovery across concurrent 401 responses', async () => {
+    const attempts = new Map<string, number>()
+    let releaseRecovery: () => void
+    const recovery = new Promise<void>((resolve) => {
+      releaseRecovery = resolve
+    })
+    const recoverSession = vi.fn(async () => {
+      await recovery
+      return true
+    })
+
+    const client = vi.fn(async (request) => {
+      const url = String(request)
+      const attempt = (attempts.get(url) ?? 0) + 1
+      attempts.set(url, attempt)
+
+      if (attempt === 1) {
+        throw httpError(401)
+      }
+
+      return url
+    })
+
+    const config = useHttpConfig()
+    config.apply({ client, recoverSession })
+
+    const requests = Promise.all([
+      new Http(config).get('/api/one'),
+      new Http(config).get('/api/two')
+    ])
+
+    await vi.waitFor(() => {
+      expect(client).toHaveBeenCalledTimes(2)
+    })
+    expect(recoverSession).toHaveBeenCalledOnce()
+
+    releaseRecovery!()
+
+    await expect(requests).resolves.toEqual(['/api/one', '/api/two'])
+    expect(client).toHaveBeenCalledTimes(4)
+  })
+
+  it('leaves callback errors observable', async () => {
+    const error = new Error('Identity provider is unavailable.')
+    const recoverSession = vi.fn(async () => {
+      throw error
+    })
+    const client = vi.fn(async (request) => {
+      if (request === '/api/csrf-cookie') {
+        return
+      }
+
+      throw httpError(401)
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(http.get('/api/items')).rejects.toBe(error)
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('leaves CSRF refresh errors observable', async () => {
+    document.cookie = 'XSRF-TOKEN=stale; Path=/'
+    const refreshError = new Error('CSRF endpoint is unavailable.')
+
+    const client = vi.fn(async (request) => {
+      if (request === '/api/csrf-cookie') {
+        throw refreshError
+      }
+
+      throw httpError(419)
+    })
+    const http = setupHttp(client)
+
+    await expect(http.post('/api/items')).rejects.toBe(refreshError)
+    expect(client).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not recover unrelated HTTP errors', async () => {
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async () => {
+      throw httpError(403)
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(http.get('/api/items')).rejects.toMatchObject({ status: 403 })
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('does not repair a 419 when XSRF support is disabled', async () => {
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async () => {
+      throw httpError(419)
+    })
+    const config = useHttpConfig()
+    config.apply({
+      client,
+      recoverSession,
+      xsrfUrl: false
+    })
+    const http = new Http(config)
+
+    await expect(http.post('/api/items')).rejects.toMatchObject({ status: 419 })
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('applies session recovery to raw download requests', async () => {
+    const recoverSession = vi.fn(async () => true)
+    const client = Object.assign(
+      vi.fn(async () => undefined),
+      {
+        raw: vi.fn(async () => {
+          if (client.raw.mock.calls.length === 1) {
+            throw httpError(401)
+          }
+
+          return Object.assign(new Response(), {
+            _data: new Blob(['content'])
+          }) as FetchResponse<Blob>
+        })
+      }
+    )
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(http.download('/api/download')).resolves.toBeUndefined()
+    expect(recoverSession).toHaveBeenCalledOnce()
+    expect(client).not.toHaveBeenCalled()
+    expect(client.raw).toHaveBeenCalledTimes(2)
+  })
+})
+
+function setupHttp(
+  client: HttpClient,
+  options: {
+    recoverSession?: () => Promise<boolean>
+  } = {}
+): Http {
+  const config = useHttpConfig()
+  config.apply({ client, ...options })
+  return new Http(config)
+}
+
+function xsrfHeader(options: unknown): string | null {
+  return new Headers((options as FetchOptions | undefined)?.headers).get('X-Xsrf-Token')
+}
+
+function httpError(status: number): Error & { status: number } {
+  return Object.assign(new Error(`HTTP ${status}`), { status })
+}

--- a/tests/http/Http.spec.ts
+++ b/tests/http/Http.spec.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream'
 import { type FetchOptions, type FetchResponse, Http } from 'sefirot/http/Http'
 import { type HttpClient, useHttpConfig } from 'sefirot/stores/HttpConfig'
 
@@ -280,6 +281,125 @@ describe('http/Http', () => {
 
     await expect(requests).resolves.toEqual(['/api/one', '/api/two'])
     expect(client).toHaveBeenCalledTimes(4)
+  })
+
+  it('reuses a completed recovery for a delayed 401 from the same session', async () => {
+    const attempts = new Map<string, number>()
+    let releaseDelayedResponse: () => void
+    const delayedResponse = new Promise<void>((resolve) => {
+      releaseDelayedResponse = resolve
+    })
+    const recoverSession = vi.fn(async () => true)
+
+    const client = vi.fn(async (request) => {
+      const url = String(request)
+      const attempt = (attempts.get(url) ?? 0) + 1
+      attempts.set(url, attempt)
+
+      if (url === '/api/two' && attempt === 1) {
+        await delayedResponse
+      }
+
+      if (attempt === 1) {
+        throw httpError(401)
+      }
+
+      return url
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    const firstRequest = http.get('/api/one')
+    const delayedRequest = http.get('/api/two')
+
+    await expect(firstRequest).resolves.toBe('/api/one')
+    releaseDelayedResponse!()
+    await expect(delayedRequest).resolves.toBe('/api/two')
+
+    expect(recoverSession).toHaveBeenCalledOnce()
+  })
+
+  it.each([401, 419])('does not retry a %i response with a one-shot body', async (status) => {
+    const error = httpError(status)
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async () => {
+      throw error
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(
+      http.put('/api/items', new ReadableStream())
+    ).rejects.toBe(error)
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('does not retry a response with a Node stream body', async () => {
+    const error = httpError(401)
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async () => {
+      throw error
+    })
+    const http = setupHttp(client, { recoverSession })
+
+    await expect(
+      http.put('/api/items', Readable.from('content'))
+    ).rejects.toBe(error)
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('does not apply Sanctum behavior to third-party URLs', async () => {
+    document.cookie = 'XSRF-TOKEN=secret; Path=/'
+    const error = httpError(401)
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async (_request, options) => {
+      expect(xsrfHeader(options)).toBeNull()
+      throw error
+    })
+    const config = useHttpConfig()
+    config.apply({
+      baseUrl: 'https://app.example.com',
+      client,
+      recoverSession
+    })
+    const http = new Http(config)
+
+    await expect(
+      http.post('/items', undefined, {
+        baseURL: 'https://example.com'
+      })
+    ).rejects.toBe(error)
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('recovers absolute URLs on the configured application origin', async () => {
+    let requestCount = 0
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async () => {
+      requestCount++
+      if (requestCount === 1) {
+        throw httpError(401)
+      }
+      return 'ok'
+    })
+    const config = useHttpConfig()
+    config.apply({
+      baseUrl: 'https://app.example.com/api',
+      client,
+      recoverSession
+    })
+    const http = new Http(config)
+
+    await expect(
+      http.get('https://app.example.com/items')
+    ).resolves.toBe('ok')
+
+    expect(recoverSession).toHaveBeenCalledOnce()
+    expect(client).toHaveBeenCalledTimes(2)
   })
 
   it('leaves callback errors observable', async () => {

--- a/tests/http/Http.spec.ts
+++ b/tests/http/Http.spec.ts
@@ -322,6 +322,74 @@ describe('http/Http', () => {
     expect(recoverSession).toHaveBeenCalledOnce()
   })
 
+  it('samples the recovery generation after asynchronous request construction', async () => {
+    let releaseHeaders: () => void
+    const delayedHeaders = new Promise<void>((resolve) => {
+      releaseHeaders = resolve
+    })
+    let headerRequestCount = 0
+    const headers = vi.fn(async () => {
+      headerRequestCount++
+      if (headerRequestCount === 1) {
+        await delayedHeaders
+      }
+      return {}
+    })
+    const recoverSession = vi.fn(async () => true)
+    let recoveryRequestCount = 0
+    const client = vi.fn(async (request) => {
+      const url = String(request)
+
+      if (url === '/api/recover') {
+        recoveryRequestCount++
+        if (recoveryRequestCount === 1) {
+          throw httpError(401)
+        }
+        return url
+      }
+
+      if (recoverSession.mock.calls.length < 2) {
+        throw httpError(401)
+      }
+
+      return url
+    })
+    const config = useHttpConfig()
+    config.apply({ client, headers, recoverSession })
+    const http = new Http(config)
+
+    const requestBuiltAfterRecovery = http.get('/api/after-recovery')
+    await vi.waitFor(() => {
+      expect(headers).toHaveBeenCalledOnce()
+    })
+
+    await expect(http.get('/api/recover')).resolves.toBe('/api/recover')
+    expect(recoverSession).toHaveBeenCalledOnce()
+
+    releaseHeaders!()
+
+    await expect(requestBuiltAfterRecovery).resolves.toBe('/api/after-recovery')
+    expect(recoverSession).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not recover status-shaped errors thrown while building a request', async () => {
+    const error = httpError(401)
+    const headers = vi.fn(async () => {
+      throw error
+    })
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn()
+    const config = useHttpConfig()
+    config.apply({ client, headers, recoverSession })
+    const http = new Http(config)
+
+    await expect(http.get('/api/items')).rejects.toBe(error)
+
+    expect(headers).toHaveBeenCalledOnce()
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).not.toHaveBeenCalled()
+  })
+
   it.each([401, 419])('does not retry a %i response with a one-shot body', async (status) => {
     const error = httpError(status)
     const recoverSession = vi.fn(async () => true)
@@ -448,6 +516,31 @@ describe('http/Http', () => {
 
     await expect(
       http.get('https://example.com/items')
+    ).rejects.toBe(error)
+
+    expect(recoverSession).not.toHaveBeenCalled()
+    expect(client).toHaveBeenCalledOnce()
+  })
+
+  it('does not recover whitespace-prefixed absolute URLs during SSR', async () => {
+    vi.stubGlobal('location', undefined)
+    document.cookie = 'XSRF-TOKEN=secret; Path=/'
+    const error = httpError(401)
+    const recoverSession = vi.fn(async () => true)
+    const client = vi.fn(async (_request, options) => {
+      expect(xsrfHeader(options)).toBeNull()
+      throw error
+    })
+    const config = useHttpConfig()
+    config.apply({
+      baseUrl: '/api',
+      client,
+      recoverSession
+    })
+    const http = new Http(config)
+
+    await expect(
+      http.post(' https://example.com/items')
     ).rejects.toBe(error)
 
     expect(recoverSession).not.toHaveBeenCalled()

--- a/tests/http/Http.spec.ts
+++ b/tests/http/Http.spec.ts
@@ -1,4 +1,3 @@
-import { Readable } from 'node:stream'
 import { type FetchOptions, type FetchResponse, Http } from 'sefirot/http/Http'
 import { type HttpClient, useHttpConfig } from 'sefirot/stores/HttpConfig'
 
@@ -112,39 +111,6 @@ describe('http/Http', () => {
     ])
   })
 
-  it('can recover the session after repairing a 419', async () => {
-    document.cookie = 'XSRF-TOKEN=stale; Path=/'
-    let requestCount = 0
-    const recoverSession = vi.fn(async () => true)
-
-    const client = vi.fn(async (request) => {
-      if (request === '/api/csrf-cookie') {
-        document.cookie = 'XSRF-TOKEN=fresh; Path=/'
-        return
-      }
-
-      requestCount++
-      if (requestCount === 1) {
-        throw httpError(419)
-      }
-      if (requestCount === 2) {
-        throw httpError(401)
-      }
-
-      return 'ok'
-    })
-    const http = setupHttp(client, { recoverSession })
-
-    await expect(http.post('/api/items')).resolves.toBe('ok')
-    expect(recoverSession).toHaveBeenCalledOnce()
-    expect(client.mock.calls.map(([request]) => request)).toEqual([
-      '/api/items',
-      '/api/csrf-cookie',
-      '/api/items',
-      '/api/items'
-    ])
-  })
-
   it('recovers the application session and rebuilds the request after a 401', async () => {
     document.cookie = 'XSRF-TOKEN=valid; Path=/'
     let requestCount = 0
@@ -217,32 +183,28 @@ describe('http/Http', () => {
     expect(client).toHaveBeenCalledOnce()
   })
 
-  it('still repairs a bootstrap request after a 419 without recovering the session', async () => {
-    document.cookie = 'XSRF-TOKEN=stale; Path=/'
+  it('can disable globally configured session recovery', async () => {
+    const error = httpError(401)
     const recoverSession = vi.fn(async () => true)
-    let requestCount = 0
-
-    const client = vi.fn(async (request) => {
-      if (request === '/api/csrf-cookie') {
-        document.cookie = 'XSRF-TOKEN=fresh; Path=/'
-        return
-      }
-
-      requestCount++
-      if (requestCount === 1) {
-        throw httpError(419)
-      }
-
-      return 'ok'
+    const client = vi.fn(async () => {
+      throw error
     })
-    const http = setupHttp(client, { recoverSession })
+    const config = useHttpConfig()
+    config.apply({ client, recoverSession })
+    config.apply({ recoverSession: undefined })
+
+    expect(config.recoverSession).toBe(recoverSession)
+
+    config.apply({ recoverSession: false })
+
+    expect(config.recoverSession).toBeUndefined()
 
     await expect(
-      http.post('/api/auth/exchange', undefined, { sessionRecovery: false })
-    ).resolves.toBe('ok')
+      new Http(config).get('/api/items')
+    ).rejects.toBe(error)
 
     expect(recoverSession).not.toHaveBeenCalled()
-    expect(client).toHaveBeenCalledTimes(3)
+    expect(client).toHaveBeenCalledOnce()
   })
 
   it('shares session recovery across concurrent 401 responses', async () => {
@@ -372,24 +334,6 @@ describe('http/Http', () => {
     expect(recoverSession).toHaveBeenCalledTimes(2)
   })
 
-  it('does not recover status-shaped errors thrown while building a request', async () => {
-    const error = httpError(401)
-    const headers = vi.fn(async () => {
-      throw error
-    })
-    const recoverSession = vi.fn(async () => true)
-    const client = vi.fn()
-    const config = useHttpConfig()
-    config.apply({ client, headers, recoverSession })
-    const http = new Http(config)
-
-    await expect(http.get('/api/items')).rejects.toBe(error)
-
-    expect(headers).toHaveBeenCalledOnce()
-    expect(recoverSession).not.toHaveBeenCalled()
-    expect(client).not.toHaveBeenCalled()
-  })
-
   it.each([401, 419])('does not retry a %i response with a one-shot body', async (status) => {
     document.cookie = 'XSRF-TOKEN=valid; Path=/'
     const error = httpError(status)
@@ -407,55 +351,13 @@ describe('http/Http', () => {
     expect(client).toHaveBeenCalledOnce()
   })
 
-  it('does not retry a response with a Node stream body', async () => {
-    document.cookie = 'XSRF-TOKEN=valid; Path=/'
-    const error = httpError(401)
-    const recoverSession = vi.fn(async () => true)
-    const client = vi.fn(async () => {
-      throw error
-    })
-    const http = setupHttp(client, { recoverSession })
-
-    await expect(
-      http.put('/api/items', Readable.from('content'))
-    ).rejects.toBe(error)
-
-    expect(recoverSession).not.toHaveBeenCalled()
-    expect(client).toHaveBeenCalledOnce()
-  })
-
-  it('does not retry a response with an async iterable body', async () => {
+  it('does not retry a response with a single-pass iterable wrapper body', async () => {
     document.cookie = 'XSRF-TOKEN=valid; Path=/'
 
-    async function* body(): AsyncGenerator<string> {
-      yield 'content'
+    const iterator = ['content'][Symbol.iterator]()
+    const body = {
+      [Symbol.iterator]: (): Iterator<string> => iterator
     }
-
-    const error = httpError(401)
-    const recoverSession = vi.fn(async () => true)
-    const client = vi.fn(async (_request, options) => {
-      for await (const chunk of options?.body as AsyncIterable<string>) {
-        expect(chunk).toBe('content')
-      }
-      throw error
-    })
-    const http = setupHttp(client, { recoverSession })
-
-    await expect(
-      http.put('/api/items', body())
-    ).rejects.toBe(error)
-
-    expect(recoverSession).not.toHaveBeenCalled()
-    expect(client).toHaveBeenCalledOnce()
-  })
-
-  it('does not retry a response with a one-shot sync iterator body', async () => {
-    document.cookie = 'XSRF-TOKEN=valid; Path=/'
-
-    function* body(): Generator<string> {
-      yield 'content'
-    }
-
     const error = httpError(401)
     const recoverSession = vi.fn(async () => true)
     const client = vi.fn(async (_request, options) => {
@@ -467,39 +369,35 @@ describe('http/Http', () => {
     const http = setupHttp(client, { recoverSession })
 
     await expect(
-      http.put('/api/items', body())
+      http.put('/api/items', body)
     ).rejects.toBe(error)
 
     expect(recoverSession).not.toHaveBeenCalled()
     expect(client).toHaveBeenCalledOnce()
   })
 
-  it('does not retry a response with a bare one-shot iterator body', async () => {
+  it('retries a response with a replayable array body', async () => {
     document.cookie = 'XSRF-TOKEN=valid; Path=/'
 
-    const values = ['content']
-    const body = {
-      next: (): IteratorResult<string> => values.length
-        ? { done: false, value: values.shift()! }
-        : { done: true, value: undefined }
-    }
-    const error = httpError(401)
+    const body = ['content']
+    let requestCount = 0
     const recoverSession = vi.fn(async () => true)
     const client = vi.fn(async (_request, options) => {
-      const iterator = options?.body as Iterator<string>
-      while (!iterator.next().done) {
-        // Consume the one-shot body before returning the response.
+      expect(options?.body).toBe(body)
+      requestCount++
+      if (requestCount === 1) {
+        throw httpError(401)
       }
-      throw error
+      return 'ok'
     })
     const http = setupHttp(client, { recoverSession })
 
     await expect(
       http.put('/api/items', body)
-    ).rejects.toBe(error)
+    ).resolves.toBe('ok')
 
-    expect(recoverSession).not.toHaveBeenCalled()
-    expect(client).toHaveBeenCalledOnce()
+    expect(recoverSession).toHaveBeenCalledOnce()
+    expect(client).toHaveBeenCalledTimes(2)
   })
 
   it('does not apply Sanctum behavior to third-party URLs', async () => {
@@ -528,31 +426,6 @@ describe('http/Http', () => {
     expect(client).toHaveBeenCalledOnce()
   })
 
-  it('matches request scoping when baseURL is explicitly undefined', async () => {
-    document.cookie = 'XSRF-TOKEN=secret; Path=/'
-    const error = httpError(401)
-    const recoverSession = vi.fn(async () => true)
-    const client = vi.fn(async (_request, options) => {
-      expect(options?.baseURL).toBeUndefined()
-      expect(xsrfHeader(options)).toBeNull()
-      throw error
-    })
-    const config = useHttpConfig()
-    config.apply({
-      baseUrl: 'https://app.example.com',
-      client,
-      recoverSession
-    })
-    const http = new Http(config)
-
-    await expect(
-      http.post('/items', undefined, { baseURL: undefined })
-    ).rejects.toBe(error)
-
-    expect(recoverSession).not.toHaveBeenCalled()
-    expect(client).toHaveBeenCalledOnce()
-  })
-
   it('recovers absolute URLs on the configured application origin', async () => {
     let requestCount = 0
     const recoverSession = vi.fn(async () => true)
@@ -573,32 +446,6 @@ describe('http/Http', () => {
 
     await expect(
       http.get('https://app.example.com/items')
-    ).resolves.toBe('ok')
-
-    expect(recoverSession).toHaveBeenCalledOnce()
-    expect(client).toHaveBeenCalledTimes(2)
-  })
-
-  it('uses the page origin when the configured base URL is empty', async () => {
-    let requestCount = 0
-    const recoverSession = vi.fn(async () => true)
-    const client = vi.fn(async () => {
-      requestCount++
-      if (requestCount === 1) {
-        throw httpError(401)
-      }
-      return 'ok'
-    })
-    const config = useHttpConfig()
-    config.apply({
-      baseUrl: '',
-      client,
-      recoverSession
-    })
-    const http = new Http(config)
-
-    await expect(
-      http.get(new URL('/items', location.href).href)
     ).resolves.toBe('ok')
 
     expect(recoverSession).toHaveBeenCalledOnce()
@@ -653,35 +500,6 @@ describe('http/Http', () => {
     expect(client).toHaveBeenCalledOnce()
   })
 
-  it.each([
-    ' https://example.com/items',
-    '\0https://example.com/items',
-    '//sefirot.invalid/items'
-  ])('does not recover externally resolving URL %j during SSR', async (url) => {
-    vi.stubGlobal('location', undefined)
-    document.cookie = 'XSRF-TOKEN=secret; Path=/'
-    const error = httpError(401)
-    const recoverSession = vi.fn(async () => true)
-    const client = vi.fn(async (_request, options) => {
-      expect(xsrfHeader(options)).toBeNull()
-      throw error
-    })
-    const config = useHttpConfig()
-    config.apply({
-      baseUrl: '/api',
-      client,
-      recoverSession
-    })
-    const http = new Http(config)
-
-    await expect(
-      http.post(url)
-    ).rejects.toBe(error)
-
-    expect(recoverSession).not.toHaveBeenCalled()
-    expect(client).toHaveBeenCalledOnce()
-  })
-
   it('leaves callback errors observable', async () => {
     const error = new Error('Identity provider is unavailable.')
     const recoverSession = vi.fn(async () => {
@@ -697,53 +515,6 @@ describe('http/Http', () => {
     const http = setupHttp(client, { recoverSession })
 
     await expect(http.get('/api/items')).rejects.toBe(error)
-    expect(client).toHaveBeenCalledOnce()
-  })
-
-  it('leaves CSRF refresh errors observable', async () => {
-    document.cookie = 'XSRF-TOKEN=stale; Path=/'
-    const refreshError = new Error('CSRF endpoint is unavailable.')
-
-    const client = vi.fn(async (request) => {
-      if (request === '/api/csrf-cookie') {
-        throw refreshError
-      }
-
-      throw httpError(419)
-    })
-    const http = setupHttp(client)
-
-    await expect(http.post('/api/items')).rejects.toBe(refreshError)
-    expect(client).toHaveBeenCalledTimes(2)
-  })
-
-  it('does not recover unrelated HTTP errors', async () => {
-    const recoverSession = vi.fn(async () => true)
-    const client = vi.fn(async () => {
-      throw httpError(403)
-    })
-    const http = setupHttp(client, { recoverSession })
-
-    await expect(http.get('/api/items')).rejects.toMatchObject({ status: 403 })
-    expect(recoverSession).not.toHaveBeenCalled()
-    expect(client).toHaveBeenCalledOnce()
-  })
-
-  it('does not repair a 419 when XSRF support is disabled', async () => {
-    const recoverSession = vi.fn(async () => true)
-    const client = vi.fn(async () => {
-      throw httpError(419)
-    })
-    const config = useHttpConfig()
-    config.apply({
-      client,
-      recoverSession,
-      xsrfUrl: false
-    })
-    const http = new Http(config)
-
-    await expect(http.post('/api/items')).rejects.toMatchObject({ status: 419 })
-    expect(recoverSession).not.toHaveBeenCalled()
     expect(client).toHaveBeenCalledOnce()
   })
 


### PR DESCRIPTION
## Summary

Adds bounded recovery for two authentication failures in the HTTP client:

- A browser may retain an `XSRF-TOKEN` after its Laravel session expires or rotates. Laravel then rejects an unsafe request with `419`. The client obtains current CSRF state, rebuilds the request, and retries it once.
- A Laravel session may expire while the application’s identity-platform session remains valid. After a `401`, an optional `recoverSession` callback can obtain fresh proof of identity, establish another Laravel session, and retry the request once without requiring interactive OAuth login.

If session recovery is unavailable or unsuccessful, the original `401` remains observable.

## Why

Laravel and an external identity platform maintain sessions with different lifetimes. Expiration of the shorter-lived Laravel session does not necessarily mean that the user’s identity-platform session has ended.

Re-establishing the Laravel session from a still-valid identity session preserves the user’s work and avoids an unnecessary login prompt. It does not bypass authentication: the identity platform must still provide valid credentials. When it cannot, recovery stops and the original authentication failure is preserved.

## Notable changes

- Refreshes Sanctum CSRF state after one `419`.
- Provides a provider-agnostic session-recovery callback for `401` responses.
- Shares concurrent CSRF and session recovery work.
- Allows authentication bootstrap requests to avoid recovery recursion.
- Limits each recovery stage to one attempt.

## Backward compatibility

Existing consumers require no migration:

- `recoverSession` is optional and disabled by default, so existing `401` handling remains unchanged unless an application enables recovery.
- `HttpRequestOptions` is `FetchOptions` plus an optional Sefirot flag. Existing calls and values typed as `FetchOptions` remain valid.
- Sefirot removes `sessionRecovery` before invoking the configured `HttpClient`, so existing client implementations continue receiving ordinary fetch options.
- All HTTP method arguments and return types remain compatible.

The only runtime behavior change is for Sanctum clients with XSRF support enabled: a `419` now triggers one CSRF refresh and retry before the error is returned. Clients with `xsrfUrl: false` retain the previous behavior.

## Test plan

- [ ] Verify a request succeeds after stale CSRF state produces a `419`.
- [ ] Verify an expired Laravel session is restored when the identity-platform session remains valid.
- [ ] Verify recovery does not require another OAuth prompt when valid identity credentials are available.
- [ ] Verify unsuccessful recovery preserves the original `401` without entering a retry loop.