### PR TITLE
feat(lens): add empty / not empty filter operators

### DIFF
--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -77,8 +77,17 @@ export interface FieldDataBase {
    * the filter UI offers them only when the backend's field definition
    * declares support, so applications whose backends don't understand
    * the operators see no change. Absent means unsupported.
+   *
+   * The object form also customizes the label of the pinned "empty"
+   * option in the column filter dropdown (e.g. "No assignees"); a plain
+   * `true` keeps the generic default label.
    */
-  emptyOperators?: boolean
+  emptyOperators?: boolean | EmptyOperatorsDeclaration
+}
+
+export interface EmptyOperatorsDeclaration {
+  labelEn?: string
+  labelJa?: string
 }
 
 export interface AvatarFieldData extends FieldDataBase {

--- a/lib/blocks/lens/FieldData.ts
+++ b/lib/blocks/lens/FieldData.ts
@@ -71,6 +71,14 @@ export interface FieldDataBase {
    * means a null blank.
    */
   emptyValue?: any
+  /**
+   * Whether the backend translates the valueless `empty` / `notEmpty`
+   * filter operators for this field. The operators are strictly opt-in:
+   * the filter UI offers them only when the backend's field definition
+   * declares support, so applications whose backends don't understand
+   * the operators see no change. Absent means unsupported.
+   */
+  emptyOperators?: boolean
 }
 
 export interface AvatarFieldData extends FieldDataBase {

--- a/lib/blocks/lens/FilterOperator.ts
+++ b/lib/blocks/lens/FilterOperator.ts
@@ -9,6 +9,8 @@ export type FilterOperator =
   | 'contains'
   | 'startsWith'
   | 'endsWith'
+  | 'empty'
+  | 'notEmpty'
 
 export const FilterOperatorLabelDict: Record<FilterOperator, string> = {
   '=': 'is',
@@ -20,5 +22,7 @@ export const FilterOperatorLabelDict: Record<FilterOperator, string> = {
   'in': 'in',
   'contains': 'contains',
   'startsWith': 'starts with',
-  'endsWith': 'ends with'
+  'endsWith': 'ends with',
+  'empty': 'is empty',
+  'notEmpty': 'is not empty'
 }

--- a/lib/blocks/lens/FilterOperator.ts
+++ b/lib/blocks/lens/FilterOperator.ts
@@ -50,3 +50,26 @@ export function isClearedFilterCondition(condition: any[]): boolean {
   }
   return condition[2] == null || (Array.isArray(condition[2]) && condition[2].length === 0)
 }
+
+/**
+ * Normalizes the value of valueless operator conditions to `null` across
+ * a filters array, groups included. Filters can enter from outside the
+ * form UI — the `filters` prop or a hand-edited URL query — where a
+ * valueless condition may carry a stray value, so the catalog normalizes
+ * them before sending a search, preserving the `[field, operator, null]`
+ * wire shape.
+ */
+export function normalizeValuelessFilterConditions(filters: any[]): any[] {
+  return filters.map((f) => {
+    if (!Array.isArray(f)) {
+      return f
+    }
+    const entry = f as any[]
+    if (entry[0] === '$and' || entry[0] === '$or') {
+      return [entry[0], normalizeValuelessFilterConditions(entry[1] ?? [])]
+    }
+    return isValuelessFilterOperator(entry[1]) && entry[2] !== null
+      ? [entry[0], entry[1], null]
+      : f
+  })
+}

--- a/lib/blocks/lens/FilterOperator.ts
+++ b/lib/blocks/lens/FilterOperator.ts
@@ -26,3 +26,27 @@ export const FilterOperatorLabelDict: Record<FilterOperator, string> = {
   'empty': 'is empty',
   'notEmpty': 'is not empty'
 }
+
+/**
+ * Whether the operator forms a complete condition without a value (the
+ * condition value is always `null`). The filter UI renders no value input
+ * for such conditions.
+ */
+export function isValuelessFilterOperator(operator: string | null): boolean {
+  return operator === 'empty' || operator === 'notEmpty'
+}
+
+/**
+ * Whether the condition tuple `[field, operator, value]` no longer
+ * carries an effective filter and should be cleared. A condition clears
+ * when its value is nullish or an empty array — scalar operators (e.g. a
+ * boolean `=`) carry a single value, so `false` is a real value to keep;
+ * only `null` clears. Valueless operators are complete without a value,
+ * so they never count as cleared.
+ */
+export function isClearedFilterCondition(condition: any[]): boolean {
+  if (isValuelessFilterOperator(condition[1])) {
+    return false
+  }
+  return condition[2] == null || (Array.isArray(condition[2]) && condition[2].length === 0)
+}

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -9,6 +9,7 @@ import { usePower } from '../../../composables/Power'
 import { useSnackbars } from '../../../stores/Snackbars'
 import { day } from '../../../support/Day'
 import { type FieldData } from '../FieldData'
+import { isClearedFilterCondition } from '../FilterOperator'
 import { type LensQuery, type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
 import { useCatalogUrlQuerySync } from '../composables/CatalogUrlQuerySync'
@@ -723,21 +724,14 @@ function onInlineFilterUpdated(filter: any[]) {
   emit('filters-updated', _filters.value)
 }
 
-// A filter value "clears" the filter when it's nullish or an empty
-// array. Scalar operators (e.g. a boolean `=`) carry a single value, so
-// `false` is a real value to keep — only `null` clears.
-function isEmptyFilterValue(value: any): boolean {
-  return value == null || (Array.isArray(value) && value.length === 0)
-}
-
 function applyNewFilter(filter: any[]) {
-  if (!isEmptyFilterValue(filter[2])) {
+  if (!isClearedFilterCondition(filter)) {
     _filters.value.push(filter)
   }
 }
 
 function replaceFilter(index: number, filter: any[]) {
-  if (isEmptyFilterValue(filter[2])) {
+  if (isClearedFilterCondition(filter)) {
     _filters.value.splice(index, 1)
     return
   }

--- a/lib/blocks/lens/components/LensCatalog.vue
+++ b/lib/blocks/lens/components/LensCatalog.vue
@@ -9,7 +9,7 @@ import { usePower } from '../../../composables/Power'
 import { useSnackbars } from '../../../stores/Snackbars'
 import { day } from '../../../support/Day'
 import { type FieldData } from '../FieldData'
-import { isClearedFilterCondition } from '../FilterOperator'
+import { isClearedFilterCondition, normalizeValuelessFilterConditions } from '../FilterOperator'
 import { type LensQuery, type LensQuerySort } from '../LensQuery'
 import { type LensResult } from '../LensResult'
 import { useCatalogUrlQuerySync } from '../composables/CatalogUrlQuerySync'
@@ -677,13 +677,16 @@ function withoutIndexField(fields: string[]): string[] {
 }
 
 // Create lens filters option by combining query (free search) filters,
-// user selected filters, and fixed filters.
+// user selected filters, and fixed filters. Filters coming from outside
+// the form UI (the `filters` prop, a hand-edited URL query) may carry a
+// stray value on a valueless condition, so normalize those to `null`
+// before they reach the wire.
 function createInputFilters(queryFilters: any[], filters: any[]) {
-  return [
+  return normalizeValuelessFilterConditions([
     ...(props.fixedFilters ?? []),
     queryFilters,
     ...filters
-  ].filter((f) => f?.length > 0)
+  ].filter((f) => f?.length > 0))
 }
 
 // Re-run the search for the new query state, dropping any stashed

--- a/lib/blocks/lens/components/LensCatalogStateFilterCondition.vue
+++ b/lib/blocks/lens/components/LensCatalogStateFilterCondition.vue
@@ -33,6 +33,10 @@ const input = computed(() => {
   return field.value?.filterInputByOperator(props.condition.operator) ?? null
 })
 
+// A valueless condition (e.g. the `empty` / `notEmpty` operators) has no
+// value to show, so the chip hides the value segment entirely.
+const valueless = computed(() => input.value?.valueless() ?? false)
+
 const fieldText = computed(() => {
   // Fall back to the raw field key when the field has no definition.
   return field.value ? field.value.label() : props.condition.field
@@ -54,7 +58,7 @@ const valueText = computedAsync(async () => {
   <div class="LensCatalogStateFilterCondition">
     <div class="field">{{ fieldText }}</div>
     <div class="operator">{{ operatorText }}</div>
-    <div class="value">
+    <div v-if="!valueless" class="value">
       {{ valueText }}
     </div>
   </div>

--- a/lib/blocks/lens/components/LensCatalogStateFilterCondition.vue
+++ b/lib/blocks/lens/components/LensCatalogStateFilterCondition.vue
@@ -2,7 +2,7 @@
 import { computedAsync } from '@vueuse/core'
 import { computed } from 'vue'
 import { type FieldData } from '../FieldData'
-import { type FilterOperator, FilterOperatorLabelDict } from '../FilterOperator'
+import { type FilterOperator, FilterOperatorLabelDict, isValuelessFilterOperator } from '../FilterOperator'
 import { useFieldFactory } from '../composables/FieldFactory'
 
 export interface Props {
@@ -29,13 +29,17 @@ const field = computed(() => {
   return fieldData ? fieldFactory.make(fieldData) : null
 })
 
+// A valueless condition (the `empty` / `notEmpty` operators) has no
+// value to show, so the chip hides the value segment entirely and never
+// resolves the input.
+const valueless = computed(() => isValuelessFilterOperator(props.condition.operator))
+
 const input = computed(() => {
+  if (valueless.value) {
+    return null
+  }
   return field.value?.filterInputByOperator(props.condition.operator) ?? null
 })
-
-// A valueless condition (e.g. the `empty` / `notEmpty` operators) has no
-// value to show, so the chip hides the value segment entirely.
-const valueless = computed(() => input.value?.valueless() ?? false)
 
 const fieldText = computed(() => {
   // Fall back to the raw field key when the field has no definition.

--- a/lib/blocks/lens/components/LensFormFilter.vue
+++ b/lib/blocks/lens/components/LensFormFilter.vue
@@ -97,7 +97,7 @@ const fieldOptions = computed(() => {
 // }
 function lensFiltersToGroup() {
   const conditions = props.filters.length > 0
-    ? pruneMissingFields(props.filters.map(lensConditionToCondition))
+    ? pruneUneditableConditions(props.filters.map(lensConditionToCondition))
     : []
 
   return {
@@ -106,15 +106,32 @@ function lensFiltersToGroup() {
   }
 }
 
-// Drop conditions that reference a field absent from `props.fields` (for
-// example a stale saved filter pointing at a field that no longer
-// exists). Such a condition can't be rendered or edited, and would
-// otherwise pass validation with a null input and silently re-emit the
-// stale filter on Apply. Groups left empty by pruning are removed too.
-function pruneMissingFields(conditions: any[]): any[] {
+// Drop conditions the form cannot render or edit: ones referencing a
+// field absent from `props.fields` (a stale saved filter pointing at a
+// field that no longer exists), and ones whose operator the field does
+// not offer (e.g. a hand-edited URL pairing `empty` with a field that
+// doesn't declare support). Mounting such a condition would throw in its
+// input resolution, and it would otherwise pass validation with a null
+// input and silently re-emit the stale filter on Apply. Groups left
+// empty by pruning are removed too.
+function pruneUneditableConditions(conditions: any[]): any[] {
   return conditions
-    .map((c) => ('connector' in c ? { ...c, conditions: pruneMissingFields(c.conditions) } : c))
-    .filter((c) => ('connector' in c ? c.conditions.length > 0 : c.field === null || props.fields[c.field]))
+    .map((c) => ('connector' in c ? { ...c, conditions: pruneUneditableConditions(c.conditions) } : c))
+    .filter((c) => ('connector' in c ? c.conditions.length > 0 : isEditableCondition(c)))
+}
+
+function isEditableCondition(c: any): boolean {
+  if (c.field === null) {
+    return true
+  }
+  const fieldData = props.fields[c.field]
+  if (!fieldData) {
+    return false
+  }
+  if (c.operator === null) {
+    return true
+  }
+  return fieldFactory.make(fieldData).availableFilterOperators().includes(c.operator)
 }
 
 function lensConditionToCondition(filter: any[]) {

--- a/lib/blocks/lens/components/LensFormFilter.vue
+++ b/lib/blocks/lens/components/LensFormFilter.vue
@@ -11,6 +11,7 @@ import { useData } from '../../../composables/Data'
 import { useLang, useTrans } from '../../../composables/Lang'
 import { useValidation } from '../../../composables/Validation'
 import { type FieldData } from '../FieldData'
+import { isValuelessFilterOperator } from '../FilterOperator'
 import { useFieldFactory } from '../composables/FieldFactory'
 import { type FilterCondition } from './LensFormFilterCondition.vue'
 import LensFormFilterGroup, { type FilterGroup } from './LensFormFilterGroup.vue'
@@ -142,7 +143,10 @@ function groupToLensFilters(conditions: (FilterGroup | FilterCondition)[]): any[
     if ('connector' in c) {
       return [c.connector, groupToLensFilters(c.conditions)]
     }
-    return [c.field, c.operator, c.value]
+    // A valueless condition always emits `null`: an initially loaded
+    // condition may carry a stray value (e.g. from a hand-edited URL)
+    // that the operator-change cast never saw.
+    return [c.field, c.operator, isValuelessFilterOperator(c.operator) ? null : c.value]
   })
 }
 

--- a/lib/blocks/lens/components/LensFormFilterCondition.vue
+++ b/lib/blocks/lens/components/LensFormFilterCondition.vue
@@ -9,7 +9,7 @@ import { useValidation } from '../../../composables/Validation'
 import { type Option } from '../../../support/InputDropdown'
 import { required } from '../../../validation/rules'
 import { type FieldData } from '../FieldData'
-import { type FilterOperator, FilterOperatorLabelDict } from '../FilterOperator'
+import { type FilterOperator, FilterOperatorLabelDict, isValuelessFilterOperator } from '../FilterOperator'
 import { useFieldFactory } from '../composables/FieldFactory'
 import { type FilterInput } from '../filter-inputs/FilterInput'
 
@@ -66,9 +66,9 @@ const operatorOptions = computed(() => {
 
 const input = ref(null) as Ref<FilterInput | null>
 
-// A valueless input (e.g. the `empty` / `notEmpty` operators) has no
+// A valueless condition (the `empty` / `notEmpty` operators) has no
 // value control: the value cell renders nothing instead of an input.
-const valueless = computed(() => input.value?.valueless() ?? false)
+const valueless = computed(() => isValuelessFilterOperator(model.value.operator))
 
 const inputComponent = computed(() => {
   return input.value && !valueless.value ? markRaw(input.value.component()) : null

--- a/lib/blocks/lens/components/LensFormFilterCondition.vue
+++ b/lib/blocks/lens/components/LensFormFilterCondition.vue
@@ -66,8 +66,12 @@ const operatorOptions = computed(() => {
 
 const input = ref(null) as Ref<FilterInput | null>
 
+// A valueless input (e.g. the `empty` / `notEmpty` operators) has no
+// value control: the value cell renders nothing instead of an input.
+const valueless = computed(() => input.value?.valueless() ?? false)
+
 const inputComponent = computed(() => {
-  return input.value ? markRaw(input.value.component()) : null
+  return input.value && !valueless.value ? markRaw(input.value.component()) : null
 })
 
 const { validation, reset: resetValidation } = useValidation(() => ({
@@ -160,7 +164,7 @@ async function resolveInput() {
     </div>
     <div class="value">
       <div v-if="input === null" class="skeleton" />
-      <Suspense v-else :key="model.field ?? '__empty__'">
+      <Suspense v-else-if="!valueless" :key="model.field ?? '__empty__'">
         <component :is="inputComponent" v-model="model.value" />
         <template #fallback>
           <div class="resolving">

--- a/lib/blocks/lens/fields/Field.ts
+++ b/lib/blocks/lens/fields/Field.ts
@@ -17,6 +17,13 @@ import * as RuleMapper from '../validation/RuleMapper'
  */
 const DEFAULT_COLUMN_WIDTH = 168
 
+/**
+ * The option value of the pinned "empty" option in column filter
+ * dropdowns. A sentinel that can never collide with real option values
+ * coming from backend resources.
+ */
+export const EmptyFilterOption = Symbol('empty-filter-option')
+
 export abstract class Field<T extends FieldData> {
   /**
    * The field context, that holds global app context
@@ -161,6 +168,35 @@ export abstract class Field<T extends FieldData> {
       }
     }
     return null
+  }
+
+  /**
+   * Whether an `empty` condition for the given key is present in the
+   * filters array.
+   */
+  protected emptyFilterActiveFor(key: string, filters: any[]): boolean {
+    return filters.some((f) => f[0] === key && f[1] === 'empty')
+  }
+
+  /**
+   * Whether the backend declares the valueless `empty` / `notEmpty`
+   * filter operators for this field. See `FieldDataBase.emptyOperators`.
+   */
+  protected emptyOperatorsEnabled(): boolean {
+    return !!this.data.emptyOperators
+  }
+
+  /**
+   * The label for the pinned "empty" option in the column filter
+   * dropdown. The backend's declaration may customize it per language
+   * (e.g. "No assignees"); the fallback is a generic localized "None".
+   */
+  protected emptyOptionLabel(): string {
+    const declaration = this.data.emptyOperators
+    const label = typeof declaration === 'object' && declaration !== null
+      ? (this.ctx.lang === 'ja' ? declaration.labelJa : declaration.labelEn)
+      : null
+    return label ?? (this.ctx.lang === 'ja' ? 'なし' : 'None')
   }
 
   /**

--- a/lib/blocks/lens/fields/RelatedManyField.ts
+++ b/lib/blocks/lens/fields/RelatedManyField.ts
@@ -7,6 +7,7 @@ import { type TableCell } from '../../../composables/Table'
 import { type RelatedManyFieldData } from '../FieldData'
 import { type FilterOperator } from '../FilterOperator'
 import { type ResourceFetcher } from '../ResourceFetcher'
+import { EmptyFilterInput } from '../filter-inputs/EmptyFilterInput'
 import { type FilterInput } from '../filter-inputs/FilterInput'
 import { SelectFilterInput } from '../filter-inputs/SelectFilterInput'
 import { Field } from './Field'
@@ -108,7 +109,9 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
     return {
       '=': selectOne,
       '!=': selectOne,
-      'in': selectMany
+      'in': selectMany,
+      'empty': new EmptyFilterInput(),
+      'notEmpty': new EmptyFilterInput()
     }
   }
 

--- a/lib/blocks/lens/fields/RelatedManyField.ts
+++ b/lib/blocks/lens/fields/RelatedManyField.ts
@@ -10,7 +10,7 @@ import { type ResourceFetcher } from '../ResourceFetcher'
 import { EmptyFilterInput } from '../filter-inputs/EmptyFilterInput'
 import { type FilterInput } from '../filter-inputs/FilterInput'
 import { SelectFilterInput } from '../filter-inputs/SelectFilterInput'
-import { Field } from './Field'
+import { EmptyFilterOption, Field } from './Field'
 
 export class RelatedManyField extends Field<RelatedManyFieldData> {
   fetcher: ResourceFetcher
@@ -32,7 +32,11 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
       return null
     }
 
-    const selected = this.inFilterValueFor(this.data.key, filters)
+    const emptyActive = this.emptyFilterActiveFor(this.data.key, filters)
+
+    const selected = emptyActive
+      ? [EmptyFilterOption]
+      : this.inFilterValueFor(this.data.key, filters)
 
     const res = await this.fetcher(method, url, this.data.resourceEndpointBody)
     const data = key ? res[key] : res
@@ -51,12 +55,26 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
           value: this.resolveValue(item[this.data.filterKey])
         })
 
+    // The pinned "empty" option filters records with no related items at
+    // all. It is mutually exclusive with the value options: selecting it
+    // swaps the whole condition to a valueless `empty`, and selecting a
+    // value swaps back to `in`.
+    if (this.emptyOperatorsEnabled()) {
+      options.unshift({ label: this.emptyOptionLabel(), value: EmptyFilterOption })
+    }
+
     return {
       type: 'filter',
       search: true,
       selected,
       options,
-      onClick: (v) => { onFilterUpdated?.([this.data.key, 'in', xor(selected, [v])]) }
+      onClick: (v) => {
+        if (v === EmptyFilterOption) {
+          onFilterUpdated?.(emptyActive ? [this.data.key, 'in', []] : [this.data.key, 'empty', null])
+          return
+        }
+        onFilterUpdated?.([this.data.key, 'in', xor(emptyActive ? [] : selected, [v])])
+      }
     }
   }
 

--- a/lib/blocks/lens/fields/RelatedManyField.ts
+++ b/lib/blocks/lens/fields/RelatedManyField.ts
@@ -106,13 +106,20 @@ export class RelatedManyField extends Field<RelatedManyFieldData> {
     const selectOne = new SelectFilterInput().options(optionsResolver)
     const selectMany = new SelectFilterInput().options(optionsResolver).multiple()
 
-    return {
+    const filters: Partial<Record<FilterOperator, FilterInput>> = {
       '=': selectOne,
       '!=': selectOne,
-      'in': selectMany,
-      'empty': new EmptyFilterInput(),
-      'notEmpty': new EmptyFilterInput()
+      'in': selectMany
     }
+
+    // The valueless operators are strictly opt-in via the backend's field
+    // definition — see `FieldDataBase.emptyOperators`.
+    if (this.data.emptyOperators) {
+      filters.empty = new EmptyFilterInput()
+      filters.notEmpty = new EmptyFilterInput()
+    }
+
+    return filters
   }
 
   // Lens id fields serialize as `{ value, display, path? }`; filters need the

--- a/lib/blocks/lens/fields/RelatedOneField.ts
+++ b/lib/blocks/lens/fields/RelatedOneField.ts
@@ -6,6 +6,7 @@ import { type TableCell } from '../../../composables/Table'
 import { type RelatedOneFieldData } from '../FieldData'
 import { type FilterOperator } from '../FilterOperator'
 import { type ResourceFetcher } from '../ResourceFetcher'
+import { EmptyFilterInput } from '../filter-inputs/EmptyFilterInput'
 import { type FilterInput } from '../filter-inputs/FilterInput'
 import { SelectFilterInput } from '../filter-inputs/SelectFilterInput'
 import { Field } from './Field'
@@ -110,7 +111,9 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
     return {
       '=': selectOne,
       '!=': selectOne,
-      'in': selectMany
+      'in': selectMany,
+      'empty': new EmptyFilterInput(),
+      'notEmpty': new EmptyFilterInput()
     }
   }
 

--- a/lib/blocks/lens/fields/RelatedOneField.ts
+++ b/lib/blocks/lens/fields/RelatedOneField.ts
@@ -108,13 +108,20 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
     const selectOne = new SelectFilterInput().options(optionsResolver)
     const selectMany = new SelectFilterInput().options(optionsResolver).multiple()
 
-    return {
+    const filters: Partial<Record<FilterOperator, FilterInput>> = {
       '=': selectOne,
       '!=': selectOne,
-      'in': selectMany,
-      'empty': new EmptyFilterInput(),
-      'notEmpty': new EmptyFilterInput()
+      'in': selectMany
     }
+
+    // The valueless operators are strictly opt-in via the backend's field
+    // definition — see `FieldDataBase.emptyOperators`.
+    if (this.data.emptyOperators) {
+      filters.empty = new EmptyFilterInput()
+      filters.notEmpty = new EmptyFilterInput()
+    }
+
+    return filters
   }
 
   // Lens id fields serialize as `{ value, display, path? }`; filters need the

--- a/lib/blocks/lens/fields/RelatedOneField.ts
+++ b/lib/blocks/lens/fields/RelatedOneField.ts
@@ -9,7 +9,7 @@ import { type ResourceFetcher } from '../ResourceFetcher'
 import { EmptyFilterInput } from '../filter-inputs/EmptyFilterInput'
 import { type FilterInput } from '../filter-inputs/FilterInput'
 import { SelectFilterInput } from '../filter-inputs/SelectFilterInput'
-import { Field } from './Field'
+import { EmptyFilterOption, Field } from './Field'
 
 export class RelatedOneField extends Field<RelatedOneFieldData> {
   fetcher: ResourceFetcher
@@ -31,7 +31,11 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
       return null
     }
 
-    const selected = this.inFilterValueFor(this.data.key, filters)
+    const emptyActive = this.emptyFilterActiveFor(this.data.key, filters)
+
+    const selected = emptyActive
+      ? [EmptyFilterOption]
+      : this.inFilterValueFor(this.data.key, filters)
 
     const res = await this.fetcher(method, url, this.data.resourceEndpointBody)
     const data = key ? res[key] : res
@@ -50,12 +54,26 @@ export class RelatedOneField extends Field<RelatedOneFieldData> {
           value: this.resolveValue(item[this.data.filterKey])
         })
 
+    // The pinned "empty" option filters records with no related record.
+    // It is mutually exclusive with the value options: selecting it swaps
+    // the whole condition to a valueless `empty`, and selecting a value
+    // swaps back to `in`.
+    if (this.emptyOperatorsEnabled()) {
+      options.unshift({ label: this.emptyOptionLabel(), value: EmptyFilterOption })
+    }
+
     return {
       type: 'filter',
       search: true,
       selected,
       options,
-      onClick: (v) => { onFilterUpdated?.([this.data.key, 'in', xor(selected, [v])]) }
+      onClick: (v) => {
+        if (v === EmptyFilterOption) {
+          onFilterUpdated?.(emptyActive ? [this.data.key, 'in', []] : [this.data.key, 'empty', null])
+          return
+        }
+        onFilterUpdated?.([this.data.key, 'in', xor(emptyActive ? [] : selected, [v])])
+      }
     }
   }
 

--- a/lib/blocks/lens/filter-inputs/EmptyFilterInput.ts
+++ b/lib/blocks/lens/filter-inputs/EmptyFilterInput.ts
@@ -1,0 +1,30 @@
+import { type ValidationArgs } from '@vuelidate/core'
+import { FilterInput } from './FilterInput'
+
+/**
+ * The filter input for valueless operators such as `empty` / `notEmpty`.
+ * The condition is complete with just the field and the operator, so this
+ * input requires no value, renders no control, and always normalizes the
+ * condition value back to `null`.
+ */
+export class EmptyFilterInput extends FilterInput {
+  override valueless(): boolean {
+    return true
+  }
+
+  rules(): Record<string, ValidationArgs> {
+    return {}
+  }
+
+  castValue(_value: any): any {
+    return null
+  }
+
+  async valueToText(_value: any): Promise<string> {
+    return ''
+  }
+
+  component(): any {
+    return null
+  }
+}

--- a/lib/blocks/lens/filter-inputs/EmptyFilterInput.ts
+++ b/lib/blocks/lens/filter-inputs/EmptyFilterInput.ts
@@ -2,16 +2,12 @@ import { type ValidationArgs } from '@vuelidate/core'
 import { FilterInput } from './FilterInput'
 
 /**
- * The filter input for valueless operators such as `empty` / `notEmpty`.
- * The condition is complete with just the field and the operator, so this
- * input requires no value, renders no control, and always normalizes the
- * condition value back to `null`.
+ * The filter input for the valueless `empty` / `notEmpty` operators (see
+ * `isValuelessFilterOperator`). The condition is complete with just the
+ * field and the operator, so this input requires no value, renders no
+ * control, and always normalizes the condition value back to `null`.
  */
 export class EmptyFilterInput extends FilterInput {
-  override valueless(): boolean {
-    return true
-  }
-
   rules(): Record<string, ValidationArgs> {
     return {}
   }

--- a/lib/blocks/lens/filter-inputs/FilterInput.ts
+++ b/lib/blocks/lens/filter-inputs/FilterInput.ts
@@ -3,6 +3,15 @@ import { defineComponent, h } from 'vue'
 
 export abstract class FilterInput {
   /**
+   * Whether the filter input represents a valueless condition (e.g. the
+   * `empty` / `notEmpty` operators). Valueless inputs render no value
+   * control, and the condition always carries `null` as its value.
+   */
+  valueless(): boolean {
+    return false
+  }
+
+  /**
    * Returns the validation rules for the filter input.
    */
   abstract rules(): Record<string, ValidationArgs>

--- a/lib/blocks/lens/filter-inputs/FilterInput.ts
+++ b/lib/blocks/lens/filter-inputs/FilterInput.ts
@@ -3,15 +3,6 @@ import { defineComponent, h } from 'vue'
 
 export abstract class FilterInput {
   /**
-   * Whether the filter input represents a valueless condition (e.g. the
-   * `empty` / `notEmpty` operators). Valueless inputs render no value
-   * control, and the condition always carries `null` as its value.
-   */
-  valueless(): boolean {
-    return false
-  }
-
-  /**
    * Returns the validation rules for the filter input.
    */
   abstract rules(): Record<string, ValidationArgs>

--- a/tests/blocks/lens/FilterOperator.spec.ts
+++ b/tests/blocks/lens/FilterOperator.spec.ts
@@ -1,0 +1,30 @@
+import { isClearedFilterCondition, isValuelessFilterOperator } from 'sefirot/blocks/lens/FilterOperator'
+
+describe('blocks/lens/FilterOperator', () => {
+  describe('isValuelessFilterOperator', () => {
+    it('marks only the empty operators as valueless', () => {
+      expect(isValuelessFilterOperator('empty')).toBe(true)
+      expect(isValuelessFilterOperator('notEmpty')).toBe(true)
+      expect(isValuelessFilterOperator('=')).toBe(false)
+      expect(isValuelessFilterOperator('in')).toBe(false)
+      expect(isValuelessFilterOperator(null)).toBe(false)
+    })
+  })
+
+  describe('isClearedFilterCondition', () => {
+    it('clears on a nullish value or an empty array', () => {
+      expect(isClearedFilterCondition(['status', '=', null])).toBe(true)
+      expect(isClearedFilterCondition(['members', 'in', []])).toBe(true)
+    })
+
+    it('keeps real values, including false', () => {
+      expect(isClearedFilterCondition(['status', '=', false])).toBe(false)
+      expect(isClearedFilterCondition(['members', 'in', [1]])).toBe(false)
+    })
+
+    it('never clears valueless operator conditions', () => {
+      expect(isClearedFilterCondition(['members', 'empty', null])).toBe(false)
+      expect(isClearedFilterCondition(['members', 'notEmpty', null])).toBe(false)
+    })
+  })
+})

--- a/tests/blocks/lens/FilterOperator.spec.ts
+++ b/tests/blocks/lens/FilterOperator.spec.ts
@@ -1,4 +1,8 @@
-import { isClearedFilterCondition, isValuelessFilterOperator } from 'sefirot/blocks/lens/FilterOperator'
+import {
+  isClearedFilterCondition,
+  isValuelessFilterOperator,
+  normalizeValuelessFilterConditions
+} from 'sefirot/blocks/lens/FilterOperator'
 
 describe('blocks/lens/FilterOperator', () => {
   describe('isValuelessFilterOperator', () => {
@@ -25,6 +29,36 @@ describe('blocks/lens/FilterOperator', () => {
     it('never clears valueless operator conditions', () => {
       expect(isClearedFilterCondition(['members', 'empty', null])).toBe(false)
       expect(isClearedFilterCondition(['members', 'notEmpty', null])).toBe(false)
+    })
+  })
+
+  describe('normalizeValuelessFilterConditions', () => {
+    it('normalizes stray values on valueless conditions to null', () => {
+      expect(normalizeValuelessFilterConditions([
+        ['members', 'empty', 42],
+        ['reviewers', 'notEmpty', 'x']
+      ])).toEqual([
+        ['members', 'empty', null],
+        ['reviewers', 'notEmpty', null]
+      ])
+    })
+
+    it('normalizes inside groups', () => {
+      expect(normalizeValuelessFilterConditions([
+        ['$or', [['members', 'empty', 42], ['age', '>', 30]]]
+      ])).toEqual([
+        ['$or', [['members', 'empty', null], ['age', '>', 30]]]
+      ])
+    })
+
+    it('leaves valued conditions untouched, including false values', () => {
+      const filters = [['status', '=', false], ['members', 'in', [1, 2]]]
+      expect(normalizeValuelessFilterConditions(filters)).toEqual(filters)
+    })
+
+    it('leaves already-null valueless conditions untouched', () => {
+      const filters = [['members', 'empty', null]]
+      expect(normalizeValuelessFilterConditions(filters)).toEqual(filters)
     })
   })
 })

--- a/tests/blocks/lens/components/LensFormFilter.spec.ts
+++ b/tests/blocks/lens/components/LensFormFilter.spec.ts
@@ -1,0 +1,111 @@
+import { mount } from '@vue/test-utils'
+import { type FieldData } from 'sefirot/blocks/lens/FieldData'
+import { FieldRegistry } from 'sefirot/blocks/lens/FieldRegistry'
+import LensFormFilter from 'sefirot/blocks/lens/components/LensFormFilter.vue'
+import LensFormFilterCondition from 'sefirot/blocks/lens/components/LensFormFilterCondition.vue'
+import { FieldRegistryKey } from 'sefirot/blocks/lens/composables/FieldRegistry'
+import { RelatedManyField } from 'sefirot/blocks/lens/fields/RelatedManyField'
+
+function makeFieldData(key: string, overrides: Partial<FieldData> = {}): FieldData {
+  return {
+    type: 'related_many',
+    key,
+    labelEn: key,
+    labelJa: key,
+    filterKey: 'id',
+    sortable: false,
+    freeze: false,
+    width: 0,
+    required: false,
+    rules: [],
+    title: 'name',
+    image: null,
+    resourceEndpointMethod: 'get',
+    resourceEndpointPath: `/api/${key}`,
+    resourceEndpointDataKey: null,
+    resourceTitle: 'name',
+    resourceImage: null,
+    displayAs: null,
+    ...overrides
+  } as FieldData
+}
+
+const fields: Record<string, FieldData> = {
+  members: makeFieldData('members', { emptyOperators: true }),
+  reviewers: makeFieldData('reviewers')
+}
+
+function mountFilter(filters: any[]) {
+  const registry = new FieldRegistry()
+
+  registry.register('related_many', (ctx, field) => {
+    return new RelatedManyField(ctx, field, (async () => []) as any)
+  })
+
+  return mount(LensFormFilter, {
+    props: {
+      fields,
+      filters,
+      filterable: ['members', 'reviewers']
+    },
+    global: {
+      provide: {
+        [FieldRegistryKey as symbol]: registry
+      }
+    }
+  })
+}
+
+describe('blocks/lens/components/LensFormFilter', () => {
+  it('renders a valueless condition for a field that declares support', () => {
+    const wrapper = mountFilter([['members', 'empty', null]])
+
+    const conditions = wrapper.findAllComponents(LensFormFilterCondition)
+    expect(conditions).toHaveLength(1)
+    expect((conditions[0] as any).props('modelValue')).toEqual({
+      field: 'members',
+      operator: 'empty',
+      value: null
+    })
+
+    wrapper.unmount()
+  })
+
+  it('prunes conditions whose operator the field does not offer', () => {
+    // `reviewers` does not declare empty operator support, so a condition
+    // injected through a hand-edited URL cannot be rendered or edited —
+    // the form prunes it instead of throwing on mount, leaving the
+    // initial blank condition.
+    const wrapper = mountFilter([
+      ['reviewers', 'empty', null],
+      ['reviewers', 'contains', 'x']
+    ])
+
+    const conditions = wrapper.findAllComponents(LensFormFilterCondition)
+    expect(conditions).toHaveLength(1)
+    expect((conditions[0] as any).props('modelValue')).toEqual({
+      field: null,
+      operator: null,
+      value: null
+    })
+
+    wrapper.unmount()
+  })
+
+  it('keeps editable conditions while pruning uneditable ones, groups included', () => {
+    const wrapper = mountFilter([
+      ['members', 'in', [1]],
+      ['$or', [['reviewers', 'empty', null]]]
+    ])
+
+    const conditions = wrapper.findAllComponents(LensFormFilterCondition)
+    expect(conditions).toHaveLength(1)
+    expect((conditions[0] as any).props('modelValue')).toEqual({
+      field: 'members',
+      operator: 'in',
+      value: [1]
+    })
+
+    wrapper.unmount()
+  })
+})

--- a/tests/blocks/lens/components/LensFormFilterCondition.spec.ts
+++ b/tests/blocks/lens/components/LensFormFilterCondition.spec.ts
@@ -26,6 +26,27 @@ const fields: Record<string, FieldData> = {
     resourceEndpointDataKey: null,
     resourceTitle: 'name',
     resourceImage: null,
+    displayAs: null,
+    emptyOperators: true
+  },
+  reviewers: {
+    type: 'related_many',
+    key: 'reviewers',
+    labelEn: 'Reviewers',
+    labelJa: 'レビュアー',
+    filterKey: 'id',
+    sortable: false,
+    freeze: false,
+    width: 0,
+    required: false,
+    rules: [],
+    title: 'name',
+    image: null,
+    resourceEndpointMethod: 'get',
+    resourceEndpointPath: '/api/reviewers',
+    resourceEndpointDataKey: null,
+    resourceTitle: 'name',
+    resourceImage: null,
     displayAs: null
   }
 }
@@ -40,7 +61,10 @@ function mountCondition(condition: FilterCondition) {
   const wrapper = mount(LensFormFilterCondition, {
     props: {
       fields,
-      fieldOptions: [{ label: 'Members', value: 'members' }],
+      fieldOptions: [
+        { label: 'Members', value: 'members' },
+        { label: 'Reviewers', value: 'reviewers' }
+      ],
       canRemove: false,
       modelValue: condition
     },
@@ -55,7 +79,7 @@ function mountCondition(condition: FilterCondition) {
 }
 
 describe('blocks/lens/components/LensFormFilterCondition', () => {
-  it('offers the valueless operators for a related field', () => {
+  it('offers the valueless operators for a related field that declares support', () => {
     const condition = reactive({ field: 'members', operator: '=' as const, value: null })
     const wrapper = mountCondition(condition)
 
@@ -63,6 +87,17 @@ describe('blocks/lens/components/LensFormFilterCondition', () => {
 
     expect(operatorOptions).toContainEqual({ label: 'is empty', value: 'empty' })
     expect(operatorOptions).toContainEqual({ label: 'is not empty', value: 'notEmpty' })
+
+    wrapper.unmount()
+  })
+
+  it('keeps the default operators for a related field without the declaration', () => {
+    const condition = reactive({ field: 'reviewers', operator: '=' as const, value: null })
+    const wrapper = mountCondition(condition)
+
+    const operatorOptions = (wrapper.findAllComponents(SInputDropdown)[1] as any).props('options')
+
+    expect(operatorOptions.map((o: any) => o.value)).toEqual(['=', '!=', 'in'])
 
     wrapper.unmount()
   })

--- a/tests/blocks/lens/components/LensFormFilterCondition.spec.ts
+++ b/tests/blocks/lens/components/LensFormFilterCondition.spec.ts
@@ -1,0 +1,98 @@
+import { mount } from '@vue/test-utils'
+import { type FieldData } from 'sefirot/blocks/lens/FieldData'
+import { FieldRegistry } from 'sefirot/blocks/lens/FieldRegistry'
+import LensFormFilterCondition, { type FilterCondition } from 'sefirot/blocks/lens/components/LensFormFilterCondition.vue'
+import { FieldRegistryKey } from 'sefirot/blocks/lens/composables/FieldRegistry'
+import { RelatedManyField } from 'sefirot/blocks/lens/fields/RelatedManyField'
+import SInputDropdown from 'sefirot/components/SInputDropdown.vue'
+import { nextTick, reactive } from 'vue'
+
+const fields: Record<string, FieldData> = {
+  members: {
+    type: 'related_many',
+    key: 'members',
+    labelEn: 'Members',
+    labelJa: 'メンバー',
+    filterKey: 'id',
+    sortable: false,
+    freeze: false,
+    width: 0,
+    required: false,
+    rules: [],
+    title: 'name',
+    image: null,
+    resourceEndpointMethod: 'get',
+    resourceEndpointPath: '/api/members',
+    resourceEndpointDataKey: null,
+    resourceTitle: 'name',
+    resourceImage: null,
+    displayAs: null
+  }
+}
+
+function mountCondition(condition: FilterCondition) {
+  const registry = new FieldRegistry()
+
+  registry.register('related_many', (ctx, field) => {
+    return new RelatedManyField(ctx, field, (async () => []) as any)
+  })
+
+  const wrapper = mount(LensFormFilterCondition, {
+    props: {
+      fields,
+      fieldOptions: [{ label: 'Members', value: 'members' }],
+      canRemove: false,
+      modelValue: condition
+    },
+    global: {
+      provide: {
+        [FieldRegistryKey as symbol]: registry
+      }
+    }
+  })
+
+  return wrapper
+}
+
+describe('blocks/lens/components/LensFormFilterCondition', () => {
+  it('offers the valueless operators for a related field', () => {
+    const condition = reactive({ field: 'members', operator: '=' as const, value: null })
+    const wrapper = mountCondition(condition)
+
+    const operatorOptions = (wrapper.findAllComponents(SInputDropdown)[1] as any).props('options')
+
+    expect(operatorOptions).toContainEqual({ label: 'is empty', value: 'empty' })
+    expect(operatorOptions).toContainEqual({ label: 'is not empty', value: 'notEmpty' })
+
+    wrapper.unmount()
+  })
+
+  it('clears the value and hides the value input when switching to a valueless operator', async () => {
+    const condition = reactive<FilterCondition>({ field: 'members', operator: '=', value: 1 })
+    const wrapper = mountCondition(condition)
+
+    expect(wrapper.find('.value').element.childElementCount).toBeGreaterThan(0)
+
+    condition.operator = 'empty'
+    await nextTick()
+
+    expect(condition.value).toBeNull()
+    expect(wrapper.find('.value').element.childElementCount).toBe(0)
+
+    wrapper.unmount()
+  })
+
+  it('shows the value input again when switching back to a valued operator', async () => {
+    const condition = reactive<FilterCondition>({ field: 'members', operator: 'empty', value: null })
+    const wrapper = mountCondition(condition)
+
+    expect(wrapper.find('.value').element.childElementCount).toBe(0)
+
+    condition.operator = 'in'
+    await nextTick()
+
+    expect(wrapper.find('.value').element.childElementCount).toBeGreaterThan(0)
+
+    wrapper.unmount()
+  })
+})

--- a/tests/blocks/lens/composables/CatalogUrlQuerySync.spec.ts
+++ b/tests/blocks/lens/composables/CatalogUrlQuerySync.spec.ts
@@ -123,6 +123,30 @@ describe('blocks/lens/composables/CatalogUrlQuerySync', () => {
     wrapper.unmount()
   })
 
+  it('round-trips valueless operator conditions', async () => {
+    const { wrapper, vm } = setupCatalog()
+
+    vm.filters = [['assignees', 'empty', null], ['reviewers', 'notEmpty', null]]
+
+    await expect.poll(() => vm.route.query.filters)
+      .toBe('[["assignees","empty",null],["reviewers","notEmpty",null]]')
+
+    wrapper.unmount()
+  })
+
+  it('restores valueless operator conditions from the URL', async () => {
+    const { wrapper, vm } = setupCatalog({
+      filters: '[["assignees","empty",null],["$or",[["reviewers","notEmpty",null]]]]'
+    })
+
+    await expect.poll(() => vm.filters).toEqual([
+      ['assignees', 'empty', null],
+      ['$or', [['reviewers', 'notEmpty', null]]]
+    ])
+
+    wrapper.unmount()
+  })
+
   it('rejects filters with an unknown shape or operator', async () => {
     const { wrapper, vm } = setupCatalog({
       filters: '[["name","~","foo"]]'

--- a/tests/blocks/lens/fields/RelatedManyField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedManyField.spec.ts
@@ -134,13 +134,18 @@ describe('blocks/lens/fields/RelatedManyField', () => {
   })
 
   describe('availableFilters', () => {
-    it('exposes "=", "!=", "in", "empty", and "notEmpty" operators when an endpoint is configured', () => {
+    it('keeps the default "=", "!=", and "in" operators when empty operator support is not declared', () => {
       const filters = make().availableFilters()
+      expect(Object.keys(filters).sort()).toEqual(['!=', '=', 'in'])
+    })
+
+    it('exposes "empty" and "notEmpty" operators when the field data declares support', () => {
+      const filters = make({ emptyOperators: true }).availableFilters()
       expect(Object.keys(filters).sort()).toEqual(['!=', '=', 'empty', 'in', 'notEmpty'])
     })
 
     it('maps the valueless operators to an EmptyFilterInput', () => {
-      const filters = make().availableFilters()
+      const filters = make({ emptyOperators: true }).availableFilters()
       expect(filters.empty).toBeInstanceOf(EmptyFilterInput)
       expect(filters.notEmpty).toBeInstanceOf(EmptyFilterInput)
     })

--- a/tests/blocks/lens/fields/RelatedManyField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedManyField.spec.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
 import { type RelatedManyFieldData } from 'sefirot/blocks/lens/FieldData'
 import { type ResourceFetcher } from 'sefirot/blocks/lens/ResourceFetcher'
+import { EmptyFilterOption } from 'sefirot/blocks/lens/fields/Field'
 import { RelatedManyField } from 'sefirot/blocks/lens/fields/RelatedManyField'
 import { EmptyFilterInput } from 'sefirot/blocks/lens/filter-inputs/EmptyFilterInput'
 import SDescAvatar from 'sefirot/components/SDescAvatar.vue'
@@ -37,11 +38,8 @@ function captureFetcher(response: any) {
   return { fetcher, calls }
 }
 
-function make(
-  overrides: Partial<RelatedManyFieldData> = {},
-  fetcher: ResourceFetcher = makeFetcher([])
-): RelatedManyField {
-  const data: RelatedManyFieldData = {
+function makeData(overrides: Partial<RelatedManyFieldData> = {}): RelatedManyFieldData {
+  return {
     type: 'related_many',
     key: 'members',
     labelEn: 'Members',
@@ -62,7 +60,13 @@ function make(
     displayAs: null,
     ...overrides
   }
-  return new RelatedManyField(ctx(), data, fetcher)
+}
+
+function make(
+  overrides: Partial<RelatedManyFieldData> = {},
+  fetcher: ResourceFetcher = makeFetcher([])
+): RelatedManyField {
+  return new RelatedManyField(ctx(), makeData(overrides), fetcher)
 }
 
 describe('blocks/lens/fields/RelatedManyField', () => {
@@ -187,6 +191,72 @@ describe('blocks/lens/fields/RelatedManyField', () => {
         { type: 'avatar', label: 'Alice', image: 'https://example.com/a.png', value: 1 },
         { type: 'avatar', label: 'Bob', image: 'https://example.com/b.png', value: 2 }
       ])
+    })
+  })
+
+  describe('tableFilterMenu (empty option)', () => {
+    const fetcher = () => makeFetcher([{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }])
+
+    it('does not add the empty option without the declaration', async () => {
+      const menu = (await make({}, fetcher()).tableFilterMenu([], () => {})) as any
+      expect(menu.options.map((o: any) => o.label)).toEqual(['Alice', 'Bob'])
+    })
+
+    it('prepends the empty option with the generic label when declared', async () => {
+      const menu = (await make({ emptyOperators: true }, fetcher()).tableFilterMenu([], () => {})) as any
+      expect(menu.options[0]).toEqual({ label: 'None', value: EmptyFilterOption })
+    })
+
+    it('uses the declared label for the current language', async () => {
+      const declaration = { emptyOperators: { labelEn: 'No assignees', labelJa: '担当者なし' } }
+
+      const en = (await make(declaration, fetcher()).tableFilterMenu([], () => {})) as any
+      expect(en.options[0].label).toBe('No assignees')
+
+      const ja = (await new RelatedManyField(
+        ctx('ja'),
+        makeData(declaration),
+        fetcher()
+      ).tableFilterMenu([], () => {})) as any
+      expect(ja.options[0].label).toBe('担当者なし')
+    })
+
+    it('applies a valueless empty condition when the empty option is clicked', async () => {
+      const updated: any[] = []
+      const menu = (await make({ emptyOperators: true }, fetcher())
+        .tableFilterMenu([], (f) => updated.push(f))) as any
+
+      menu.onClick(EmptyFilterOption)
+      expect(updated).toEqual([['members', 'empty', null]])
+    })
+
+    it('clears the empty condition when the empty option is clicked again', async () => {
+      const updated: any[] = []
+      const menu = (await make({ emptyOperators: true }, fetcher())
+        .tableFilterMenu([['members', 'empty', null]], (f) => updated.push(f))) as any
+
+      expect(menu.selected).toEqual([EmptyFilterOption])
+
+      menu.onClick(EmptyFilterOption)
+      expect(updated).toEqual([['members', 'in', []]])
+    })
+
+    it('swaps from the empty condition to a value selection', async () => {
+      const updated: any[] = []
+      const menu = (await make({ emptyOperators: true }, fetcher())
+        .tableFilterMenu([['members', 'empty', null]], (f) => updated.push(f))) as any
+
+      menu.onClick(1)
+      expect(updated).toEqual([['members', 'in', [1]]])
+    })
+
+    it('keeps the plain value toggling when the empty condition is not active', async () => {
+      const updated: any[] = []
+      const menu = (await make({ emptyOperators: true }, fetcher())
+        .tableFilterMenu([['members', 'in', [1]]], (f) => updated.push(f))) as any
+
+      menu.onClick(2)
+      expect(updated).toEqual([['members', 'in', [1, 2]]])
     })
   })
 

--- a/tests/blocks/lens/fields/RelatedManyField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedManyField.spec.ts
@@ -3,6 +3,7 @@ import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
 import { type RelatedManyFieldData } from 'sefirot/blocks/lens/FieldData'
 import { type ResourceFetcher } from 'sefirot/blocks/lens/ResourceFetcher'
 import { RelatedManyField } from 'sefirot/blocks/lens/fields/RelatedManyField'
+import { EmptyFilterInput } from 'sefirot/blocks/lens/filter-inputs/EmptyFilterInput'
 import SDescAvatar from 'sefirot/components/SDescAvatar.vue'
 import SDescPill from 'sefirot/components/SDescPill.vue'
 import { DataListStateKey } from 'sefirot/composables/DataList'
@@ -133,9 +134,15 @@ describe('blocks/lens/fields/RelatedManyField', () => {
   })
 
   describe('availableFilters', () => {
-    it('exposes "=", "!=", and "in" operators when an endpoint is configured', () => {
+    it('exposes "=", "!=", "in", "empty", and "notEmpty" operators when an endpoint is configured', () => {
       const filters = make().availableFilters()
-      expect(Object.keys(filters).sort()).toEqual(['!=', '=', 'in'])
+      expect(Object.keys(filters).sort()).toEqual(['!=', '=', 'empty', 'in', 'notEmpty'])
+    })
+
+    it('maps the valueless operators to an EmptyFilterInput', () => {
+      const filters = make().availableFilters()
+      expect(filters.empty).toBeInstanceOf(EmptyFilterInput)
+      expect(filters.notEmpty).toBeInstanceOf(EmptyFilterInput)
     })
 
     it('returns no filters when the resource endpoint is empty', () => {

--- a/tests/blocks/lens/fields/RelatedOneField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedOneField.spec.ts
@@ -139,13 +139,18 @@ describe('blocks/lens/fields/RelatedOneField', () => {
   })
 
   describe('availableFilters', () => {
-    it('exposes "=", "!=", "in", "empty", and "notEmpty" operators when an endpoint is configured', () => {
+    it('keeps the default "=", "!=", and "in" operators when empty operator support is not declared', () => {
       const filters = make().availableFilters()
+      expect(Object.keys(filters).sort()).toEqual(['!=', '=', 'in'])
+    })
+
+    it('exposes "empty" and "notEmpty" operators when the field data declares support', () => {
+      const filters = make({ emptyOperators: true }).availableFilters()
       expect(Object.keys(filters).sort()).toEqual(['!=', '=', 'empty', 'in', 'notEmpty'])
     })
 
     it('maps the valueless operators to an EmptyFilterInput', () => {
-      const filters = make().availableFilters()
+      const filters = make({ emptyOperators: true }).availableFilters()
       expect(filters.empty).toBeInstanceOf(EmptyFilterInput)
       expect(filters.notEmpty).toBeInstanceOf(EmptyFilterInput)
     })

--- a/tests/blocks/lens/fields/RelatedOneField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedOneField.spec.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
 import { type RelatedOneFieldData } from 'sefirot/blocks/lens/FieldData'
 import { type ResourceFetcher } from 'sefirot/blocks/lens/ResourceFetcher'
+import { EmptyFilterOption } from 'sefirot/blocks/lens/fields/Field'
 import { RelatedOneField } from 'sefirot/blocks/lens/fields/RelatedOneField'
 import { EmptyFilterInput } from 'sefirot/blocks/lens/filter-inputs/EmptyFilterInput'
 import SDescAvatar from 'sefirot/components/SDescAvatar.vue'
@@ -177,6 +178,24 @@ describe('blocks/lens/fields/RelatedOneField', () => {
         { label: 'Japan', value: 1 },
         { label: 'USA', value: 2 }
       ])
+    })
+
+    it('does not add the empty option without the declaration', async () => {
+      const fetcher = makeFetcher([{ id: 1, name: 'Japan' }])
+      const menu = (await make({}, fetcher).tableFilterMenu([], () => {})) as any
+      expect(menu.options.map((o: any) => o.label)).toEqual(['Japan'])
+    })
+
+    it('prepends the empty option and toggles the valueless condition when declared', async () => {
+      const updated: any[] = []
+      const fetcher = makeFetcher([{ id: 1, name: 'Japan' }])
+      const menu = (await make({ emptyOperators: true }, fetcher)
+        .tableFilterMenu([], (f) => updated.push(f))) as any
+
+      expect(menu.options[0]).toEqual({ label: 'None', value: EmptyFilterOption })
+
+      menu.onClick(EmptyFilterOption)
+      expect(updated).toEqual([['country', 'empty', null]])
     })
 
     it('builds avatar-style options when displayAs is "avatar"', async () => {

--- a/tests/blocks/lens/fields/RelatedOneField.spec.ts
+++ b/tests/blocks/lens/fields/RelatedOneField.spec.ts
@@ -3,6 +3,7 @@ import { type FieldContext } from 'sefirot/blocks/lens/FieldContext'
 import { type RelatedOneFieldData } from 'sefirot/blocks/lens/FieldData'
 import { type ResourceFetcher } from 'sefirot/blocks/lens/ResourceFetcher'
 import { RelatedOneField } from 'sefirot/blocks/lens/fields/RelatedOneField'
+import { EmptyFilterInput } from 'sefirot/blocks/lens/filter-inputs/EmptyFilterInput'
 import SDescAvatar from 'sefirot/components/SDescAvatar.vue'
 import { DataListStateKey } from 'sefirot/composables/DataList'
 import { computed } from 'vue'
@@ -138,9 +139,15 @@ describe('blocks/lens/fields/RelatedOneField', () => {
   })
 
   describe('availableFilters', () => {
-    it('exposes "=", "!=", and "in" operators when an endpoint is configured', () => {
+    it('exposes "=", "!=", "in", "empty", and "notEmpty" operators when an endpoint is configured', () => {
       const filters = make().availableFilters()
-      expect(Object.keys(filters).sort()).toEqual(['!=', '=', 'in'])
+      expect(Object.keys(filters).sort()).toEqual(['!=', '=', 'empty', 'in', 'notEmpty'])
+    })
+
+    it('maps the valueless operators to an EmptyFilterInput', () => {
+      const filters = make().availableFilters()
+      expect(filters.empty).toBeInstanceOf(EmptyFilterInput)
+      expect(filters.notEmpty).toBeInstanceOf(EmptyFilterInput)
     })
 
     it('returns no filters when the resource endpoint is empty', () => {

--- a/tests/blocks/lens/filter-inputs/EmptyFilterInput.spec.ts
+++ b/tests/blocks/lens/filter-inputs/EmptyFilterInput.spec.ts
@@ -1,10 +1,6 @@
 import { EmptyFilterInput } from 'sefirot/blocks/lens/filter-inputs/EmptyFilterInput'
 
 describe('blocks/lens/filter-inputs/EmptyFilterInput', () => {
-  it('is valueless', () => {
-    expect(new EmptyFilterInput().valueless()).toBe(true)
-  })
-
   it('requires no value', () => {
     expect(new EmptyFilterInput().rules()).toEqual({})
   })

--- a/tests/blocks/lens/filter-inputs/EmptyFilterInput.spec.ts
+++ b/tests/blocks/lens/filter-inputs/EmptyFilterInput.spec.ts
@@ -1,0 +1,27 @@
+import { EmptyFilterInput } from 'sefirot/blocks/lens/filter-inputs/EmptyFilterInput'
+
+describe('blocks/lens/filter-inputs/EmptyFilterInput', () => {
+  it('is valueless', () => {
+    expect(new EmptyFilterInput().valueless()).toBe(true)
+  })
+
+  it('requires no value', () => {
+    expect(new EmptyFilterInput().rules()).toEqual({})
+  })
+
+  it('casts any value to null', () => {
+    const input = new EmptyFilterInput()
+    expect(input.castValue(null)).toBeNull()
+    expect(input.castValue('foo')).toBeNull()
+    expect(input.castValue([1, 2])).toBeNull()
+    expect(input.castValue(0)).toBeNull()
+  })
+
+  it('renders no value text', async () => {
+    expect(await new EmptyFilterInput().valueToText('anything')).toBe('')
+  })
+
+  it('has no value component', () => {
+    expect(new EmptyFilterInput().component()).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Adds valueless `empty` / `notEmpty` operators to the Lens filter vocabulary (labels "is empty" / "is not empty"), so catalogs can filter records by whether a field has any value — e.g. records with no related items at all. Availability starts with the relation-backed filter inputs (`related_many` / `related_one`).

The operators surface in two places:

- the **Advanced search** form, as regular operator choices, and
- the **column filter dropdown**, as a pinned option at the top of the value list (e.g. "None", GitHub-style) that toggles the valueless `empty` condition.

**Both are strictly opt-in via backend-declared field data**: the optional `FieldDataBase.emptyOperators` key gates them, so applications whose backends do not declare support see zero UI or query behavior change from upgrading — the default operator set and dropdowns stay exactly as before.

Closes #776

## Design notes

- **Opt-in declaration**: `FieldDataBase.emptyOperators?: boolean | { labelEn?, labelJa? }` (absent = unsupported). `RelatedManyField` / `RelatedOneField` add the operators to `availableFilters()` and the pinned dropdown option only when the backend's field definition declares support. The object form customizes the pinned option's label (e.g. "No assignees"); `true` keeps the localized generic default ("None" / 「なし」).
- **Pinned dropdown option**: mutually exclusive with the value options — selecting it swaps the field's whole condition to the valueless `empty`, selecting a value swaps back to `in`, and re-selecting it clears the condition. Its option value is the `EmptyFilterOption` symbol, which cannot collide with backend resource values. `notEmpty` is intentionally not offered in the dropdown (unnatural in a value-list context); it remains available in the Advanced search.
- **Valueless-operator knowledge is centralized** in `FilterOperator.ts`: `isValuelessFilterOperator` drives the form's hidden value cell and the chip's hidden value segment, and `isClearedFilterCondition` replaces the catalog's inline "empty value clears the filter" check so valueless conditions survive the inline path (scalar `false` handling is preserved).
- **Wire shape**: a valueless condition keeps the existing 3-tuple `[field, operator, null]`. This round-trips through condition serialization, `LensQuery.filters`, and the catalog URL query sync without changing the tuple contract. Conditions entering from outside the form UI (the `filters` prop, a hand-edited URL) are normalized before the wire: `normalizeValuelessFilterConditions` nulls stray values when the catalog assembles a search, and `groupToLensFilters` emits `null` for valueless operators on Apply.
- **Hand-crafted URL hardening**: `isFilterEntry`'s operator allow-list has no field context, so a URL can pair a dictionary-valid operator with a field that doesn't offer it. The chip never resolves the filter input for valueless conditions, and the Advanced search form prunes conditions whose operator the field does not offer (`pruneUneditableConditions`, extending the existing missing-field pruning) — this also fixes the pre-existing form-mount throw for valued-operator mismatches (e.g. `contains` on a relation field). Remaining pre-existing edge, unchanged: the chip still resolves inputs for valued-operator mismatches and throws there, as before this PR.
- **`EmptyFilterInput`**: the `FilterInput` for valueless operators — no `required` rule, `castValue()` normalizes to `null` (switching from a valued operator clears the stale value), empty `valueToText()`, no component.
- The `availableFilters()` gate on a missing resource endpoint is unchanged: a relation field without an endpoint still exposes no filters (and no filter dropdown) at all.

## Tests

- `FilterOperator` spec: `isValuelessFilterOperator`, `isClearedFilterCondition` (incl. scalar-`false` preservation), and `normalizeValuelessFilterConditions` (stray values, groups, `false` preservation).
- `EmptyFilterInput` unit spec (rules / castValue / valueToText / component).
- `RelatedManyField` / `RelatedOneField` specs: **without the declaration both the operator set and the dropdown options are exactly the previous defaults** (the zero-change guarantee); with it, the operators appear, the pinned option is prepended with the generic or declared per-language label, and clicking it toggles `[key, 'empty', null]` ⇄ cleared, while value clicks swap back to `in`.
- `LensFormFilterCondition` component spec: a declaring field offers the operators; a non-declaring field keeps the default dropdown; switching to `empty` clears the value and hides the value input; switching back restores it.
- `LensFormFilter` component spec: a declaring field renders the valueless condition; a non-declaring field's injected conditions are pruned without throwing (groups included).
- `CatalogUrlQuerySync` specs: valueless conditions round-trip state → URL and URL → state (incl. inside an `$or` group).

`pnpm check:fail` (type + lint + tests) is green.

Note: filter operators are not currently documented in `docs/` or `stories/`, so there is no doc page to extend; the operator dictionary in `FilterOperator.ts` and the `FieldDataBase.emptyOperators` doc comment remain the source.

## Test plan

- [ ] Verified end-to-end against a consuming application via a local package link: with the field declaring `emptyOperators`, the Advanced search offers "is empty" / "is not empty" and the column dropdown shows the labeled pinned option, both producing the valueless `[field, operator, null]` condition (URL round-trip included); without the declaration the filter UI is unchanged. A maintainer review of the UI behavior is welcome but no consumer-specific steps are required here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)