### PR TITLE
ci: adopt npm trusted publishing with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    # Must match the environment configured in the npm trusted publisher
+    # settings for @globalbrain/sefirot.
+    environment: npm
+
+    permissions:
+      contents: read
+      id-token: write # required for npm trusted publishing (OIDC)
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          # No caches in the publish job: keeps restored artifacts out of the
+          # supply chain of what gets published.
+          package-manager-cache: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # pnpm exchanges the OIDC token with the registry itself; provenance is
+      # generated automatically for public packages. --no-git-checks because
+      # the release event checks out a detached tag, not a branch.
+      - run: pnpm publish --no-git-checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,13 @@ jobs:
     timeout-minutes: 4
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           cache: true
       - run: pnpm check:fail

--- a/.release-it.ts
+++ b/.release-it.ts
@@ -13,6 +13,12 @@ export default {
       return context.changelog.split('\n').slice(1).join('\n').trim()
     }
   },
+  npm: {
+    // The registry publish happens in CI via npm trusted publishing (OIDC) —
+    // see .github/workflows/release.yml. release-it only bumps the version,
+    // tags, and creates the GitHub release that triggers it.
+    publish: false
+  },
   plugins: {
     '@release-it/conventional-changelog': {
       preset: 'angular',

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:coverage": "vitest run --coverage",
     "check": "pnpm run --aggregate-output '/^(type|lint|test:fail)$/'",
     "check:fail": "pnpm run --aggregate-output '/^(type|lint:fail|test:fail)$/'",
-    "release": "npm whoami >/dev/null 2>&1 || npm login && release-it"
+    "release": "release-it"
   },
   "dependencies": {
     "@iconify-json/lucide": "^1.2.116",


### PR DESCRIPTION
## Summary

Publish `@globalbrain/sefirot` to npm via [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC) with provenance, from a new `release.yml` workflow. release-it no longer publishes to the registry from a maintainer machine — it keeps doing the version bump, changelog, tag, and GitHub release, and that release event now triggers the publish in CI.

## Why

Token publishing is the legacy path: npm revoked classic tokens in December 2025, and granular write tokens now expire within 90 days. Trusted publishing leaves no long-lived credential to steal, and each release carries a provenance attestation linking the published tarball to the exact commit and workflow run that built it (current versions on npm have no attestations).

## Notable changes

- New `.github/workflows/release.yml` — runs on `release: published`, publishes with `pnpm publish` under `environment: npm`. Least privilege throughout: top-level `permissions: contents: read`, `id-token: write` only on the publish job, `persist-credentials: false`, and no dependency install or caches in the publish job (nothing but the checked-out tag feeds the tarball). pnpm handles the OIDC exchange and provenance natively (fixed in pnpm 11.1.3; we pin 11.9.0), so no npm CLI upgrade step is needed and `registry-url` is deliberately not set on setup-node.
- `.release-it.ts` — `npm.publish: false`; the `release` script drops its `npm login` gate accordingly.
- `test.yml` — actions bumped to latest and re-pinned by full commit SHA: `actions/checkout` v6.0.2 → v7.0.1, `actions/setup-node` v6.4.0 → v7.0.0, `pnpm/action-setup` v6.0.8 → v6.0.10. No behavioral change here (checkout v7's breaking change only affects `pull_request_target`/`workflow_run` triggers).

## Test plan

- `actionlint` and `zizmor` report no findings on both workflows.
- After the npm-side setup below and merge: run `pnpm release`, verify the workflow run publishes the new version, the provenance badge appears on npmjs.com, and a token-based `npm publish` from a laptop is rejected.

Fixes #781

## Requires npm-side setup

Draft until a package owner configures this on npmjs.com:

1. `@globalbrain/sefirot` → Settings → Trusted Publisher → GitHub Actions, with exactly: organization `globalbrain`, repository `sefirot`, workflow filename `release.yml`, environment name `npm` — and `npm publish` selected as the allowed action (required for configurations created after May 20, 2026).
2. Then: Settings → Publishing access → "Require two-factor authentication and disallow tokens", closing the token path for good.

Also on GitHub (needs repo admin): protect the `npm` environment (required reviewers and/or a wait timer). It is auto-created on the first run, but the protection rules are what gate the publish.
